### PR TITLE
Add more software structure (functions, etc.) and pre/post-conditions

### DIFF
--- a/RACK-Ontology/OwlModels/ANALYSIS.owl
+++ b/RACK-Ontology/OwlModels/ANALYSIS.owl
@@ -16,6 +16,10 @@
     <owl:imports rdf:resource="http://sadl.org/sadlbasemodel"/>
     <rdfs:comment xml:lang="en">This ontology was created from a SADL file 'ANALYSIS.sadl' and should not be directly edited.</rdfs:comment>
   </owl:Ontology>
+  <owl:Class rdf:ID="ANALYSIS_ANNOTATION">
+    <rdfs:comment xml:lang="en">A result of the analysis that is linked to some specific part of the system.</rdfs:comment>
+    <rdfs:subClassOf rdf:resource="PROV-S#ENTITY"/>
+  </owl:Class>
   <owl:Class rdf:ID="ANALYSIS_RESULT">
     <owl:equivalentClass>
       <owl:Class>
@@ -26,6 +30,9 @@
         </owl:oneOf>
       </owl:Class>
     </owl:equivalentClass>
+  </owl:Class>
+  <owl:Class rdf:ID="ANALYSIS_ANNOTATION_TYPE">
+    <rdfs:comment xml:lang="en">An open/extensible set of types of analysis annotations</rdfs:comment>
   </owl:Class>
   <owl:Class rdf:ID="ANALYSIS">
     <rdfs:subClassOf rdf:resource="PROV-S#ACTIVITY"/>
@@ -49,8 +56,26 @@
     <rdfs:range rdf:resource="PROV-S#ENTITY"/>
     <rdfs:domain rdf:resource="#ANALYSIS_REPORT"/>
   </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:ID="annotationType">
+    <rdfs:comment xml:lang="en">The type of the annotation.</rdfs:comment>
+    <rdfs:range rdf:resource="#ANALYSIS_ANNOTATION_TYPE"/>
+    <rdfs:domain rdf:resource="#ANALYSIS_ANNOTATION"/>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:ID="fromReport">
+    <rdfs:comment xml:lang="en">Which analysis report this annotation comes from.</rdfs:comment>
+    <rdfs:range rdf:resource="PROV-S#ENTITY"/>
+    <rdfs:domain rdf:resource="#ANALYSIS_ANNOTATION"/>
+  </owl:ObjectProperty>
   <owl:ObjectProperty rdf:ID="result">
     <rdfs:range rdf:resource="#ANALYSIS_RESULT"/>
     <rdfs:domain rdf:resource="#ANALYSIS_REPORT"/>
   </owl:ObjectProperty>
+  <owl:DatatypeProperty rdf:ID="description">
+    <rdfs:comment xml:lang="en">The content of the annotation.</rdfs:comment>
+    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+    <rdfs:domain rdf:resource="#ANALYSIS_ANNOTATION"/>
+  </owl:DatatypeProperty>
+  <A:ANALYSIS_ANNOTATION_TYPE rdf:ID="POSTCONDITION"/>
+  <A:ANALYSIS_ANNOTATION_TYPE rdf:ID="INVARIANT"/>
+  <A:ANALYSIS_ANNOTATION_TYPE rdf:ID="PRECONDITION"/>
 </rdf:RDF>

--- a/RACK-Ontology/OwlModels/CPP.owl
+++ b/RACK-Ontology/OwlModels/CPP.owl
@@ -1,0 +1,122 @@
+<rdf:RDF
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:sadlimplicitmodel="http://sadl.org/sadlimplicitmodel"
+    xmlns:sw="http://arcos.rack/SOFTWARE"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:cpp="http://CPP/CPP#"
+    xmlns:sadlbasemodel="http://sadl.org/sadlbasemodel"
+    xmlns:sys="http://arcos.rack/SYSTEM"
+    xmlns:j.0="http://arcos.rack/SOFTWARE#"
+    xmlns:j.1="http://arcos.rack/ANALYSIS#"
+    xmlns:A="http://arcos.rack/ANALYSIS"
+    xmlns:owl="http://www.w3.org/2002/07/owl#"
+    xmlns:builtinfunctions="http://sadl.org/builtinfunctions"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+  xml:base="http://CPP/CPP">
+  <owl:Ontology rdf:about="">
+    <owl:imports rdf:resource="http://arcos.rack/SOFTWARE"/>
+    <owl:imports rdf:resource="http://arcos.rack/SYSTEM"/>
+    <owl:imports rdf:resource="http://arcos.rack/ANALYSIS"/>
+    <owl:imports rdf:resource="http://sadl.org/builtinfunctions"/>
+    <owl:imports rdf:resource="http://sadl.org/sadlimplicitmodel"/>
+    <owl:imports rdf:resource="http://sadl.org/sadlbasemodel"/>
+    <rdfs:comment xml:lang="en">This ontology was created from a SADL file 'CPP.sadl' and should not be directly edited.</rdfs:comment>
+  </owl:Ontology>
+  <j.1:ANALYSIS rdf:ID="INTERVAL_ANALYSIS"/>
+  <j.0:COMPONENT rdf:ID="MAIN">
+    <j.0:mentions>
+      <j.0:COMPONENT rdf:ID="GENERATOR_CON">
+        <j.0:mentions>
+          <j.0:COMPONENT rdf:ID="GENERATOR_STATE">
+            <j.0:definedIn>
+              <j.0:CODE_FILE rdf:ID="EXAMPLE_CPP">
+                <j.0:language>
+                  <j.0:LANGUAGE rdf:ID="CPP"/>
+                </j.0:language>
+              </j.0:CODE_FILE>
+            </j.0:definedIn>
+            <j.0:annotations>
+              <j.1:ANALYSIS_ANNOTATION rdf:ID="STATE_INVARIANT">
+                <j.1:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+                >This variable is non-negative.</j.1:description>
+                <j.1:annotationType rdf:resource="http://arcos.rack/ANALYSIS#INVARIANT"/>
+                <j.1:fromReport>
+                  <j.1:ANALYSIS_REPORT rdf:ID="INTERVAL_ANALYSIS_REPORT">
+                    <j.1:analyzes rdf:resource="#EXAMPLE_CPP"/>
+                  </j.1:ANALYSIS_REPORT>
+                </j.1:fromReport>
+              </j.1:ANALYSIS_ANNOTATION>
+            </j.0:annotations>
+            <j.0:subcomponentOf>
+              <j.0:COMPONENT rdf:ID="GENERATOR">
+                <j.0:definedIn rdf:resource="#EXAMPLE_CPP"/>
+                <j.0:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+                >Generator</j.0:name>
+                <j.0:componentType rdf:resource="http://arcos.rack/SOFTWARE#CLASS"/>
+              </j.0:COMPONENT>
+            </j.0:subcomponentOf>
+            <j.0:valueType rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+            >int</j.0:valueType>
+            <j.0:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+            >state</j.0:name>
+            <j.0:componentType rdf:resource="http://arcos.rack/SOFTWARE#CLASS_MEMBER_VARIABLE"/>
+          </j.0:COMPONENT>
+        </j.0:mentions>
+        <j.0:definedIn rdf:resource="#EXAMPLE_CPP"/>
+        <j.0:valueType rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+        >()</j.0:valueType>
+        <j.0:subcomponentOf rdf:resource="#GENERATOR"/>
+        <j.0:componentType rdf:resource="http://arcos.rack/SOFTWARE#CLASS_CONSTRUCTOR"/>
+      </j.0:COMPONENT>
+    </j.0:mentions>
+    <j.0:mentions>
+      <j.0:COMPONENT rdf:ID="NEXT">
+        <j.0:mentions rdf:resource="#GENERATOR_STATE"/>
+        <j.0:definedIn rdf:resource="#EXAMPLE_CPP"/>
+        <j.0:subcomponentOf rdf:resource="#GENERATOR"/>
+        <j.0:valueType rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+        >int()</j.0:valueType>
+        <j.0:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+        >next</j.0:name>
+        <j.0:componentType rdf:resource="http://arcos.rack/SOFTWARE#CLASS_METHOD"/>
+      </j.0:COMPONENT>
+    </j.0:mentions>
+    <j.0:mentions rdf:resource="#GENERATOR"/>
+    <j.0:mentions>
+      <j.0:COMPONENT rdf:ID="OPERATOR_LTLT">
+        <j.0:definedIn>
+          <j.0:LIBRARY rdf:ID="LIBCPP"/>
+        </j.0:definedIn>
+        <j.0:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+        >operator&lt;&lt;</j.0:name>
+        <j.0:componentType rdf:resource="http://arcos.rack/SOFTWARE#SOURCE_FUNCTION"/>
+      </j.0:COMPONENT>
+    </j.0:mentions>
+    <j.0:componentType rdf:resource="http://arcos.rack/SOFTWARE#SOURCE_FUNCTION"/>
+    <j.0:mentions>
+      <j.0:COMPONENT rdf:ID="ENDL">
+        <j.0:definedIn rdf:resource="#LIBCPP"/>
+        <j.0:valueType rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+        >template&lt; class CharT, class Traits &gt; std::basic_ostream&lt;CharT, Traits&gt;&amp; ( std::basic_ostream&lt;CharT, Traits&gt;&amp;)</j.0:valueType>
+        <j.0:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+        >std::cout</j.0:name>
+        <j.0:componentType rdf:resource="http://arcos.rack/SOFTWARE#SOURCE_GLOBAL_VARIABLE"/>
+      </j.0:COMPONENT>
+    </j.0:mentions>
+    <j.0:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+    >main</j.0:name>
+    <j.0:definedIn rdf:resource="#EXAMPLE_CPP"/>
+    <j.0:mentions>
+      <j.0:COMPONENT rdf:ID="COUT">
+        <j.0:definedIn rdf:resource="#LIBCPP"/>
+        <j.0:valueType rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+        >std::ostream</j.0:valueType>
+        <j.0:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+        >std::cout</j.0:name>
+        <j.0:componentType rdf:resource="http://arcos.rack/SOFTWARE#SOURCE_GLOBAL_VARIABLE"/>
+      </j.0:COMPONENT>
+    </j.0:mentions>
+    <j.0:valueType rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+    >int(int,char*[])</j.0:valueType>
+  </j.0:COMPONENT>
+</rdf:RDF>

--- a/RACK-Ontology/OwlModels/CounterApplication.owl
+++ b/RACK-Ontology/OwlModels/CounterApplication.owl
@@ -1,38 +1,265 @@
 <rdf:RDF
     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-    xmlns:sadlbasemodel="http://sadl.org/sadlbasemodel"
-    xmlns:sys="http://arcos.rack/SYSTEM"
-    xmlns:j.0="http://arcos.rack/PROV-S#"
-    xmlns:j.1="http://arcos.rack/SYSTEM#"
-    xmlns:owl="http://www.w3.org/2002/07/owl#"
     xmlns:trnstlsys="http://TurnstileSystem/CounterApplication#"
     xmlns:sadlimplicitmodel="http://sadl.org/sadlimplicitmodel"
+    xmlns:sw="http://arcos.rack/SOFTWARE"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:sadlbasemodel="http://sadl.org/sadlbasemodel"
+    xmlns:sys="http://arcos.rack/SYSTEM"
+    xmlns:j.0="http://arcos.rack/SOFTWARE#"
+    xmlns:j.1="http://arcos.rack/PROV-S#"
+    xmlns:j.2="http://arcos.rack/SYSTEM#"
+    xmlns:owl="http://www.w3.org/2002/07/owl#"
     xmlns:builtinfunctions="http://sadl.org/builtinfunctions"
     xmlns:trnstl="http://TurnstileSystem/Turnstiles"
-    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
   xml:base="http://TurnstileSystem/CounterApplication">
   <owl:Ontology rdf:about="">
     <owl:imports rdf:resource="Turnstiles"/>
+    <owl:imports rdf:resource="http://arcos.rack/SOFTWARE"/>
     <owl:imports rdf:resource="http://arcos.rack/SYSTEM"/>
     <owl:imports rdf:resource="http://sadl.org/builtinfunctions"/>
     <owl:imports rdf:resource="http://sadl.org/sadlimplicitmodel"/>
     <owl:imports rdf:resource="http://sadl.org/sadlbasemodel"/>
     <rdfs:comment xml:lang="en">This ontology was created from a SADL file 'CounterApplication.sadl' and should not be directly edited.</rdfs:comment>
   </owl:Ontology>
-  <j.1:SYSTEM rdf:ID="OutputThread">
-    <j.1:partOf rdf:resource="Turnstiles#CounterApplication"/>
-    <j.0:uniqueIdentifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
-    >OutputThread</j.0:uniqueIdentifier>
-  </j.1:SYSTEM>
-  <j.1:SYSTEM rdf:ID="ExecutiveThread">
-    <j.1:partOf rdf:resource="Turnstiles#CounterApplication"/>
-    <j.0:uniqueIdentifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
-    >ExecutiveThread</j.0:uniqueIdentifier>
-  </j.1:SYSTEM>
-  <j.1:SYSTEM rdf:ID="InputThread">
-    <j.1:partOf rdf:resource="Turnstiles#CounterApplication"/>
-    <j.0:uniqueIdentifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
-    >InputThread</j.0:uniqueIdentifier>
-  </j.1:SYSTEM>
+  <j.2:SYSTEM rdf:ID="ExecutiveThread">
+    <j.2:partOf rdf:resource="Turnstiles#CounterApplication"/>
+    <j.1:uniqueIdentifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+    >ExecutiveThread</j.1:uniqueIdentifier>
+  </j.2:SYSTEM>
+  <j.2:SYSTEM rdf:ID="InputThread">
+    <j.2:partOf rdf:resource="Turnstiles#CounterApplication"/>
+    <j.1:uniqueIdentifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+    >InputThread</j.1:uniqueIdentifier>
+  </j.2:SYSTEM>
+  <j.0:COMPONENT rdf:ID="main_function">
+    <j.0:definedIn>
+      <j.0:CODE_FILE rdf:ID="counter_c">
+        <j.0:language>
+          <j.0:LANGUAGE rdf:ID="c">
+            <j.1:uniqueIdentifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+            >c</j.1:uniqueIdentifier>
+          </j.0:LANGUAGE>
+        </j.0:language>
+        <j.1:uniqueIdentifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+        >counter_c</j.1:uniqueIdentifier>
+      </j.0:CODE_FILE>
+    </j.0:definedIn>
+    <j.0:valueType rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+    >int(int argc, char* argv[])</j.0:valueType>
+    <j.0:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+    >main</j.0:name>
+    <j.0:componentType rdf:resource="http://arcos.rack/SOFTWARE#SOURCE_FUNCTION"/>
+    <j.1:uniqueIdentifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+    >main_function</j.1:uniqueIdentifier>
+  </j.0:COMPONENT>
+  <j.0:COMPONENT rdf:ID="output_function">
+    <j.0:definedIn>
+      <j.0:CODE_FILE rdf:ID="output_c">
+        <j.0:language rdf:resource="#c"/>
+        <j.1:uniqueIdentifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+        >output_c</j.1:uniqueIdentifier>
+      </j.0:CODE_FILE>
+    </j.0:definedIn>
+    <j.0:valueType rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+    >void()</j.0:valueType>
+    <j.0:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+    >output</j.0:name>
+    <j.0:componentType rdf:resource="http://arcos.rack/SOFTWARE#SOURCE_FUNCTION"/>
+    <j.1:uniqueIdentifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+    >output_function</j.1:uniqueIdentifier>
+  </j.0:COMPONENT>
+  <j.0:PACKAGE_FILE rdf:ID="dist_tar">
+    <j.1:wasGeneratedBy>
+      <j.0:PACKAGE rdf:ID="tarPackaging">
+        <j.1:used>
+          <j.0:EXECUTABLE rdf:ID="counter_exe">
+            <j.0:createBy>
+              <j.0:COMPILE rdf:ID="counter_exe_Compiling">
+                <j.1:used>
+                  <j.0:CODE_FILE rdf:ID="counter_h">
+                    <j.0:language rdf:resource="#c"/>
+                    <j.1:uniqueIdentifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+                    >counter_h</j.1:uniqueIdentifier>
+                  </j.0:CODE_FILE>
+                </j.1:used>
+                <j.1:used rdf:resource="#counter_c"/>
+                <j.1:used>
+                  <j.0:LIBRARY rdf:ID="libhw_so">
+                    <j.0:createBy>
+                      <j.0:COMPILE rdf:ID="libhw_so_Compiling">
+                        <j.1:used>
+                          <j.0:OBJECT_FILE rdf:ID="hw_o">
+                            <j.0:createBy>
+                              <j.0:COMPILE rdf:ID="hw_o_Compiling">
+                                <j.1:used>
+                                  <j.0:CODE_FILE rdf:ID="hw_h">
+                                    <j.0:language rdf:resource="#c"/>
+                                    <j.1:uniqueIdentifier rdf:datatype=
+                                    "http://www.w3.org/2001/XMLSchema#string"
+                                    >hw_h</j.1:uniqueIdentifier>
+                                  </j.0:CODE_FILE>
+                                </j.1:used>
+                                <j.1:used>
+                                  <j.0:CODE_FILE rdf:ID="hw_c">
+                                    <j.0:language rdf:resource="#c"/>
+                                    <j.1:uniqueIdentifier rdf:datatype=
+                                    "http://www.w3.org/2001/XMLSchema#string"
+                                    >hw_c</j.1:uniqueIdentifier>
+                                  </j.0:CODE_FILE>
+                                </j.1:used>
+                                <j.0:performedBy>
+                                  <j.1:AGENT rdf:ID="make">
+                                    <j.1:uniqueIdentifier rdf:datatype=
+                                    "http://www.w3.org/2001/XMLSchema#string"
+                                    >make</j.1:uniqueIdentifier>
+                                  </j.1:AGENT>
+                                </j.0:performedBy>
+                                <j.0:performedBy>
+                                  <j.0:COMPILER rdf:ID="cc">
+                                    <j.1:uniqueIdentifier rdf:datatype=
+                                    "http://www.w3.org/2001/XMLSchema#string"
+                                    >cc</j.1:uniqueIdentifier>
+                                  </j.0:COMPILER>
+                                </j.0:performedBy>
+                                <j.1:uniqueIdentifier rdf:datatype=
+                                "http://www.w3.org/2001/XMLSchema#string"
+                                >hw_o_Compiling</j.1:uniqueIdentifier>
+                              </j.0:COMPILE>
+                            </j.0:createBy>
+                            <j.1:uniqueIdentifier rdf:datatype=
+                            "http://www.w3.org/2001/XMLSchema#string"
+                            >hw_o</j.1:uniqueIdentifier>
+                          </j.0:OBJECT_FILE>
+                        </j.1:used>
+                        <j.0:performedBy rdf:resource="#make"/>
+                        <j.0:performedBy rdf:resource="#cc"/>
+                        <j.1:uniqueIdentifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+                        >libhw_so_Compiling</j.1:uniqueIdentifier>
+                      </j.0:COMPILE>
+                    </j.0:createBy>
+                    <j.1:uniqueIdentifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+                    >libhw_so</j.1:uniqueIdentifier>
+                  </j.0:LIBRARY>
+                </j.1:used>
+                <j.1:used>
+                  <j.0:OBJECT_FILE rdf:ID="output_o">
+                    <j.0:createBy>
+                      <j.0:COMPILE rdf:ID="output_o_Compiling">
+                        <j.1:used>
+                          <j.0:CODE_FILE rdf:ID="output_h">
+                            <j.0:language rdf:resource="#c"/>
+                            <j.1:uniqueIdentifier rdf:datatype=
+                            "http://www.w3.org/2001/XMLSchema#string"
+                            >output_h</j.1:uniqueIdentifier>
+                          </j.0:CODE_FILE>
+                        </j.1:used>
+                        <j.1:used rdf:resource="#output_c"/>
+                        <j.0:performedBy rdf:resource="#make"/>
+                        <j.0:performedBy rdf:resource="#cc"/>
+                        <j.1:uniqueIdentifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+                        >output_o_Compiling</j.1:uniqueIdentifier>
+                      </j.0:COMPILE>
+                    </j.0:createBy>
+                    <j.1:uniqueIdentifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+                    >output_o</j.1:uniqueIdentifier>
+                  </j.0:OBJECT_FILE>
+                </j.1:used>
+                <j.1:used>
+                  <j.0:OBJECT_FILE rdf:ID="input_o">
+                    <j.0:createBy>
+                      <j.0:COMPILE rdf:ID="input_o_Compiling">
+                        <j.1:used>
+                          <j.0:CODE_FILE rdf:ID="input_h">
+                            <j.0:language rdf:resource="#c"/>
+                            <j.1:uniqueIdentifier rdf:datatype=
+                            "http://www.w3.org/2001/XMLSchema#string"
+                            >input_h</j.1:uniqueIdentifier>
+                          </j.0:CODE_FILE>
+                        </j.1:used>
+                        <j.1:used>
+                          <j.0:CODE_FILE rdf:ID="input_c">
+                            <j.0:language rdf:resource="#c"/>
+                            <j.1:uniqueIdentifier rdf:datatype=
+                            "http://www.w3.org/2001/XMLSchema#string"
+                            >input_c</j.1:uniqueIdentifier>
+                          </j.0:CODE_FILE>
+                        </j.1:used>
+                        <j.0:performedBy rdf:resource="#make"/>
+                        <j.0:performedBy rdf:resource="#cc"/>
+                        <j.1:uniqueIdentifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+                        >input_o_Compiling</j.1:uniqueIdentifier>
+                      </j.0:COMPILE>
+                    </j.0:createBy>
+                    <j.1:uniqueIdentifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+                    >input_o</j.1:uniqueIdentifier>
+                  </j.0:OBJECT_FILE>
+                </j.1:used>
+                <j.0:performedBy rdf:resource="#make"/>
+                <j.0:performedBy rdf:resource="#cc"/>
+                <j.1:uniqueIdentifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+                >counter_exe_Compiling</j.1:uniqueIdentifier>
+              </j.0:COMPILE>
+            </j.0:createBy>
+            <j.1:uniqueIdentifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+            >counter_exe</j.1:uniqueIdentifier>
+          </j.0:EXECUTABLE>
+        </j.1:used>
+        <j.1:used rdf:resource="#libhw_so"/>
+        <j.1:used>
+          <j.0:CONFIG_FILE rdf:ID="conf_json">
+            <j.1:uniqueIdentifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+            >conf_json</j.1:uniqueIdentifier>
+          </j.0:CONFIG_FILE>
+        </j.1:used>
+        <j.0:performedBy rdf:resource="#cc"/>
+        <j.0:performedBy>
+          <j.0:PACKAGER rdf:ID="tar">
+            <j.1:uniqueIdentifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+            >tar</j.1:uniqueIdentifier>
+          </j.0:PACKAGER>
+        </j.0:performedBy>
+        <j.1:uniqueIdentifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+        >tarPackaging</j.1:uniqueIdentifier>
+      </j.0:PACKAGE>
+    </j.1:wasGeneratedBy>
+    <j.1:uniqueIdentifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+    >dist_tar</j.1:uniqueIdentifier>
+  </j.0:PACKAGE_FILE>
+  <j.2:SYSTEM rdf:ID="OutputThread">
+    <j.2:partOf rdf:resource="Turnstiles#CounterApplication"/>
+    <j.1:uniqueIdentifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+    >OutputThread</j.1:uniqueIdentifier>
+  </j.2:SYSTEM>
+  <j.0:COMPILE rdf:ID="test_exe_Compiling">
+    <j.1:used>
+      <j.0:CODE_FILE rdf:ID="test_h">
+        <j.0:language rdf:resource="#c"/>
+        <j.1:uniqueIdentifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+        >test_h</j.1:uniqueIdentifier>
+      </j.0:CODE_FILE>
+    </j.1:used>
+    <j.1:used>
+      <j.0:CODE_FILE rdf:ID="test_c">
+        <j.0:language rdf:resource="#c"/>
+        <j.1:uniqueIdentifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+        >test_c</j.1:uniqueIdentifier>
+      </j.0:CODE_FILE>
+    </j.1:used>
+    <j.0:performedBy rdf:resource="#make"/>
+    <j.0:performedBy rdf:resource="#cc"/>
+    <j.1:uniqueIdentifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+    >test_exe_Compiling</j.1:uniqueIdentifier>
+  </j.0:COMPILE>
+  <j.0:COMPONENT rdf:ID="input_function">
+    <j.0:definedIn rdf:resource="#input_c"/>
+    <j.0:valueType rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+    >void()</j.0:valueType>
+    <j.0:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+    >input</j.0:name>
+    <j.0:componentType rdf:resource="http://arcos.rack/SOFTWARE#SOURCE_FUNCTION"/>
+    <j.1:uniqueIdentifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+    >input_function</j.1:uniqueIdentifier>
+  </j.0:COMPONENT>
 </rdf:RDF>

--- a/RACK-Ontology/OwlModels/CounterApplicationUnitTesting.owl
+++ b/RACK-Ontology/OwlModels/CounterApplicationUnitTesting.owl
@@ -1,0 +1,103 @@
+<rdf:RDF
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:sadlbasemodel="http://sadl.org/sadlbasemodel"
+    xmlns:j.0="http://arcos.rack/PROV-S#"
+    xmlns:tst="http://arcos.rack/TESTING"
+    xmlns:owl="http://www.w3.org/2002/07/owl#"
+    xmlns:sadlimplicitmodel="http://sadl.org/sadlimplicitmodel"
+    xmlns:builtinfunctions="http://sadl.org/builtinfunctions"
+    xmlns:cntrapprq="http://TurnstileSystem/CounterApplicationRequirements"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+    xmlns:cntrapputst="http://TurnstileSystem/CounterApplicationUnitTesting#"
+    xmlns:j.1="http://arcos.rack/TESTING#"
+  xml:base="http://TurnstileSystem/CounterApplicationUnitTesting">
+  <owl:Ontology rdf:about="">
+    <owl:imports rdf:resource="CounterApplicationRequirements"/>
+    <owl:imports rdf:resource="http://arcos.rack/TESTING"/>
+    <owl:imports rdf:resource="http://sadl.org/builtinfunctions"/>
+    <owl:imports rdf:resource="http://sadl.org/sadlimplicitmodel"/>
+    <owl:imports rdf:resource="http://sadl.org/sadlbasemodel"/>
+    <rdfs:comment xml:lang="en">This ontology was created from a SADL file 'CounterApplicationUnitTesting.sadl' and should not be directly edited.</rdfs:comment>
+  </owl:Ontology>
+  <j.1:TEST_RESULT rdf:ID="UTR-1-1-1">
+    <j.1:executedBy>
+      <j.1:TEST_EXECUTION rdf:ID="UnitTestRun1"/>
+    </j.1:executedBy>
+    <j.1:result rdf:resource="http://arcos.rack/TESTING#Passed"/>
+    <j.1:confirms>
+      <j.1:TEST rdf:ID="UTC-1-1">
+        <j.0:uniqueIdentifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+        >UTC-1-1</j.0:uniqueIdentifier>
+      </j.1:TEST>
+    </j.1:confirms>
+    <j.0:uniqueIdentifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+    >UTR-1-1-1</j.0:uniqueIdentifier>
+  </j.1:TEST_RESULT>
+  <j.1:TEST_RESULT rdf:ID="UTR-1-1-2">
+    <j.1:executedBy>
+      <j.1:TEST_EXECUTION rdf:ID="UnitTestRun2"/>
+    </j.1:executedBy>
+    <j.1:result rdf:resource="http://arcos.rack/TESTING#Passed"/>
+    <j.1:confirms rdf:resource="#UTC-1-1"/>
+    <j.0:uniqueIdentifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+    >UTR-1-1-2</j.0:uniqueIdentifier>
+  </j.1:TEST_RESULT>
+  <j.1:TEST_RESULT rdf:ID="UTR-1-2-1">
+    <j.1:executedBy rdf:resource="#UnitTestRun1"/>
+    <j.1:result rdf:resource="http://arcos.rack/TESTING#Passed"/>
+    <j.1:confirms>
+      <j.1:TEST rdf:ID="UTC-1-2">
+        <j.0:uniqueIdentifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+        >UTC-1-2</j.0:uniqueIdentifier>
+      </j.1:TEST>
+    </j.1:confirms>
+    <j.0:uniqueIdentifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+    >UTR-1-2-1</j.0:uniqueIdentifier>
+  </j.1:TEST_RESULT>
+  <j.1:TEST_RESULT rdf:ID="UTR-1-2-2">
+    <j.1:executedBy rdf:resource="#UnitTestRun2"/>
+    <j.1:result rdf:resource="http://arcos.rack/TESTING#Passed"/>
+    <j.1:confirms rdf:resource="#UTC-1-2"/>
+    <j.0:uniqueIdentifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+    >UTR-1-2-2</j.0:uniqueIdentifier>
+  </j.1:TEST_RESULT>
+  <j.1:TEST_RESULT rdf:ID="UTR-1-3-1">
+    <j.1:executedBy rdf:resource="#UnitTestRun1"/>
+    <j.1:result rdf:resource="http://arcos.rack/TESTING#Passed"/>
+    <j.1:confirms>
+      <j.1:TEST rdf:ID="UTC-1-3">
+        <j.0:uniqueIdentifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+        >UTC-1-3</j.0:uniqueIdentifier>
+      </j.1:TEST>
+    </j.1:confirms>
+    <j.0:uniqueIdentifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+    >UTR-1-3-1</j.0:uniqueIdentifier>
+  </j.1:TEST_RESULT>
+  <j.1:TEST_RESULT rdf:ID="UTR-1-4-2">
+    <j.1:executedBy rdf:resource="#UnitTestRun2"/>
+    <j.1:result rdf:resource="http://arcos.rack/TESTING#Failed"/>
+    <j.1:confirms>
+      <j.1:TEST rdf:ID="UTC-1-4">
+        <j.0:uniqueIdentifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+        >UTC-1-4</j.0:uniqueIdentifier>
+      </j.1:TEST>
+    </j.1:confirms>
+    <j.0:uniqueIdentifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+    >UTR-1-4-2</j.0:uniqueIdentifier>
+  </j.1:TEST_RESULT>
+  <j.1:TEST_RESULT rdf:ID="UTR-1-3-2">
+    <j.1:executedBy rdf:resource="#UnitTestRun2"/>
+    <j.1:result rdf:resource="http://arcos.rack/TESTING#Passed"/>
+    <j.1:confirms rdf:resource="#UTC-1-3"/>
+    <j.0:uniqueIdentifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+    >UTR-1-3-2</j.0:uniqueIdentifier>
+  </j.1:TEST_RESULT>
+  <j.1:TEST_RESULT rdf:ID="UTR-1-4-1">
+    <j.1:executedBy rdf:resource="#UnitTestRun1"/>
+    <j.1:result rdf:resource="http://arcos.rack/TESTING#Failed"/>
+    <j.1:confirms rdf:resource="#UTC-1-4"/>
+    <j.0:uniqueIdentifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+    >UTR-1-4-1</j.0:uniqueIdentifier>
+  </j.1:TEST_RESULT>
+</rdf:RDF>

--- a/RACK-Ontology/OwlModels/GenerateCSV.owl
+++ b/RACK-Ontology/OwlModels/GenerateCSV.owl
@@ -1,21 +1,33 @@
 <rdf:RDF
     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-    xmlns:sadlbasemodel="http://sadl.org/sadlbasemodel"
     xmlns:cntrapptst="http://TurnstileSystem/CounterApplicationTesting"
+    xmlns:sadlimplicitmodel="http://sadl.org/sadlimplicitmodel"
+    xmlns:cntrapprq="http://TurnstileSystem/CounterApplicationRequirements"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:trnstlsys="http://TurnstileSystem/CounterApplication"
+    xmlns:sadlbasemodel="http://sadl.org/sadlbasemodel"
     xmlns:owl="http://www.w3.org/2002/07/owl#"
     xmlns:gencsv="http://TurnstileSystem/GenerateCSV#"
-    xmlns:sadlimplicitmodel="http://sadl.org/sadlimplicitmodel"
     xmlns:builtinfunctions="http://sadl.org/builtinfunctions"
-    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:trnstl="http://TurnstileSystem/Turnstiles"
+    xmlns:ingaterq="http://TurnstileSystem/InGateRequirement"
+    xmlns:cntrapputst="http://TurnstileSystem/CounterApplicationUnitTesting"
     xmlns:cntrappllr="http://TurnstileSystem/CounterApplicationLLR"
     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+    xmlns:ha="http://TurnstileSystem/HazardAssesment"
   xml:base="http://TurnstileSystem/GenerateCSV">
   <owl:Ontology rdf:about="">
+    <owl:imports rdf:resource="InGateRequirement"/>
+    <owl:imports rdf:resource="Turnstiles"/>
+    <owl:imports rdf:resource="CounterApplicationRequirements"/>
+    <owl:imports rdf:resource="HazardAssesment"/>
     <owl:imports rdf:resource="CounterApplicationTesting"/>
+    <owl:imports rdf:resource="CounterApplicationUnitTesting"/>
+    <owl:imports rdf:resource="http://sadl.org/sadlbasemodel"/>
     <owl:imports rdf:resource="CounterApplicationLLR"/>
+    <owl:imports rdf:resource="CounterApplication"/>
+    <rdfs:comment xml:lang="en">This ontology was created from a SADL file 'GenerateCSV.sadl' and should not be directly edited.</rdfs:comment>
     <owl:imports rdf:resource="http://sadl.org/builtinfunctions"/>
     <owl:imports rdf:resource="http://sadl.org/sadlimplicitmodel"/>
-    <owl:imports rdf:resource="http://sadl.org/sadlbasemodel"/>
-    <rdfs:comment xml:lang="en">This ontology was created from a SADL file 'GenerateCSV.sadl' and should not be directly edited.</rdfs:comment>
   </owl:Ontology>
 </rdf:RDF>

--- a/RACK-Ontology/OwlModels/SOFTWARE.owl
+++ b/RACK-Ontology/OwlModels/SOFTWARE.owl
@@ -2,6 +2,7 @@
     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
     xmlns:sw="http://arcos.rack/SOFTWARE#"
     xmlns:sadlbasemodel="http://sadl.org/sadlbasemodel"
+    xmlns:j.0="http://arcos.rack/PROV-S#"
     xmlns:provs="http://arcos.rack/PROV-S"
     xmlns:owl="http://www.w3.org/2002/07/owl#"
     xmlns:sadlimplicitmodel="http://sadl.org/sadlimplicitmodel"
@@ -31,6 +32,18 @@
   <owl:Class rdf:ID="CODE_FILE">
     <rdfs:subClassOf rdf:resource="PROV-S#ENTITY"/>
   </owl:Class>
+  <owl:Class rdf:ID="COMPONENT">
+    <rdfs:subClassOf>
+      <owl:Restriction>
+        <owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >1</owl:cardinality>
+        <owl:onProperty>
+          <owl:ObjectProperty rdf:ID="componentType"/>
+        </owl:onProperty>
+      </owl:Restriction>
+    </rdfs:subClassOf>
+    <rdfs:subClassOf rdf:resource="PROV-S#ENTITY"/>
+  </owl:Class>
   <owl:Class rdf:ID="LANGUAGE">
     <rdfs:subClassOf rdf:resource="PROV-S#ENTITY"/>
   </owl:Class>
@@ -42,6 +55,20 @@
   </owl:Class>
   <owl:Class rdf:ID="BUILD">
     <rdfs:subClassOf rdf:resource="PROV-S#ACTIVITY"/>
+  </owl:Class>
+  <owl:Class rdf:ID="COMPONENT_TYPE">
+    <rdfs:subClassOf>
+      <owl:Restriction>
+        <owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >1</owl:cardinality>
+        <owl:onProperty>
+          <rdf:Description rdf:about="PROV-S#uniqueIdentifier">
+            <rdfs:domain rdf:resource="#COMPONENT_TYPE"/>
+          </rdf:Description>
+        </owl:onProperty>
+      </owl:Restriction>
+    </rdfs:subClassOf>
+    <rdfs:comment xml:lang="en">An open/extensible set of types of software components</rdfs:comment>
   </owl:Class>
   <owl:Class rdf:ID="EXECUTABLE">
     <rdfs:subClassOf rdf:resource="PROV-S#ENTITY"/>
@@ -71,20 +98,49 @@
     <rdfs:range rdf:resource="PROV-S#ENTITY"/>
     <rdfs:domain rdf:resource="#CODE_FILE"/>
   </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:ID="subcomponentOf">
+    <rdfs:comment xml:lang="en">A structural sub-component, e.g., a function might be a subcomponent of module.</rdfs:comment>
+    <rdfs:range rdf:resource="PROV-S#ENTITY"/>
+    <rdfs:domain rdf:resource="#COMPONENT"/>
+  </owl:ObjectProperty>
   <owl:ObjectProperty rdf:ID="referenced">
     <rdfs:subPropertyOf rdf:resource="PROV-S#used"/>
     <rdfs:range rdf:resource="PROV-S#ENTITY"/>
     <rdfs:domain rdf:resource="#CODE_DEVELOPMENT"/>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:ID="instantiates">
+    <rdfs:comment xml:lang="en">What logical component (system) does this physical component (code) instantiate or implement?</rdfs:comment>
+    <rdfs:range rdf:resource="PROV-S#ENTITY"/>
+    <rdfs:domain rdf:resource="#COMPONENT"/>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:ID="definedIn">
+    <rdfs:comment xml:lang="en">Defining entity of this code structure. This could be a CODE_FILE, LIBRARY, etc.</rdfs:comment>
+    <rdfs:range rdf:resource="PROV-S#ENTITY"/>
+    <rdfs:domain rdf:resource="#COMPONENT"/>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:ID="language">
+    <rdfs:subPropertyOf rdf:resource="PROV-S#wasDerivedFrom"/>
+    <rdfs:range rdf:resource="#LANGUAGE"/>
+    <rdfs:domain rdf:resource="#CODE_FILE"/>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:about="#componentType">
+    <rdfs:range rdf:resource="#COMPONENT_TYPE"/>
+    <rdfs:domain rdf:resource="#COMPONENT"/>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:ID="annotations">
+    <rdfs:comment xml:lang="en">Analysis annotations that apply to this component.</rdfs:comment>
+    <rdfs:range rdf:resource="PROV-S#ENTITY"/>
+    <rdfs:domain rdf:resource="#COMPONENT"/>
   </owl:ObjectProperty>
   <owl:ObjectProperty rdf:ID="step">
     <rdfs:subPropertyOf rdf:resource="PROV-S#wasInformedBy"/>
     <rdfs:range rdf:resource="PROV-S#ACTIVITY"/>
     <rdfs:domain rdf:resource="#BUILD"/>
   </owl:ObjectProperty>
-  <owl:ObjectProperty rdf:ID="language">
-    <rdfs:subPropertyOf rdf:resource="PROV-S#wasDerivedFrom"/>
-    <rdfs:range rdf:resource="#LANGUAGE"/>
-    <rdfs:domain rdf:resource="#CODE_FILE"/>
+  <owl:ObjectProperty rdf:ID="requirements">
+    <rdfs:comment xml:lang="en">Low-level requirements that apply to this component.</rdfs:comment>
+    <rdfs:range rdf:resource="PROV-S#ENTITY"/>
+    <rdfs:domain rdf:resource="#COMPONENT"/>
   </owl:ObjectProperty>
   <owl:ObjectProperty rdf:ID="createBy">
     <rdfs:domain>
@@ -100,6 +156,11 @@
     </rdfs:domain>
     <rdfs:range rdf:resource="PROV-S#ACTIVITY"/>
     <rdfs:subPropertyOf rdf:resource="PROV-S#wasGeneratedBy"/>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:ID="mentions">
+    <rdfs:comment xml:lang="en">A component referenced by this one, e.g., a callee or variable being used.</rdfs:comment>
+    <rdfs:range rdf:resource="PROV-S#ENTITY"/>
+    <rdfs:domain rdf:resource="#COMPONENT"/>
   </owl:ObjectProperty>
   <owl:ObjectProperty rdf:ID="performedBy">
     <rdfs:domain>
@@ -119,8 +180,72 @@
     <rdfs:range rdf:resource="PROV-S#AGENT"/>
     <rdfs:domain rdf:resource="#CODE_DEVELOPMENT"/>
   </owl:ObjectProperty>
+  <owl:DatatypeProperty rdf:ID="name">
+    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+    <rdfs:domain rdf:resource="#COMPONENT"/>
+  </owl:DatatypeProperty>
+  <owl:DatatypeProperty rdf:ID="valueType">
+    <rdfs:comment xml:lang="en">The type of this value, if applicable (e.g. for functions or variables).</rdfs:comment>
+    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+    <rdfs:domain rdf:resource="#COMPONENT"/>
+  </owl:DatatypeProperty>
   <owl:DatatypeProperty rdf:ID="version">
     <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
     <rdfs:domain rdf:resource="#LANGUAGE"/>
   </owl:DatatypeProperty>
+  <sw:COMPONENT_TYPE rdf:ID="MODULE">
+    <j.0:uniqueIdentifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+    >MODULE</j.0:uniqueIdentifier>
+    <rdfs:comment xml:lang="en">A collection of related code, usually grouped in a lexical scope.</rdfs:comment>
+  </sw:COMPONENT_TYPE>
+  <sw:COMPONENT_TYPE rdf:ID="CLASS">
+    <j.0:uniqueIdentifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+    >CLASS</j.0:uniqueIdentifier>
+    <rdfs:comment xml:lang="en">A class in an object-oriented language.</rdfs:comment>
+  </sw:COMPONENT_TYPE>
+  <sw:COMPONENT_TYPE rdf:ID="CLASS_CONSTRUCTOR">
+    <j.0:uniqueIdentifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+    >CLASS_CONSTRUCTOR</j.0:uniqueIdentifier>
+    <rdfs:comment xml:lang="en">A constructor in an object-oriented language.</rdfs:comment>
+  </sw:COMPONENT_TYPE>
+  <sw:COMPONENT_TYPE rdf:ID="SOURCE_FUNCTION">
+    <j.0:uniqueIdentifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+    >SOURCE_FUNCTION</j.0:uniqueIdentifier>
+    <rdfs:comment xml:lang="en">A function or procedure declared or defined in source code.</rdfs:comment>
+  </sw:COMPONENT_TYPE>
+  <sw:COMPONENT_TYPE rdf:ID="BINARY_BASIC_BLOCK">
+    <j.0:uniqueIdentifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+    >BINARY_BASIC_BLOCK</j.0:uniqueIdentifier>
+    <rdfs:comment xml:lang="en">A basic block at the binary level.</rdfs:comment>
+  </sw:COMPONENT_TYPE>
+  <sw:COMPONENT_TYPE rdf:ID="BINARY_GLOBAL_VARIABLE">
+    <j.0:uniqueIdentifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+    >BINARY_GLOBAL_VARIABLE</j.0:uniqueIdentifier>
+    <rdfs:comment xml:lang="en">A global variable (generally in the .data or .bss sections).</rdfs:comment>
+  </sw:COMPONENT_TYPE>
+  <sw:COMPONENT_TYPE rdf:ID="CLASS_METHOD">
+    <j.0:uniqueIdentifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+    >CLASS_METHOD</j.0:uniqueIdentifier>
+    <rdfs:comment xml:lang="en">A method attached to a class in an object-oriented language.</rdfs:comment>
+  </sw:COMPONENT_TYPE>
+  <sw:COMPONENT_TYPE rdf:ID="BINARY_FUNCTION">
+    <j.0:uniqueIdentifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+    >BINARY_FUNCTION</j.0:uniqueIdentifier>
+    <rdfs:comment xml:lang="en">A function in a binary, as defined by the appropriate ABI.</rdfs:comment>
+  </sw:COMPONENT_TYPE>
+  <sw:COMPONENT_TYPE rdf:ID="SOURCE_GLOBAL_VARIABLE">
+    <j.0:uniqueIdentifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+    >SOURCE_GLOBAL_VARIABLE</j.0:uniqueIdentifier>
+    <rdfs:comment xml:lang="en">A global variable declared or defined in source code.</rdfs:comment>
+  </sw:COMPONENT_TYPE>
+  <sw:COMPONENT_TYPE rdf:ID="NAMESPACE">
+    <j.0:uniqueIdentifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+    >NAMESPACE</j.0:uniqueIdentifier>
+    <rdfs:comment xml:lang="en">A collection of related code, usually grouped in a lexical scope.</rdfs:comment>
+  </sw:COMPONENT_TYPE>
+  <sw:COMPONENT_TYPE rdf:ID="CLASS_MEMBER_VARIABLE">
+    <j.0:uniqueIdentifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+    >CLASS_MEMBER_VARIABLE</j.0:uniqueIdentifier>
+    <rdfs:comment xml:lang="en">A variable attached to the instances of a class in an object-oriented language.</rdfs:comment>
+  </sw:COMPONENT_TYPE>
 </rdf:RDF>

--- a/RACK-Ontology/OwlModels/ont-policy.rdf
+++ b/RACK-Ontology/OwlModels/ont-policy.rdf
@@ -2,313 +2,327 @@
     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
     xmlns:j.0="http://jena.hpl.hp.com/schemas/2003/03/ont-manager#">
   <j.0:OntologySpec>
-    <j.0:publicURI rdf:resource="http://arcos.rack/SOFTWARE"/>
-    <j.0:altURL rdf:resource="file:/Users/emertens/Source/arcos/RACK/RACK-Ontology/OwlModels/SOFTWARE.owl"/>
-    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
-    <j.0:createdBy>SADL</j.0:createdBy>
-    <j.0:prefix rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
-    >sw</j.0:prefix>
-  </j.0:OntologySpec>
-  <j.0:OntologySpec>
-    <j.0:publicURI rdf:resource="http://TurnstileSystem/CounterApplicationLLR"/>
-    <j.0:altURL rdf:resource="file:/Users/emertens/Source/arcos/RACK/RACK-Ontology/OwlModels/CounterApplicationLLR.owl"/>
-    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
-    <j.0:createdBy>SADL</j.0:createdBy>
-    <j.0:prefix rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
-    >cntrappllr</j.0:prefix>
-  </j.0:OntologySpec>
-  <j.0:OntologySpec>
-    <j.0:publicURI rdf:resource="http://TurnstileSystem/CounterApplicationTesting.metrics"/>
-    <j.0:altURL rdf:resource="file:/Users/emertens/Source/arcos/RACK/RACK-Ontology/OwlModels/CounterApplicationTesting.sadl.metrics.owl"/>
-    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
     <j.0:createdBy>SRL_Metrics</j.0:createdBy>
-  </j.0:OntologySpec>
-  <j.0:OntologySpec>
-    <j.0:publicURI rdf:resource="http://arcos.rack/SACM-S.metrics"/>
-    <j.0:altURL rdf:resource="file:/Users/emertens/Source/arcos/RACK/RACK-Ontology/OwlModels/SACM-S.sadl.metrics.owl"/>
     <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
-    <j.0:createdBy>SRL_Metrics</j.0:createdBy>
-  </j.0:OntologySpec>
-  <j.0:OntologySpec>
-    <j.0:publicURI rdf:resource="http://arcos.rack/PROV-S"/>
-    <j.0:altURL rdf:resource="file:/Users/emertens/Source/arcos/RACK/RACK-Ontology/OwlModels/PROV-S.owl"/>
-    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
-    <j.0:createdBy>SADL</j.0:createdBy>
-    <j.0:prefix rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
-    >provs</j.0:prefix>
-  </j.0:OntologySpec>
-  <j.0:OntologySpec>
-    <j.0:publicURI rdf:resource="http://arcos.rack/REQUIREMENTS.metrics"/>
-    <j.0:altURL rdf:resource="file:/Users/emertens/Source/arcos/RACK/RACK-Ontology/OwlModels/REQUIREMENTS.sadl.metrics.owl"/>
-    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
-    <j.0:createdBy>SRL_Metrics</j.0:createdBy>
-  </j.0:OntologySpec>
-  <j.0:OntologySpec>
-    <j.0:publicURI rdf:resource="http://arcos.rack/SYSTEM"/>
-    <j.0:altURL rdf:resource="file:/Users/emertens/Source/arcos/RACK/RACK-Ontology/OwlModels/SYSTEM.owl"/>
-    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
-    <j.0:createdBy>SADL</j.0:createdBy>
-    <j.0:prefix rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
-    >sys</j.0:prefix>
-  </j.0:OntologySpec>
-  <j.0:OntologySpec>
-    <j.0:publicURI rdf:resource="http://arcos.rack/REVIEW"/>
-    <j.0:altURL rdf:resource="file:/Users/emertens/Source/arcos/RACK/RACK-Ontology/OwlModels/REVIEW.owl"/>
-    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
-    <j.0:createdBy>SADL</j.0:createdBy>
-    <j.0:prefix rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
-    >Rv</j.0:prefix>
-  </j.0:OntologySpec>
-  <j.0:OntologySpec>
+    <j.0:altURL rdf:resource="file:/home/siddharthist/code/arcos/rack/RACK-Ontology/OwlModels/REVIEW.sadl.metrics.owl"/>
     <j.0:publicURI rdf:resource="http://arcos.rack/REVIEW.metrics"/>
-    <j.0:altURL rdf:resource="file:/Users/emertens/Source/arcos/RACK/RACK-Ontology/OwlModels/REVIEW.sadl.metrics.owl"/>
-    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
+  </j.0:OntologySpec>
+  <j.0:OntologySpec>
     <j.0:createdBy>SRL_Metrics</j.0:createdBy>
+    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
+    <j.0:altURL rdf:resource="file:/home/siddharthist/code/arcos/rack/RACK-Ontology/OwlModels/GenerateCSV.sadl.metrics.owl"/>
+    <j.0:publicURI rdf:resource="http://TurnstileSystem/GenerateCSV.metrics"/>
   </j.0:OntologySpec>
   <j.0:OntologySpec>
-    <j.0:publicURI rdf:resource="http://TurnstileSystem/HazardAssesment"/>
-    <j.0:altURL rdf:resource="file:/Users/emertens/Source/arcos/RACK/RACK-Ontology/OwlModels/HazardAssesment.owl"/>
-    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
-    <j.0:createdBy>SADL</j.0:createdBy>
-    <j.0:prefix rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
-    >ha</j.0:prefix>
-  </j.0:OntologySpec>
-  <j.0:OntologySpec>
-    <j.0:publicURI rdf:resource="http://arcos.rack/PROV-S.metrics"/>
-    <j.0:altURL rdf:resource="file:/Users/emertens/Source/arcos/RACK/RACK-Ontology/OwlModels/PROV-S.sadl.metrics.owl"/>
-    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
     <j.0:createdBy>SRL_Metrics</j.0:createdBy>
+    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
+    <j.0:altURL rdf:resource="file:/home/siddharthist/code/arcos/rack/RACK-Ontology/OwlModels/CounterApplicationRequirements.sadl.metrics.owl"/>
+    <j.0:publicURI rdf:resource="http://TurnstileSystem/CounterApplicationRequirements.metrics"/>
   </j.0:OntologySpec>
   <j.0:OntologySpec>
-    <j.0:publicURI rdf:resource="http://arcos.rack/properties"/>
-    <j.0:altURL rdf:resource="file:/Users/emertens/Source/arcos/RACK/RACK-Ontology/OwlModels/properties.owl"/>
-    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
-    <j.0:createdBy>SADL</j.0:createdBy>
     <j.0:prefix rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
-    >P</j.0:prefix>
+    >smpl2</j.0:prefix>
+    <j.0:createdBy>SADL</j.0:createdBy>
+    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
+    <j.0:altURL rdf:resource="file:/C:/sadl/git/RACK/RACK-Ontology/OwlModels/Sample2.owl"/>
+    <j.0:publicURI rdf:resource="http://TurnstileSystem/Sample2"/>
   </j.0:OntologySpec>
   <j.0:OntologySpec>
-    <j.0:publicURI rdf:resource="http://TurnstileSystem/Turnstiles"/>
-    <j.0:altURL rdf:resource="file:/Users/emertens/Source/arcos/RACK/RACK-Ontology/OwlModels/Turnstiles.owl"/>
-    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
-    <j.0:createdBy>SADL</j.0:createdBy>
-    <j.0:prefix rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
-    >trnstl</j.0:prefix>
-  </j.0:OntologySpec>
-  <j.0:OntologySpec>
-    <j.0:publicURI rdf:resource="http://arcos.rack/ANALYSIS"/>
-    <j.0:altURL rdf:resource="file:/Users/emertens/Source/arcos/RACK/RACK-Ontology/OwlModels/ANALYSIS.owl"/>
-    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
-    <j.0:createdBy>SADL</j.0:createdBy>
-    <j.0:prefix rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
-    >A</j.0:prefix>
-  </j.0:OntologySpec>
-  <j.0:OntologySpec>
-    <j.0:publicURI rdf:resource="http://TurnstileSystem/CounterApplication"/>
-    <j.0:altURL rdf:resource="file:/Users/emertens/Source/arcos/RACK/RACK-Ontology/OwlModels/CounterApplication.owl"/>
-    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
-    <j.0:createdBy>SADL</j.0:createdBy>
     <j.0:prefix rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
     >trnstlsys</j.0:prefix>
-  </j.0:OntologySpec>
-  <j.0:OntologySpec>
-    <j.0:publicURI rdf:resource="http://arcos.rack/SOFTWARE.metrics"/>
-    <j.0:altURL rdf:resource="file:/Users/emertens/Source/arcos/RACK/RACK-Ontology/OwlModels/SOFTWARE.sadl.metrics.owl"/>
+    <j.0:createdBy>SADL</j.0:createdBy>
     <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
-    <j.0:createdBy>SRL_Metrics</j.0:createdBy>
-  </j.0:OntologySpec>
-  <j.0:OntologySpec>
-    <j.0:publicURI rdf:resource="http://arcos.rack/TESTING.metrics"/>
-    <j.0:altURL rdf:resource="file:/Users/emertens/Source/arcos/RACK/RACK-Ontology/OwlModels/TESTING.sadl.metrics.owl"/>
-    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
-    <j.0:createdBy>SRL_Metrics</j.0:createdBy>
+    <j.0:altURL rdf:resource="file:/home/siddharthist/code/arcos/rack/RACK-Ontology/OwlModels/CounterApplication.owl"/>
+    <j.0:publicURI rdf:resource="http://TurnstileSystem/CounterApplication"/>
   </j.0:OntologySpec>
   <j.0:OntologySpec>
     <j.0:prefix rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
     >genpropinfo</j.0:prefix>
     <j.0:createdBy>SADL</j.0:createdBy>
     <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
-    <j.0:altURL rdf:resource="file:/Users/emertens/Source/arcos/RACK/RACK-Ontology/OwlModels/GeneratePropInfoCSV.owl"/>
+    <j.0:altURL rdf:resource="file:/home/siddharthist/code/arcos/rack/RACK-Ontology/OwlModels/GeneratePropInfoCSV.owl"/>
     <j.0:publicURI rdf:resource="http://arcos.rack/GeneratePropInfoCSV"/>
   </j.0:OntologySpec>
   <j.0:OntologySpec>
-    <j.0:publicURI rdf:resource="http://TurnstileSystem/CounterApplicationRequirements.metrics"/>
-    <j.0:altURL rdf:resource="file:/Users/emertens/Source/arcos/RACK/RACK-Ontology/OwlModels/CounterApplicationRequirements.sadl.metrics.owl"/>
-    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
-    <j.0:createdBy>SRL_Metrics</j.0:createdBy>
-  </j.0:OntologySpec>
-  <j.0:OntologySpec>
     <j.0:prefix rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
-    >AGENTS</j.0:prefix>
+    >P</j.0:prefix>
     <j.0:createdBy>SADL</j.0:createdBy>
     <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
-    <j.0:altURL rdf:resource="file:/Users/emertens/Source/arcos/RACK/RACK-Ontology/OwlModels/AGENTS.owl"/>
-    <j.0:publicURI rdf:resource="http://arcos.rack/AGENTS"/>
-  </j.0:OntologySpec>
-  <j.0:OntologySpec>
-    <j.0:publicURI rdf:resource="http://TurnstileSystem/Turnstiles.metrics"/>
-    <j.0:altURL rdf:resource="file:/Users/emertens/Source/arcos/RACK/RACK-Ontology/OwlModels/Turnstiles.sadl.metrics.owl"/>
-    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
-    <j.0:createdBy>SRL_Metrics</j.0:createdBy>
+    <j.0:altURL rdf:resource="file:/home/siddharthist/code/arcos/rack/RACK-Ontology/OwlModels/properties.owl"/>
+    <j.0:publicURI rdf:resource="http://arcos.rack/properties"/>
   </j.0:OntologySpec>
   <j.0:OntologySpec>
     <j.0:createdBy>SRL_Metrics</j.0:createdBy>
     <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
-    <j.0:altURL rdf:resource="file:/Users/emertens/Source/arcos/RACK/RACK-Ontology/OwlModels/GeneratePropInfoCSV.sadl.metrics.owl"/>
+    <j.0:altURL rdf:resource="file:/home/siddharthist/code/arcos/rack/RACK-Ontology/OwlModels/CounterApplication.sadl.metrics.owl"/>
+    <j.0:publicURI rdf:resource="http://TurnstileSystem/CounterApplication.metrics"/>
+  </j.0:OntologySpec>
+  <j.0:OntologySpec>
+    <j.0:createdBy>SRL_Metrics</j.0:createdBy>
+    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
+    <j.0:altURL rdf:resource="file:/home/siddharthist/code/arcos/rack/RACK-Ontology/OwlModels/GeneratePropInfoCSV.sadl.metrics.owl"/>
     <j.0:publicURI rdf:resource="http://arcos.rack/GeneratePropInfoCSV.metrics"/>
   </j.0:OntologySpec>
   <j.0:OntologySpec>
-    <j.0:publicURI rdf:resource="http://arcos.rack/HAZARD"/>
-    <j.0:altURL rdf:resource="file:/Users/emertens/Source/arcos/RACK/RACK-Ontology/OwlModels/HAZARD.owl"/>
+    <j.0:createdBy>SRL_Metrics</j.0:createdBy>
     <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
-    <j.0:createdBy>SADL</j.0:createdBy>
+    <j.0:altURL rdf:resource="file:/home/siddharthist/code/arcos/rack/RACK-Ontology/OwlModels/PROV-S.sadl.metrics.owl"/>
+    <j.0:publicURI rdf:resource="http://arcos.rack/PROV-S.metrics"/>
+  </j.0:OntologySpec>
+  <j.0:OntologySpec>
     <j.0:prefix rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
-    >H</j.0:prefix>
+    >builtinfunctions</j.0:prefix>
+    <j.0:createdBy>SADL</j.0:createdBy>
+    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
+    <j.0:altURL rdf:resource="file:/home/siddharthist/code/arcos/rack/RACK-Ontology/OwlModels/SadlBuiltinFunctions.owl"/>
+    <j.0:publicURI rdf:resource="http://sadl.org/builtinfunctions"/>
+  </j.0:OntologySpec>
+  <j.0:OntologySpec>
+    <j.0:prefix rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+    >sadlimplicitmodel</j.0:prefix>
+    <j.0:createdBy>SADL</j.0:createdBy>
+    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
+    <j.0:altURL rdf:resource="file:/home/siddharthist/code/arcos/rack/RACK-Ontology/OwlModels/SadlImplicitModel.owl"/>
+    <j.0:publicURI rdf:resource="http://sadl.org/sadlimplicitmodel"/>
   </j.0:OntologySpec>
   <j.0:OntologySpec>
     <j.0:createdBy>SRL_Metrics</j.0:createdBy>
     <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
-    <j.0:altURL rdf:resource="file:/Users/emertens/Source/arcos/RACK/RACK-Ontology/OwlModels/ANALYSIS.sadl.metrics.owl"/>
+    <j.0:altURL rdf:resource="file:/home/siddharthist/code/arcos/rack/RACK-Ontology/OwlModels/properties.sadl.metrics.owl"/>
+    <j.0:publicURI rdf:resource="http://arcos.rack/properties.metrics"/>
+  </j.0:OntologySpec>
+  <j.0:OntologySpec>
+    <j.0:prefix rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+    >H</j.0:prefix>
+    <j.0:createdBy>SADL</j.0:createdBy>
+    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
+    <j.0:altURL rdf:resource="file:/home/siddharthist/code/arcos/rack/RACK-Ontology/OwlModels/HAZARD.owl"/>
+    <j.0:publicURI rdf:resource="http://arcos.rack/HAZARD"/>
+  </j.0:OntologySpec>
+  <j.0:OntologySpec>
+    <j.0:prefix rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+    >ingaterq</j.0:prefix>
+    <j.0:createdBy>SADL</j.0:createdBy>
+    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
+    <j.0:altURL rdf:resource="file:/home/siddharthist/code/arcos/rack/RACK-Ontology/OwlModels/InGateRequirements.owl"/>
+    <j.0:publicURI rdf:resource="http://TurnstileSystem/InGateRequirement"/>
+  </j.0:OntologySpec>
+  <j.0:OntologySpec>
+    <j.0:prefix rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+    >provs</j.0:prefix>
+    <j.0:createdBy>SADL</j.0:createdBy>
+    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
+    <j.0:altURL rdf:resource="file:/home/siddharthist/code/arcos/rack/RACK-Ontology/OwlModels/PROV-S.owl"/>
+    <j.0:publicURI rdf:resource="http://arcos.rack/PROV-S"/>
+  </j.0:OntologySpec>
+  <j.0:OntologySpec>
+    <j.0:prefix rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+    >cntrappllr</j.0:prefix>
+    <j.0:createdBy>SADL</j.0:createdBy>
+    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
+    <j.0:altURL rdf:resource="file:/home/siddharthist/code/arcos/rack/RACK-Ontology/OwlModels/CounterApplicationLLR.owl"/>
+    <j.0:publicURI rdf:resource="http://TurnstileSystem/CounterApplicationLLR"/>
+  </j.0:OntologySpec>
+  <j.0:OntologySpec>
+    <j.0:prefix rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+    >cpp</j.0:prefix>
+    <j.0:createdBy>SADL</j.0:createdBy>
+    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
+    <j.0:altURL rdf:resource="file:/home/siddharthist/code/arcos/rack/RACK-Ontology/OwlModels/CPP.owl"/>
+    <j.0:publicURI rdf:resource="http://CPP/CPP"/>
+  </j.0:OntologySpec>
+  <j.0:OntologySpec>
+    <j.0:createdBy>SRL_Metrics</j.0:createdBy>
+    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
+    <j.0:altURL rdf:resource="file:/home/siddharthist/code/arcos/rack/RACK-Ontology/OwlModels/HazardAssesment.sadl.metrics.owl"/>
+    <j.0:publicURI rdf:resource="http://TurnstileSystem/HazardAssesment.metrics"/>
+  </j.0:OntologySpec>
+  <j.0:OntologySpec>
+    <j.0:createdBy>SRL_Metrics</j.0:createdBy>
+    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
+    <j.0:altURL rdf:resource="file:/home/siddharthist/code/arcos/rack/RACK-Ontology/OwlModels/SACM-S.sadl.metrics.owl"/>
+    <j.0:publicURI rdf:resource="http://arcos.rack/SACM-S.metrics"/>
+  </j.0:OntologySpec>
+  <j.0:OntologySpec>
+    <j.0:createdBy>SRL_Metrics</j.0:createdBy>
+    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
+    <j.0:altURL rdf:resource="file:/home/siddharthist/code/arcos/rack/RACK-Ontology/OwlModels/CPP.sadl.metrics.owl"/>
+    <j.0:publicURI rdf:resource="http://CPP/CPP.metrics"/>
+  </j.0:OntologySpec>
+  <j.0:OntologySpec>
+    <j.0:createdBy>SRL_Metrics</j.0:createdBy>
+    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
+    <j.0:altURL rdf:resource="file:/home/siddharthist/code/arcos/rack/RACK-Ontology/OwlModels/TESTING.sadl.metrics.owl"/>
+    <j.0:publicURI rdf:resource="http://arcos.rack/TESTING.metrics"/>
+  </j.0:OntologySpec>
+  <j.0:OntologySpec>
+    <j.0:createdBy>SRL_Metrics</j.0:createdBy>
+    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
+    <j.0:altURL rdf:resource="file:/home/siddharthist/code/arcos/rack/RACK-Ontology/OwlModels/CounterApplicationLLR.sadl.metrics.owl"/>
+    <j.0:publicURI rdf:resource="http://TurnstileSystem/CounterApplicationLLR.metrics"/>
+  </j.0:OntologySpec>
+  <j.0:OntologySpec>
+    <j.0:createdBy>SRL_Metrics</j.0:createdBy>
+    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
+    <j.0:altURL rdf:resource="file:/home/siddharthist/code/arcos/rack/RACK-Ontology/OwlModels/Turnstiles.sadl.metrics.owl"/>
+    <j.0:publicURI rdf:resource="http://TurnstileSystem/Turnstiles.metrics"/>
+  </j.0:OntologySpec>
+  <j.0:OntologySpec>
+    <j.0:createdBy>SRL_Metrics</j.0:createdBy>
+    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
+    <j.0:altURL rdf:resource="file:/home/siddharthist/code/arcos/rack/RACK-Ontology/OwlModels/ANALYSIS.sadl.metrics.owl"/>
     <j.0:publicURI rdf:resource="http://arcos.rack/ANALYSIS.metrics"/>
   </j.0:OntologySpec>
   <j.0:OntologySpec>
-    <j.0:publicURI rdf:resource="http://TurnstileSystem/CounterApplicationLLR.metrics"/>
-    <j.0:altURL rdf:resource="file:/Users/emertens/Source/arcos/RACK/RACK-Ontology/OwlModels/CounterApplicationLLR.sadl.metrics.owl"/>
-    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
     <j.0:createdBy>SRL_Metrics</j.0:createdBy>
+    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
+    <j.0:altURL rdf:resource="file:/home/siddharthist/code/arcos/rack/RACK-Ontology/OwlModels/SOFTWARE.sadl.metrics.owl"/>
+    <j.0:publicURI rdf:resource="http://arcos.rack/SOFTWARE.metrics"/>
   </j.0:OntologySpec>
   <j.0:OntologySpec>
-    <j.0:publicURI rdf:resource="http://sadl.org/sadlimplicitmodel"/>
-    <j.0:altURL rdf:resource="file:/Users/emertens/Source/arcos/RACK/RACK-Ontology/OwlModels/SadlImplicitModel.owl"/>
-    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
-    <j.0:createdBy>SADL</j.0:createdBy>
-    <j.0:prefix rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
-    >sadlimplicitmodel</j.0:prefix>
-  </j.0:OntologySpec>
-  <j.0:OntologySpec>
-    <j.0:publicURI rdf:resource="http://TurnstileSystem/HazardAssesment.metrics"/>
-    <j.0:altURL rdf:resource="file:/Users/emertens/Source/arcos/RACK/RACK-Ontology/OwlModels/HazardAssesment.sadl.metrics.owl"/>
-    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
-    <j.0:createdBy>SRL_Metrics</j.0:createdBy>
-  </j.0:OntologySpec>
-  <j.0:OntologySpec>
-    <j.0:publicURI rdf:resource="http://TurnstileSystem/Sample2.metrics"/>
-    <j.0:altURL rdf:resource="file:/C:/sadl/git/RACK/RACK-Ontology/OwlModels/Sample2.sadl.metrics.owl"/>
-    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
-    <j.0:createdBy>SRL_Metrics</j.0:createdBy>
-  </j.0:OntologySpec>
-  <j.0:OntologySpec>
-    <j.0:publicURI rdf:resource="http://arcos.rack/REQUIREMENTS"/>
-    <j.0:altURL rdf:resource="file:/Users/emertens/Source/arcos/RACK/RACK-Ontology/OwlModels/REQUIREMENTS.owl"/>
-    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
-    <j.0:createdBy>SADL</j.0:createdBy>
-    <j.0:prefix rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
-    >Rq</j.0:prefix>
-  </j.0:OntologySpec>
-  <j.0:OntologySpec>
-    <j.0:publicURI rdf:resource="http://arcos.rack/SACM-S"/>
-    <j.0:altURL rdf:resource="file:/Users/emertens/Source/arcos/RACK/RACK-Ontology/OwlModels/SACM-S.owl"/>
-    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
-    <j.0:createdBy>SADL</j.0:createdBy>
-    <j.0:prefix rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
-    >sacms</j.0:prefix>
-  </j.0:OntologySpec>
-  <j.0:OntologySpec>
-    <j.0:publicURI rdf:resource="http://TurnstileSystem/GenerateCSV"/>
-    <j.0:altURL rdf:resource="file:/Users/emertens/Source/arcos/RACK/RACK-Ontology/OwlModels/GenerateCSV.owl"/>
-    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
-    <j.0:createdBy>SADL</j.0:createdBy>
-    <j.0:prefix rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
-    >gencsv</j.0:prefix>
-  </j.0:OntologySpec>
-  <j.0:OntologySpec>
-    <j.0:publicURI rdf:resource="http://arcos.rack/HAZARD.metrics"/>
-    <j.0:altURL rdf:resource="file:/Users/emertens/Source/arcos/RACK/RACK-Ontology/OwlModels/HAZARD.sadl.metrics.owl"/>
-    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
-    <j.0:createdBy>SRL_Metrics</j.0:createdBy>
-  </j.0:OntologySpec>
-  <j.0:OntologySpec>
-    <j.0:publicURI rdf:resource="http://TurnstileSystem/CounterApplicationTesting"/>
-    <j.0:altURL rdf:resource="file:/Users/emertens/Source/arcos/RACK/RACK-Ontology/OwlModels/CounterApplicationTesting.owl"/>
-    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
-    <j.0:createdBy>SADL</j.0:createdBy>
-    <j.0:prefix rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
-    >cntrapptst</j.0:prefix>
-  </j.0:OntologySpec>
-  <j.0:OntologySpec>
-    <j.0:publicURI rdf:resource="http://TurnstileSystem/CounterApplication.metrics"/>
-    <j.0:altURL rdf:resource="file:/Users/emertens/Source/arcos/RACK/RACK-Ontology/OwlModels/CounterApplication.sadl.metrics.owl"/>
-    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
-    <j.0:createdBy>SRL_Metrics</j.0:createdBy>
-  </j.0:OntologySpec>
-  <j.0:OntologySpec>
-    <j.0:publicURI rdf:resource="http://arcos.rack/TESTING"/>
-    <j.0:altURL rdf:resource="file:/Users/emertens/Source/arcos/RACK/RACK-Ontology/OwlModels/TESTING.owl"/>
-    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
-    <j.0:createdBy>SADL</j.0:createdBy>
-    <j.0:prefix rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
-    >tst</j.0:prefix>
-  </j.0:OntologySpec>
-  <j.0:OntologySpec>
-    <j.0:publicURI rdf:resource="http://TurnstileSystem/CounterApplicationRequirements"/>
-    <j.0:altURL rdf:resource="file:/Users/emertens/Source/arcos/RACK/RACK-Ontology/OwlModels/CounterApplicationRequirements.owl"/>
-    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
-    <j.0:createdBy>SADL</j.0:createdBy>
     <j.0:prefix rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
     >cntrapprq</j.0:prefix>
+    <j.0:createdBy>SADL</j.0:createdBy>
+    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
+    <j.0:altURL rdf:resource="file:/home/siddharthist/code/arcos/rack/RACK-Ontology/OwlModels/CounterApplicationRequirements.owl"/>
+    <j.0:publicURI rdf:resource="http://TurnstileSystem/CounterApplicationRequirements"/>
   </j.0:OntologySpec>
   <j.0:OntologySpec>
-    <j.0:publicURI rdf:resource="http://arcos.rack/properties.metrics"/>
-    <j.0:altURL rdf:resource="file:/Users/emertens/Source/arcos/RACK/RACK-Ontology/OwlModels/properties.sadl.metrics.owl"/>
+    <j.0:prefix rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+    >cntrapptst</j.0:prefix>
+    <j.0:createdBy>SADL</j.0:createdBy>
     <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
+    <j.0:altURL rdf:resource="file:/home/siddharthist/code/arcos/rack/RACK-Ontology/OwlModels/CounterApplicationTesting.owl"/>
+    <j.0:publicURI rdf:resource="http://TurnstileSystem/CounterApplicationTesting"/>
+  </j.0:OntologySpec>
+  <j.0:OntologySpec>
     <j.0:createdBy>SRL_Metrics</j.0:createdBy>
+    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
+    <j.0:altURL rdf:resource="file:/home/siddharthist/code/arcos/rack/RACK-Ontology/OwlModels/CounterApplicationUnitTesting.sadl.metrics.owl"/>
+    <j.0:publicURI rdf:resource="http://TurnstileSystem/CounterApplicationUnitTesting.metrics"/>
   </j.0:OntologySpec>
   <j.0:OntologySpec>
-    <j.0:publicURI rdf:resource="http://sadl.org/builtinfunctions"/>
-    <j.0:altURL rdf:resource="file:/Users/emertens/Source/arcos/RACK/RACK-Ontology/OwlModels/SadlBuiltinFunctions.owl"/>
-    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
-    <j.0:createdBy>SADL</j.0:createdBy>
     <j.0:prefix rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
-    >builtinfunctions</j.0:prefix>
-  </j.0:OntologySpec>
-  <j.0:OntologySpec>
-    <j.0:publicURI rdf:resource="http://TurnstileSystem/InGateRequirement"/>
-    <j.0:altURL rdf:resource="file:/Users/emertens/Source/arcos/RACK/RACK-Ontology/OwlModels/InGateRequirements.owl"/>
-    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
+    >A</j.0:prefix>
     <j.0:createdBy>SADL</j.0:createdBy>
-    <j.0:prefix rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
-    >ingaterq</j.0:prefix>
+    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
+    <j.0:altURL rdf:resource="file:/home/siddharthist/code/arcos/rack/RACK-Ontology/OwlModels/ANALYSIS.owl"/>
+    <j.0:publicURI rdf:resource="http://arcos.rack/ANALYSIS"/>
   </j.0:OntologySpec>
   <j.0:OntologySpec>
-    <j.0:publicURI rdf:resource="http://TurnstileSystem/Sample2"/>
-    <j.0:altURL rdf:resource="file:/C:/sadl/git/RACK/RACK-Ontology/OwlModels/Sample2.owl"/>
-    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
+    <j.0:prefix rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+    >ha</j.0:prefix>
     <j.0:createdBy>SADL</j.0:createdBy>
-    <j.0:prefix rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
-    >smpl2</j.0:prefix>
+    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
+    <j.0:altURL rdf:resource="file:/home/siddharthist/code/arcos/rack/RACK-Ontology/OwlModels/HazardAssesment.owl"/>
+    <j.0:publicURI rdf:resource="http://TurnstileSystem/HazardAssesment"/>
   </j.0:OntologySpec>
   <j.0:OntologySpec>
-    <j.0:publicURI rdf:resource="http://arcos.rack/SYSTEM.metrics"/>
-    <j.0:altURL rdf:resource="file:/Users/emertens/Source/arcos/RACK/RACK-Ontology/OwlModels/SYSTEM.sadl.metrics.owl"/>
-    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
     <j.0:createdBy>SRL_Metrics</j.0:createdBy>
-  </j.0:OntologySpec>
-  <j.0:OntologySpec>
+    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
+    <j.0:altURL rdf:resource="file:/home/siddharthist/code/arcos/rack/RACK-Ontology/OwlModels/InGateRequirements.sadl.metrics.owl"/>
     <j.0:publicURI rdf:resource="http://TurnstileSystem/InGateRequirement.metrics"/>
-    <j.0:altURL rdf:resource="file:/Users/emertens/Source/arcos/RACK/RACK-Ontology/OwlModels/InGateRequirements.sadl.metrics.owl"/>
-    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
-    <j.0:createdBy>SRL_Metrics</j.0:createdBy>
   </j.0:OntologySpec>
   <j.0:OntologySpec>
-    <j.0:publicURI rdf:resource="http://arcos.rack/AGENTS.metrics"/>
-    <j.0:altURL rdf:resource="file:/Users/emertens/Source/arcos/RACK/RACK-Ontology/OwlModels/AGENTS.sadl.metrics.owl"/>
+    <j.0:prefix rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+    >trnstl</j.0:prefix>
+    <j.0:createdBy>SADL</j.0:createdBy>
     <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
-    <j.0:createdBy>SRL_Metrics</j.0:createdBy>
+    <j.0:altURL rdf:resource="file:/home/siddharthist/code/arcos/rack/RACK-Ontology/OwlModels/Turnstiles.owl"/>
+    <j.0:publicURI rdf:resource="http://TurnstileSystem/Turnstiles"/>
   </j.0:OntologySpec>
   <j.0:OntologySpec>
-    <j.0:publicURI rdf:resource="http://TurnstileSystem/GenerateCSV.metrics"/>
-    <j.0:altURL rdf:resource="file:/Users/emertens/Source/arcos/RACK/RACK-Ontology/OwlModels/GenerateCSV.sadl.metrics.owl"/>
+    <j.0:prefix rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+    >cntrapputst</j.0:prefix>
+    <j.0:createdBy>SADL</j.0:createdBy>
     <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
+    <j.0:altURL rdf:resource="file:/home/siddharthist/code/arcos/rack/RACK-Ontology/OwlModels/CounterApplicationUnitTesting.owl"/>
+    <j.0:publicURI rdf:resource="http://TurnstileSystem/CounterApplicationUnitTesting"/>
+  </j.0:OntologySpec>
+  <j.0:OntologySpec>
+    <j.0:prefix rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+    >gencsv</j.0:prefix>
+    <j.0:createdBy>SADL</j.0:createdBy>
+    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
+    <j.0:altURL rdf:resource="file:/home/siddharthist/code/arcos/rack/RACK-Ontology/OwlModels/GenerateCSV.owl"/>
+    <j.0:publicURI rdf:resource="http://TurnstileSystem/GenerateCSV"/>
+  </j.0:OntologySpec>
+  <j.0:OntologySpec>
+    <j.0:prefix rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+    >sacms</j.0:prefix>
+    <j.0:createdBy>SADL</j.0:createdBy>
+    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
+    <j.0:altURL rdf:resource="file:/home/siddharthist/code/arcos/rack/RACK-Ontology/OwlModels/SACM-S.owl"/>
+    <j.0:publicURI rdf:resource="http://arcos.rack/SACM-S"/>
+  </j.0:OntologySpec>
+  <j.0:OntologySpec>
+    <j.0:prefix rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+    >Rq</j.0:prefix>
+    <j.0:createdBy>SADL</j.0:createdBy>
+    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
+    <j.0:altURL rdf:resource="file:/home/siddharthist/code/arcos/rack/RACK-Ontology/OwlModels/REQUIREMENTS.owl"/>
+    <j.0:publicURI rdf:resource="http://arcos.rack/REQUIREMENTS"/>
+  </j.0:OntologySpec>
+  <j.0:OntologySpec>
+    <j.0:prefix rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+    >sys</j.0:prefix>
+    <j.0:createdBy>SADL</j.0:createdBy>
+    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
+    <j.0:altURL rdf:resource="file:/home/siddharthist/code/arcos/rack/RACK-Ontology/OwlModels/SYSTEM.owl"/>
+    <j.0:publicURI rdf:resource="http://arcos.rack/SYSTEM"/>
+  </j.0:OntologySpec>
+  <j.0:OntologySpec>
     <j.0:createdBy>SRL_Metrics</j.0:createdBy>
+    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
+    <j.0:altURL rdf:resource="file:/home/siddharthist/code/arcos/rack/RACK-Ontology/OwlModels/HAZARD.sadl.metrics.owl"/>
+    <j.0:publicURI rdf:resource="http://arcos.rack/HAZARD.metrics"/>
+  </j.0:OntologySpec>
+  <j.0:OntologySpec>
+    <j.0:prefix rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+    >sw</j.0:prefix>
+    <j.0:createdBy>SADL</j.0:createdBy>
+    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
+    <j.0:altURL rdf:resource="file:/home/siddharthist/code/arcos/rack/RACK-Ontology/OwlModels/SOFTWARE.owl"/>
+    <j.0:publicURI rdf:resource="http://arcos.rack/SOFTWARE"/>
+  </j.0:OntologySpec>
+  <j.0:OntologySpec>
+    <j.0:createdBy>SRL_Metrics</j.0:createdBy>
+    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
+    <j.0:altURL rdf:resource="file:/home/siddharthist/code/arcos/rack/RACK-Ontology/OwlModels/CounterApplicationTesting.sadl.metrics.owl"/>
+    <j.0:publicURI rdf:resource="http://TurnstileSystem/CounterApplicationTesting.metrics"/>
+  </j.0:OntologySpec>
+  <j.0:OntologySpec>
+    <j.0:createdBy>SRL_Metrics</j.0:createdBy>
+    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
+    <j.0:altURL rdf:resource="file:/home/siddharthist/code/arcos/rack/RACK-Ontology/OwlModels/SYSTEM.sadl.metrics.owl"/>
+    <j.0:publicURI rdf:resource="http://arcos.rack/SYSTEM.metrics"/>
+  </j.0:OntologySpec>
+  <j.0:OntologySpec>
+    <j.0:prefix rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+    >Rv</j.0:prefix>
+    <j.0:createdBy>SADL</j.0:createdBy>
+    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
+    <j.0:altURL rdf:resource="file:/home/siddharthist/code/arcos/rack/RACK-Ontology/OwlModels/REVIEW.owl"/>
+    <j.0:publicURI rdf:resource="http://arcos.rack/REVIEW"/>
+  </j.0:OntologySpec>
+  <j.0:OntologySpec>
+    <j.0:createdBy>SRL_Metrics</j.0:createdBy>
+    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
+    <j.0:altURL rdf:resource="file:/home/siddharthist/code/arcos/rack/RACK-Ontology/OwlModels/REQUIREMENTS.sadl.metrics.owl"/>
+    <j.0:publicURI rdf:resource="http://arcos.rack/REQUIREMENTS.metrics"/>
+  </j.0:OntologySpec>
+  <j.0:OntologySpec>
+    <j.0:createdBy>SRL_Metrics</j.0:createdBy>
+    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
+    <j.0:altURL rdf:resource="file:/C:/sadl/git/RACK/RACK-Ontology/OwlModels/Sample2.sadl.metrics.owl"/>
+    <j.0:publicURI rdf:resource="http://TurnstileSystem/Sample2.metrics"/>
+  </j.0:OntologySpec>
+  <j.0:OntologySpec>
+    <j.0:prefix rdf:datatype="http://www.w3.org/2001/XMLSchema#string"
+    >tst</j.0:prefix>
+    <j.0:createdBy>SADL</j.0:createdBy>
+    <j.0:language rdf:resource="http://www.w3.org/2002/07/owl"/>
+    <j.0:altURL rdf:resource="file:/home/siddharthist/code/arcos/rack/RACK-Ontology/OwlModels/TESTING.owl"/>
+    <j.0:publicURI rdf:resource="http://arcos.rack/TESTING"/>
   </j.0:OntologySpec>
 </rdf:RDF>

--- a/RACK-Ontology/models/CPP/CPP.sadl
+++ b/RACK-Ontology/models/CPP/CPP.sadl
@@ -1,0 +1,78 @@
+uri "http://CPP/CPP" alias cpp.
+import "http://arcos.rack/ANALYSIS".
+import "http://arcos.rack/SYSTEM".
+import "http://arcos.rack/SOFTWARE".
+
+CPP is a sw:LANGUAGE.
+
+LIBCPP is a LIBRARY.
+
+EXAMPLE_CPP is a CODE_FILE
+  has sw:language CPP.
+
+INTERVAL_ANALYSIS is a ANALYSIS.
+
+INTERVAL_ANALYSIS_REPORT is a ANALYSIS_REPORT
+  has analyzes EXAMPLE_CPP.
+
+STATE_INVARIANT is a ANALYSIS_ANNOTATION
+  has fromReport INTERVAL_ANALYSIS_REPORT
+  has annotationType INVARIANT
+  has description "This variable is non-negative.".
+
+OPERATOR_LTLT is a COMPONENT
+  has componentType SOURCE_FUNCTION
+  has name "operator<<"
+  definedIn LIBCPP.
+
+COUT is a COMPONENT
+  has componentType SOURCE_GLOBAL_VARIABLE
+  has name "std::cout"
+  has valueType "std::ostream"
+  definedIn LIBCPP.
+
+ENDL is a COMPONENT
+  has componentType SOURCE_GLOBAL_VARIABLE
+  has name "std::cout"
+  has valueType "template< class CharT, class Traits > std::basic_ostream<CharT, Traits>& ( std::basic_ostream<CharT, Traits>&)" // definitely not sure how this should work
+  definedIn LIBCPP.
+
+GENERATOR is a COMPONENT
+  has componentType CLASS
+  has name "Generator"
+  definedIn EXAMPLE_CPP.
+
+GENERATOR_STATE is a COMPONENT
+  has componentType CLASS_MEMBER_VARIABLE
+  has name "state"
+  has valueType "int"
+  has subcomponentOf GENERATOR
+  has annotations STATE_INVARIANT
+  has definedIn EXAMPLE_CPP.
+
+GENERATOR_CON is a COMPONENT
+  has componentType CLASS_CONSTRUCTOR
+  has subcomponentOf GENERATOR
+  has valueType "()"
+  has definedIn EXAMPLE_CPP
+  mentions GENERATOR_STATE. // implicitly.
+
+NEXT is a COMPONENT
+  has componentType CLASS_METHOD
+  has name "next"
+  has valueType "int()"
+  subcomponentOf GENERATOR
+  definedIn EXAMPLE_CPP
+  mentions GENERATOR_STATE.
+
+MAIN is a COMPONENT
+  has componentType SOURCE_FUNCTION
+  has name "main"
+  has valueType "int(int,char*[])"
+  has definedIn EXAMPLE_CPP
+  mentions GENERATOR
+  mentions GENERATOR_CON
+  mentions NEXT
+  mentions COUT
+  mentions ENDL
+  mentions OPERATOR_LTLT.

--- a/RACK-Ontology/models/CPP/src/example.cpp
+++ b/RACK-Ontology/models/CPP/src/example.cpp
@@ -1,0 +1,16 @@
+#include <iostream>
+
+class Generator {
+  int state = 1;
+
+  int next() {
+    state = state * 3 % 10;
+    return state;
+  }
+};
+
+int main(int argc, char *argv[]) {
+  Generator g;
+  std::cout << g.next() << g.next() << std::endl;
+  return 0;
+}

--- a/RACK-Ontology/models/TurnstileSystem/CounterApplication.sadl
+++ b/RACK-Ontology/models/TurnstileSystem/CounterApplication.sadl
@@ -37,6 +37,13 @@ input_h is a CODE_FILE
     has uniqueIdentifier "input_h",
     has sw:language c.
 
+input_function is a COMPONENT
+    has uniqueIdentifier "input_function"
+    has componentType SOURCE_FUNCTION
+    has name "input"
+    has valueType "void()"
+    has definedIn input_c.
+
 input_o_Compiling is a COMPILE
     has uniqueIdentifier "input_o_Compiling",
     has performedBy cc,
@@ -56,6 +63,13 @@ output_c is a CODE_FILE
 output_h is a CODE_FILE
     has uniqueIdentifier "output_h",
     has sw:language c.
+
+output_function is a COMPONENT
+    has uniqueIdentifier "output_function"
+    has componentType SOURCE_FUNCTION
+    has name "output"
+    has valueType "void()"
+    has definedIn output_c.
 
 output_o_Compiling is a COMPILE
     has uniqueIdentifier "output_o_Compiling",
@@ -107,6 +121,13 @@ counter_c is a CODE_FILE
 counter_h is a CODE_FILE
     has uniqueIdentifier "counter_h",
     has sw:language c.
+
+main_function is a COMPONENT
+    has uniqueIdentifier "main_function"
+    has componentType SOURCE_FUNCTION
+    has name "main"
+    has valueType "int(int argc, char* argv[])"
+    has definedIn counter_c.
 
 counter_exe_Compiling is a COMPILE
     has uniqueIdentifier "counter_exe_Compiling",

--- a/RACK-Ontology/ontology/ANALYSIS.sadl
+++ b/RACK-Ontology/ontology/ANALYSIS.sadl
@@ -14,3 +14,25 @@ ANALYSIS_REPORT is a type of ENTITY.
 ANALYSIS is a type of ACTIVITY.
 	performedBy (note "Entity that is responsible for producing an analysis, could be a person or a tool. ") describes ANALYSIS with values of type AGENT.
 	performedBy is a type of wasAssociatedWith.
+
+ANALYSIS_ANNOTATION_TYPE
+    (note "An open/extensible set of types of analysis annotations")
+    is a class.
+
+// A few common instances:
+PRECONDITION
+    (note "A constraint that should hold in advance of successful operation of this unit of code.")
+    is a ANALYSIS_ANNOTATION_TYPE.
+POSTCONDITION
+    (note "A constraint that should hold after of successful operation of this unit of code.")
+    is a ANALYSIS_ANNOTATION_TYPE.
+INVARIANT
+    (note "A constraint on this unit of code or data that is true at any point in the program's execution.")
+    is a ANALYSIS_ANNOTATION_TYPE.
+
+ANALYSIS_ANNOTATION
+    (note "A result of the analysis that is linked to some specific part of the system.")
+    is a type of ENTITY.
+    fromReport (note "Which analysis report this annotation comes from.") describes ANALYSIS_ANNOTATION with values of type ENTITY.
+    description (note "The content of the annotation.") describes ANALYSIS_ANNOTATION with values of type string.
+    annotationType (note "The type of the annotation.") describes ANALYSIS_ANNOTATION with values of type ANALYSIS_ANNOTATION_TYPE.

--- a/RACK-Ontology/ontology/SOFTWARE.sadl
+++ b/RACK-Ontology/ontology/SOFTWARE.sadl
@@ -14,7 +14,6 @@ CODE_FILE is a type of ENTITY.
 	createBy is a type of wasGeneratedBy.
 
 LANGUAGE is a type of ENTITY.
-	
 	^version describes LANGUAGE with values of type string.
 	
 	
@@ -66,5 +65,64 @@ PACKAGE is a type of ACTIVITY.
 	performedBy describes PACKAGE with values of type AGENT.
 	performedBy is a type of wasAssociatedWith.
 
+COMPONENT_TYPE
+    (note "An open/extensible set of types of software components")
+    is a class.
+    uniqueIdentifier describes COMPONENT_TYPE with a single value of type string.
 
-	
+// A few common instances:
+SOURCE_FUNCTION
+    (note "A function or procedure declared or defined in source code.")
+    is a COMPONENT_TYPE
+    has uniqueIdentifier "SOURCE_FUNCTION".
+BINARY_FUNCTION
+    (note "A function in a binary, as defined by the appropriate ABI.")
+    is a COMPONENT_TYPE
+    has uniqueIdentifier "BINARY_FUNCTION".
+SOURCE_GLOBAL_VARIABLE
+    (note "A global variable declared or defined in source code.")
+    is a COMPONENT_TYPE
+    has uniqueIdentifier "SOURCE_GLOBAL_VARIABLE".
+BINARY_GLOBAL_VARIABLE
+    (note "A global variable (generally in the .data or .bss sections).")
+    is a COMPONENT_TYPE
+    has uniqueIdentifier "BINARY_GLOBAL_VARIABLE".
+BINARY_BASIC_BLOCK
+    (note "A basic block at the binary level.")
+    is a COMPONENT_TYPE
+    has uniqueIdentifier "BINARY_BASIC_BLOCK".
+CLASS
+    (note "A class in an object-oriented language.")
+    is a COMPONENT_TYPE
+    has uniqueIdentifier "CLASS".
+CLASS_METHOD
+    (note "A method attached to a class in an object-oriented language.")
+    is a COMPONENT_TYPE
+    has uniqueIdentifier "CLASS_METHOD".
+CLASS_MEMBER_VARIABLE
+    (note "A variable attached to the instances of a class in an object-oriented language.")
+    is a COMPONENT_TYPE
+    has uniqueIdentifier "CLASS_MEMBER_VARIABLE".
+CLASS_CONSTRUCTOR
+    (note "A constructor in an object-oriented language.")
+    is a COMPONENT_TYPE
+    has uniqueIdentifier "CLASS_CONSTRUCTOR".
+MODULE
+    (note "A collection of related code, usually grouped in a lexical scope.")
+    is a COMPONENT_TYPE
+    has uniqueIdentifier "MODULE".
+NAMESPACE
+    (note "A collection of related code, usually grouped in a lexical scope.")
+    is a COMPONENT_TYPE
+    has uniqueIdentifier "NAMESPACE".
+
+COMPONENT is a type of ENTITY.
+    name describes COMPONENT with values of type string.
+    componentType describes COMPONENT with a single value of type COMPONENT_TYPE.
+    valueType (note "The type of this value, if applicable (e.g. for functions or variables).") describes COMPONENT with values of type string.
+    instantiates (note "What logical component (system) does this physical component (code) instantiate or implement?") describes COMPONENT with values of type ENTITY.
+    definedIn (note "Defining entity of this code structure. This could be a CODE_FILE, LIBRARY, etc.") describes COMPONENT with values of type ENTITY.
+    mentions (note "A component referenced by this one, e.g., a callee or variable being used.") describes COMPONENT with values of type ENTITY.
+    subcomponentOf (note "A structural sub-component, e.g., a function might be a subcomponent of module.") describes COMPONENT with values of type ENTITY.
+    requirements (note "Low-level requirements that apply to this component.") describes COMPONENT with values of type ENTITY.
+    annotations (note "Analysis annotations that apply to this component.") describes COMPONENT with values of type ENTITY.


### PR DESCRIPTION
Fixes #55 
Fixes #72 

Both the structure of software and analysis results were left as open sets so that TA1s can define their own instances. This allows for flexibility, e.g., by allowing for analysis of software written in languages that we didn't anticipate.

Possible follow-ups/TODOs:

 - [ ] Instantiate the `BINARY_*` classes

Open questions:

 - How do we support knowing the locations of components in source or binary files? GrammaTech asked for "Specification of the unit, e.g. name of object file, location/address/offsetwhere the component starts"