### PR TITLE
rack.py: trim final / in base_url

### DIFF
--- a/RACK-Ontology/scripts/rack.py
+++ b/RACK-Ontology/scripts/rack.py
@@ -201,6 +201,10 @@ def main() -> None:
 
     logging.basicConfig(level=logging.INFO)
 
+    if args.base_url.endswith('/'):
+        logging.warning('Trimming the final \'/\' from your base_url')
+        args.base_url = args.base_url[:-1]
+
     try:
         if args.command is None:
             logging.error('Subcommand required (use --help to see options)')


### PR DESCRIPTION
I often copy-paste the URL from my web browser, which inserts a final
slash, e.g. http://1.2.3.4/, but the script attempts to add a port,
which gives the failing http://1.2.3.4/:1234.

This simply detects if the base_url ends with a /, and trims it, with a
warning.