### PR TITLE
Use specific property targets instead of base classes.

### DIFF
--- a/RACK-Ontology/ontology/ANALYSIS.sadl
+++ b/RACK-Ontology/ontology/ANALYSIS.sadl
@@ -11,7 +11,7 @@ ANALYSIS_REPORT
     analyzes (note "ENTITY(s) under analysis") describes ANALYSIS_REPORT with values of type ENTITY.
     analyzes is a type of wasDerivedFrom.
 
-    producedBy (note "ACTIVITY(s) (e.g. ANALYSIS) producing this report") describes ANALYSIS_REPORT with values of type ACTIVITY.
+    producedBy (note "ANALYSIS/ANALYSES activity producing this report") describes ANALYSIS_REPORT with values of type ANALYSIS.
     producedBy is a type of wasGeneratedBy.
 
 ANALYSIS
@@ -39,6 +39,6 @@ INVARIANT
 ANALYSIS_ANNOTATION
     (note "A result of the analysis that is linked to some specific part of the system.")
     is a type of ENTITY.
-    fromReport (note "Which analysis report this annotation comes from.") describes ANALYSIS_ANNOTATION with values of type ENTITY.
+    fromReport (note "Which analysis report this annotation comes from.") describes ANALYSIS_ANNOTATION with values of type ANALYSIS_REPORT.
     description (note "The content of the annotation.") describes ANALYSIS_ANNOTATION with values of type string.
     annotationType (note "The type of the annotation.") describes ANALYSIS_ANNOTATION with values of type ANALYSIS_ANNOTATION_TYPE.

--- a/RACK-Ontology/ontology/REQUIREMENTS.sadl
+++ b/RACK-Ontology/ontology/REQUIREMENTS.sadl
@@ -19,13 +19,13 @@ REQUIREMENT
 	governs (note "ENTITY(s) that are the subject of the requirement") describes REQUIREMENT with values of type ENTITY.
 	governs is a type of wasDerivedFrom.
 
-	satisfies (note "Parent ENTITY(s) (e.g. REQUIREMENT) that this REQUIREMENT is derived from") describes REQUIREMENT with values of type ENTITY.
+	satisfies (note "Parent REQUIREMENT(s) ENTITY that this REQUIREMENT is derived from") describes REQUIREMENT with values of type REQUIREMENT.
 	satisfies is a type of wasDerivedFrom.
 
-	mitigates (note "ENTITY(s) (e.g. HAZARD) that is being mitigated by this REQUIREMENT") describes REQUIREMENT with values of type ENTITY.
+	mitigates (note "HAZARD(s) ENTITY that is being mitigated by this REQUIREMENT") describes REQUIREMENT with values of type HAZARD.
 	mitigates is a type of wasDerivedFrom.
 
-	createdBy (note "ACTIVITY(s) (e.g. REQUIREMENT_DEVELOPMENT) that created this REQUIREMENT") describes REQUIREMENT with values of type ACTIVITY.
+	createdBy (note "REQUIREMENT_DEVELOPMENT(s) ACTIVITY that created this REQUIREMENT") describes REQUIREMENT with values of type REQUIREMENT_DEVELOPMENT.
 	createdBy is a type of wasGeneratedBy.
 
 
@@ -35,13 +35,13 @@ DATA_DICTIONARY_TERM
 
 	text (note "Description of the term") describes DATA_DICTIONARY_TERM with values of type string.
 
-	providedBy (note "ENTITY(s) (e.g. REQUIREMENT) that provides this information") describes DATA_DICTIONARY_TERM with values of type ENTITY.
+	providedBy (note "REQUIREMENT(s) ENTITY that provides this information") describes DATA_DICTIONARY_TERM with values of type REQUIREMENT.
 	providedBy is a type of wasDerivedFrom.
 
-	consumedBy (note "ENTITY(s) (e.g. REQUIREMENT) that consumes this information") describes DATA_DICTIONARY_TERM with values of type ENTITY.
+	consumedBy (note "REQUIREMENT(s) ENTITY that consumes this information") describes DATA_DICTIONARY_TERM with values of type REQUIREMENT.
 	consumedBy is a type of wasDerivedFrom.
 
-	createdBy (note "ACTIVITY(s) (e.g. REQUIREMENT_DEVELOPMENT) that created this data dictionary term") describes DATA_DICTIONARY_TERM with values of type ACTIVITY.
+	createdBy (note "REQUIREMENT_DEVELOPMENT(s) ACTIVITY that created this data dictionary term") describes DATA_DICTIONARY_TERM with values of type REQUIREMENT_DEVELOPMENT.
 	createdBy is a type of wasGeneratedBy.
 
 
@@ -55,5 +55,5 @@ REQUIREMENT_DEVELOPMENT
 	referenced (note "Source materials (requirement and design docs) used during development") describes REQUIREMENT_DEVELOPMENT with values of type ENTITY.
 	referenced is a type of used.
 
-	governedBy (note "ENTITY(s) (e.g. REQUIREMENTS, any sort of document) used during this ACTIVITY") describes REQUIREMENT_DEVELOPMENT with values of type ENTITY.
+	governedBy (note "REQUIREMENT(s) ENTITY (any sort of document) used during this ACTIVITY") describes REQUIREMENT_DEVELOPMENT with values of type REQUIREMENT.
 	governedBy is a type of used.

--- a/RACK-Ontology/ontology/REVIEW.sadl
+++ b/RACK-Ontology/ontology/REVIEW.sadl
@@ -11,7 +11,7 @@ REVIEW_LOG
 	reviewResult (note "Review status descriptor") describes REVIEW_LOG with values of type REVIEW_STATE.
 	REVIEW_STATE is a class, must be one of {Passed, ReviseWithoutReview, ReviseWithReview}.
 
-	createBy (note "ACTIVITY(s) (e.g. REVIEW) that created this log") describes REVIEW_LOG with values of type ACTIVITY.
+	createBy (note "REVIEW(s) ACTIVITY that created this log") describes REVIEW_LOG with values of type REVIEW.
 	createBy is a type of wasGeneratedBy.
 
 REVIEW
@@ -27,5 +27,5 @@ REVIEW
 	reviewed (note "ENTITY(s) being reviewed") describes REVIEW with values of type ENTITY.
 	reviewed is a type of used.
 
-	governedBy (note "ENTITY(s) (e.g. REQUIREMENT) used for performing the review") describes REVIEW with values of type ENTITY.
+	governedBy (note "REQUIREMENT(s) ENTITY used for performing the review") describes REVIEW with values of type REQUIREMENT.
 	governedBy is a type of used.

--- a/RACK-Ontology/ontology/SACM-S.sadl
+++ b/RACK-Ontology/ontology/SACM-S.sadl
@@ -23,7 +23,7 @@ ASSERTED_INFERENCE is a type of ENTITY.
 	target  describes ASSERTED_INFERENCE  with values of type ENTITY.
 	target is a type of wasDerivedFrom.
 
-	reasoning describes ASSERTED_INFERENCE  with values of type ENTITY.
+	reasoning describes ASSERTED_INFERENCE  with values of type ARGUMENT_REASONING.
 	reasoning is a type of wasDerivedFrom.
 
 

--- a/RACK-Ontology/ontology/SOFTWARE.sadl
+++ b/RACK-Ontology/ontology/SOFTWARE.sadl
@@ -8,7 +8,7 @@ FILE
 
 	fileFormat (note "The byte-level encoding of a file") describes FILE with values of type FORMAT.
 
-    satisfies (note "ENTITY(s) (e.g. REQUIREMENT) that this code file participates in satisfying") describes FILE with values of type ENTITY.
+    satisfies (note "REQUIREMENT that this code file participates in satisfying") describes FILE with values of type REQUIREMENT.
     satisfies is a type of wasDerivedFrom.
 
     createBy (note "ACTIVITY(s) that created this file") describes FILE with values of type ACTIVITY.
@@ -25,10 +25,10 @@ CODE_DEVELOPMENT
     author (note "AGENT(s) who participated in this ACTIVITY") describes CODE_DEVELOPMENT with values of type AGENT.
     author is a type of wasAssociatedWith.
 
-    referenced (note "ENTITY(s) (e.g. REQUIREMENT) that were referenced during this ACTIVITY") describes CODE_DEVELOPMENT with values of type ENTITY.
+    referenced (note "REQUIREMENT(s) that were referenced during this ACTIVITY") describes CODE_DEVELOPMENT with values of type REQUIREMENT.
     referenced is a type of used.
 
-    governedBy (note "ENTITY(s) (e.g. REQUIREMENT) that gave rise to this ACTIVITY") describes CODE_DEVELOPMENT with values of type ENTITY.
+    governedBy (note "REQUIREMENT(s) that gave rise to this ACTIVITY") describes CODE_DEVELOPMENT with values of type REQUIREMENT.
     governedBy is a type of used.
 
 BUILD
@@ -121,11 +121,11 @@ COMPONENT is a type of ENTITY.
     name describes COMPONENT with values of type string.
     componentType describes COMPONENT with a single value of type COMPONENT_TYPE.
     valueType (note "The type of this value, if applicable (e.g. for functions or variables).") describes COMPONENT with values of type string.
-    instantiates (note "What logical component (system) does this physical component (code) instantiate or implement?") describes COMPONENT with values of type ENTITY.
-    definedIn (note "Defining entity of this code structure. This could be a CODE_FILE, LIBRARY, etc.") describes COMPONENT with values of type ENTITY.
-    mentions (note "A component referenced by this one, e.g., a callee or variable being used.") describes COMPONENT with values of type ENTITY.
-    subcomponentOf (note "A structural sub-component, e.g., a function might be a subcomponent of module.") describes COMPONENT with values of type ENTITY.
-    requirements (note "Low-level requirements that apply to this component.") describes COMPONENT with values of type ENTITY.
-    annotations (note "Analysis annotations that apply to this component.") describes COMPONENT with values of type ENTITY.
+    instantiates (note "What logical component (system) does this physical component (code) instantiate or implement?") describes COMPONENT with values of type SYSTEM.
+    definedIn (note "Defining entity of this code structure. This could be a CODE_FILE, LIBRARY, etc.") describes COMPONENT with values of type SYSTEM.
+    mentions (note "A component referenced by this one, e.g., a callee or variable being used.") describes COMPONENT with values of type COMPONENT.
+    subcomponentOf (note "A structural sub-component, e.g., a function might be a subcomponent of module.") describes COMPONENT with values of type COMPONENT.
+    requirements (note "Low-level requirements that apply to this component.") describes COMPONENT with values of type REQUIREMENTS.
+    annotations (note "Analysis annotations that apply to this component.") describes COMPONENT with values of type ANALYSIS_ANNOTATION.
     controlFlowsToUnconditionally (note "Control flows from this component to the target unconditionally.") describes COMPONENT with values of type COMPONENT.
     controlFlowsToConditionally (note "Control flows from this component to the target conditionally.") describes COMPONENT with values of type COMPONENT.

--- a/RACK-Ontology/ontology/SYSTEM.sadl
+++ b/RACK-Ontology/ontology/SYSTEM.sadl
@@ -5,10 +5,10 @@ SYSTEM
 	(note "SYSTEMs classify logical parts of the whole system being developed")
 	is a type of ENTITY.
 
-	partOf (note "Used to define a relationship to a higher level system") describes SYSTEM with values of type ENTITY.
+	partOf (note "Used to define a relationship to a higher level system") describes SYSTEM with values of type SYSTEM.
 	partOf is a type of wasDerivedFrom.
 
-	producedBy (note "ACTIVITY(s) participating in developing this SYSTEM") describes SYSTEM with values of type ACTIVITY.
+	producedBy (note "SYSTEM_DEVELOPMENT(s) ACTIVITY participating in developing this SYSTEM") describes SYSTEM with values of type SYSTEM_DEVELOPMENT.
 	producedBy is a type of wasGeneratedBy.
 
 	provides (note "List of entities that this SYSTEM provides to others") describes SYSTEM with values of type ENTITY.
@@ -21,11 +21,11 @@ INTERFACE
 	(note "INTERFACEs describe directed connections between an ENTITY (e.g. SYSTEM) providing what another ENTITY (e.g. SYSTEM) requires")
 	is a type of ENTITY.
 
-	source (note "ENTITY (e.g. SYSTEM) that provides what the INTERFACE offers") describes INTERFACE with values of type ENTITY.
+	source (note "SYSTEM that provides what the INTERFACE offers") describes INTERFACE with values of type SYSTEM.
 	source is the inverse of provides.
 	source is a type of wasDerivedFrom.
 
-	destination (note "ENTITY (e.g. SYSTEM) that requires what the INTERFACE offers") describes INTERFACE with values of type ENTITY.
+	destination (note "SYSTEM that requires what the INTERFACE offers") describes INTERFACE with values of type SYSTEM.
 	destination is the inverse of requires.
 	destination is a type of wasDerivedFrom.
 

--- a/RACK-Ontology/ontology/TESTING.sadl
+++ b/RACK-Ontology/ontology/TESTING.sadl
@@ -5,10 +5,10 @@ TEST
 	(note "Description of a single test")
 	is a type of ENTITY.
 
-	verifies (note "Parent ENTITY(s) (e.g. REQUIREMENT) that this requirement is derived from") describes TEST with values of type ENTITY.
+	verifies (note "The requirement associated with this TEST") describes TEST with values of type REQUIREMENT.
 	verifies is a type of wasDerivedFrom.
 
-	producedBy (note "TEST_DEVELOPMENT activity(s) this test belongs to") describes TEST with values of type ACTIVITY.
+	producedBy (note "TEST_DEVELOPMENT ACTIVITY(s) this test belongs to") describes TEST with values of type TEST_DEVELOPMENT.
 	producedBy is a type of wasGeneratedBy.
 
 TEST_RESULT
@@ -18,10 +18,10 @@ TEST_RESULT
 	result (note "Pass/Failed/Indeterminate status resulting from a TEST_EXECUTION") describes TEST_RESULT with values of type TEST_STATUS.
 	TEST_STATUS is a class, must be one of {Passed, Failed, Indeterminate}.
 
-	confirms (note "Parent test(s) of this test result") describes TEST_RESULT with values of type ENTITY.
+	confirms (note "Parent test(s) of this test result") describes TEST_RESULT with values of type TEST.
 	confirms is a type of wasDerivedFrom.
 
-	executedBy (note "ACTIVITY(s) that created this test result") describes TEST_RESULT with values of type ACTIVITY.
+	executedBy (note "ACTIVITY(s) that created this test result") describes TEST_RESULT with values of type TEST_EXECUTION.
 	executedBy is a type of wasGeneratedBy.
 
 TEST_DEVELOPMENT


### PR DESCRIPTION
Using base classes as property targets introduces ambiguity and
removes the ability to provide any reasoning or Jena inference
regarding the relationships in the ontology (a specific class can
always be demoted to a base class, but the reverse is not true).  In
addition, it means that the actual structure is dictated by the user
data entered into the system rather than the ontology.

Now that we have identified the mechanisms by which we intend to
control the core ontology and support expansion and extension in
response to needs from users, we can remove this underlying ambiguity
from our specification.