### PR TITLE
Add query nodegroups for software structure

### DIFF
--- a/nodegroups/queries/query Compilation Inputs.json
+++ b/nodegroups/queries/query Compilation Inputs.json
@@ -1,0 +1,169 @@
+{
+	"version": 2,
+	"sparqlConn": {
+		"name": "RACK local fuseki",
+		"domain": "",
+		"enableOwlImports": true,
+		"model": [
+			{
+				"type": "fuseki",
+				"url": "http://localhost:3030/RACK",
+				"graph": "http://rack001/model"
+			}
+		],
+		"data": [
+			{
+				"type": "fuseki",
+				"url": "http://localhost:3030/RACK",
+				"graph": "http://rack001/data"
+			}
+		]
+	},
+	"sNodeGroup": {
+		"version": 11,
+		"limit": 0,
+		"offset": 0,
+		"sNodeList": [
+			{
+				"propList": [
+					{
+						"KeyName": "filename",
+						"ValueType": "string",
+						"relationship": "http://www.w3.org/2001/XMLSchema#string",
+						"UriRelationship": "http://arcos.rack/SOFTWARE#filename",
+						"Constraints": "",
+						"fullURIName": "",
+						"SparqlID": "?input_file",
+						"isReturned": true,
+						"optMinus": 0,
+						"isRuntimeConstrained": false,
+						"instanceValues": [],
+						"isMarkedForDeletion": false
+					}
+				],
+				"nodeList": [],
+				"NodeName": "FILE",
+				"fullURIName": "http://arcos.rack/SOFTWARE#FILE",
+				"subClassNames": [],
+				"SparqlID": "?FILE_0",
+				"isReturned": false,
+				"isRuntimeConstrained": false,
+				"valueConstraint": "",
+				"instanceValue": null,
+				"deletionMode": "NO_DELETE"
+			},
+			{
+				"propList": [],
+				"nodeList": [
+					{
+						"SnodeSparqlIDs": [
+							"?FILE_0"
+						],
+						"OptionalMinus": [
+							0
+						],
+						"Qualifiers": [
+							""
+						],
+						"DeletionMarkers": [
+							false
+						],
+						"KeyName": "compileInput",
+						"ValueType": "FILE",
+						"UriValueType": "http://arcos.rack/SOFTWARE#FILE",
+						"ConnectBy": "compileInput",
+						"Connected": true,
+						"UriConnectBy": "http://arcos.rack/SOFTWARE#compileInput"
+					}
+				],
+				"NodeName": "COMPILE",
+				"fullURIName": "http://arcos.rack/SOFTWARE#COMPILE",
+				"subClassNames": [],
+				"SparqlID": "?COMPILE",
+				"isReturned": false,
+				"isRuntimeConstrained": false,
+				"valueConstraint": "",
+				"instanceValue": null,
+				"deletionMode": "NO_DELETE"
+			},
+			{
+				"propList": [
+					{
+						"KeyName": "filename",
+						"ValueType": "string",
+						"relationship": "http://www.w3.org/2001/XMLSchema#string",
+						"UriRelationship": "http://arcos.rack/SOFTWARE#filename",
+						"Constraints": "",
+						"fullURIName": "",
+						"SparqlID": "?output_file",
+						"isReturned": true,
+						"optMinus": 0,
+						"isRuntimeConstrained": false,
+						"instanceValues": [],
+						"isMarkedForDeletion": false
+					}
+				],
+				"nodeList": [
+					{
+						"SnodeSparqlIDs": [
+							"?COMPILE"
+						],
+						"OptionalMinus": [
+							0
+						],
+						"Qualifiers": [
+							""
+						],
+						"DeletionMarkers": [
+							false
+						],
+						"KeyName": "createBy",
+						"ValueType": "ACTIVITY",
+						"UriValueType": "http://arcos.rack/PROV-S#ACTIVITY",
+						"ConnectBy": "createBy",
+						"Connected": true,
+						"UriConnectBy": "http://arcos.rack/SOFTWARE#createBy"
+					}
+				],
+				"NodeName": "FILE",
+				"fullURIName": "http://arcos.rack/SOFTWARE#FILE",
+				"subClassNames": [],
+				"SparqlID": "?FILE",
+				"isReturned": false,
+				"isRuntimeConstrained": false,
+				"valueConstraint": "",
+				"instanceValue": null,
+				"deletionMode": "NO_DELETE"
+			}
+		],
+		"orderBy": []
+	},
+	"importSpec": {
+		"version": "1",
+		"baseURI": "",
+		"columns": [],
+		"dataValidator": [],
+		"texts": [],
+		"transforms": [],
+		"nodes": [
+			{
+				"sparqlID": "?FILE",
+				"type": "http://arcos.rack/SOFTWARE#FILE",
+				"mapping": [],
+				"props": []
+			},
+			{
+				"sparqlID": "?COMPILE",
+				"type": "http://arcos.rack/SOFTWARE#COMPILE",
+				"mapping": [],
+				"props": []
+			},
+			{
+				"sparqlID": "?FILE_0",
+				"type": "http://arcos.rack/SOFTWARE#FILE",
+				"mapping": [],
+				"props": []
+			}
+		]
+	}
+}

--- a/nodegroups/queries/query Control Flow From Function.json
+++ b/nodegroups/queries/query Control Flow From Function.json
@@ -1,0 +1,129 @@
+{
+	"version": 2,
+	"sparqlConn": {
+		"name": "RACK local fuseki",
+		"domain": "",
+		"enableOwlImports": true,
+		"model": [
+			{
+				"type": "fuseki",
+				"url": "http://localhost:3030/RACK",
+				"graph": "http://rack001/model"
+			}
+		],
+		"data": [
+			{
+				"type": "fuseki",
+				"url": "http://localhost:3030/RACK",
+				"graph": "http://rack001/data"
+			}
+		]
+	},
+	"sNodeGroup": {
+		"version": 11,
+		"limit": 0,
+		"offset": 0,
+		"sNodeList": [
+			{
+				"propList": [
+					{
+						"KeyName": "name",
+						"ValueType": "string",
+						"relationship": "http://www.w3.org/2001/XMLSchema#string",
+						"UriRelationship": "http://arcos.rack/SOFTWARE#name",
+						"Constraints": "",
+						"fullURIName": "",
+						"SparqlID": "?generatedAtTime",
+						"isReturned": true,
+						"optMinus": 0,
+						"isRuntimeConstrained": false,
+						"instanceValues": [],
+						"isMarkedForDeletion": false
+					}
+				],
+				"nodeList": [],
+				"NodeName": "COMPONENT",
+				"fullURIName": "http://arcos.rack/SOFTWARE#COMPONENT",
+				"subClassNames": [],
+				"SparqlID": "?COMPONENT_0",
+				"isReturned": false,
+				"isRuntimeConstrained": false,
+				"valueConstraint": "",
+				"instanceValue": null,
+				"deletionMode": "NO_DELETE"
+			},
+			{
+				"propList": [
+					{
+						"KeyName": "name",
+						"ValueType": "string",
+						"relationship": "http://www.w3.org/2001/XMLSchema#string",
+						"UriRelationship": "http://arcos.rack/SOFTWARE#name",
+						"Constraints": "",
+						"fullURIName": "",
+						"SparqlID": "?name",
+						"isReturned": true,
+						"optMinus": 0,
+						"isRuntimeConstrained": true,
+						"instanceValues": [],
+						"isMarkedForDeletion": false
+					}
+				],
+				"nodeList": [
+					{
+						"SnodeSparqlIDs": [
+							"?COMPONENT_0"
+						],
+						"OptionalMinus": [
+							0
+						],
+						"Qualifiers": [
+							""
+						],
+						"DeletionMarkers": [
+							false
+						],
+						"KeyName": "controlFlowsToUnconditionally",
+						"ValueType": "COMPONENT",
+						"UriValueType": "http://arcos.rack/SOFTWARE#COMPONENT",
+						"ConnectBy": "controlFlowsToUnconditionally",
+						"Connected": true,
+						"UriConnectBy": "http://arcos.rack/SOFTWARE#controlFlowsToUnconditionally"
+					}
+				],
+				"NodeName": "COMPONENT",
+				"fullURIName": "http://arcos.rack/SOFTWARE#COMPONENT",
+				"subClassNames": [],
+				"SparqlID": "?COMPONENT",
+				"isReturned": false,
+				"isRuntimeConstrained": false,
+				"valueConstraint": "",
+				"instanceValue": null,
+				"deletionMode": "NO_DELETE"
+			}
+		],
+		"orderBy": []
+	},
+	"importSpec": {
+		"version": "1",
+		"baseURI": "",
+		"columns": [],
+		"dataValidator": [],
+		"texts": [],
+		"transforms": [],
+		"nodes": [
+			{
+				"sparqlID": "?COMPONENT",
+				"type": "http://arcos.rack/SOFTWARE#COMPONENT",
+				"mapping": [],
+				"props": []
+			},
+			{
+				"sparqlID": "?COMPONENT_0",
+				"type": "http://arcos.rack/SOFTWARE#COMPONENT",
+				"mapping": [],
+				"props": []
+			}
+		]
+	}
+}

--- a/nodegroups/queries/query Files of a Given Format.json
+++ b/nodegroups/queries/query Files of a Given Format.json
@@ -1,0 +1,129 @@
+{
+	"version": 2,
+	"sparqlConn": {
+		"name": "RACK local fuseki",
+		"domain": "",
+		"enableOwlImports": true,
+		"model": [
+			{
+				"type": "fuseki",
+				"url": "http://localhost:3030/RACK",
+				"graph": "http://rack001/model"
+			}
+		],
+		"data": [
+			{
+				"type": "fuseki",
+				"url": "http://localhost:3030/RACK",
+				"graph": "http://rack001/data"
+			}
+		]
+	},
+	"sNodeGroup": {
+		"version": 11,
+		"limit": 0,
+		"offset": 0,
+		"sNodeList": [
+			{
+				"propList": [
+					{
+						"KeyName": "uniqueIdentifier",
+						"ValueType": "string",
+						"relationship": "http://www.w3.org/2001/XMLSchema#string",
+						"UriRelationship": "http://arcos.rack/PROV-S#uniqueIdentifier",
+						"Constraints": "",
+						"fullURIName": "",
+						"SparqlID": "?format",
+						"isReturned": true,
+						"optMinus": 0,
+						"isRuntimeConstrained": true,
+						"instanceValues": [],
+						"isMarkedForDeletion": false
+					}
+				],
+				"nodeList": [],
+				"NodeName": "FORMAT",
+				"fullURIName": "http://arcos.rack/SOFTWARE#FORMAT",
+				"subClassNames": [],
+				"SparqlID": "?FORMAT",
+				"isReturned": false,
+				"isRuntimeConstrained": false,
+				"valueConstraint": "",
+				"instanceValue": null,
+				"deletionMode": "NO_DELETE"
+			},
+			{
+				"propList": [
+					{
+						"KeyName": "filename",
+						"ValueType": "string",
+						"relationship": "http://www.w3.org/2001/XMLSchema#string",
+						"UriRelationship": "http://arcos.rack/SOFTWARE#filename",
+						"Constraints": "",
+						"fullURIName": "",
+						"SparqlID": "?filename",
+						"isReturned": true,
+						"optMinus": 0,
+						"isRuntimeConstrained": false,
+						"instanceValues": [],
+						"isMarkedForDeletion": false
+					}
+				],
+				"nodeList": [
+					{
+						"SnodeSparqlIDs": [
+							"?FORMAT"
+						],
+						"OptionalMinus": [
+							0
+						],
+						"Qualifiers": [
+							""
+						],
+						"DeletionMarkers": [
+							false
+						],
+						"KeyName": "fileFormat",
+						"ValueType": "FORMAT",
+						"UriValueType": "http://arcos.rack/SOFTWARE#FORMAT",
+						"ConnectBy": "fileFormat",
+						"Connected": true,
+						"UriConnectBy": "http://arcos.rack/SOFTWARE#fileFormat"
+					}
+				],
+				"NodeName": "FILE",
+				"fullURIName": "http://arcos.rack/SOFTWARE#FILE",
+				"subClassNames": [],
+				"SparqlID": "?FILE",
+				"isReturned": false,
+				"isRuntimeConstrained": false,
+				"valueConstraint": "",
+				"instanceValue": null,
+				"deletionMode": "NO_DELETE"
+			}
+		],
+		"orderBy": []
+	},
+	"importSpec": {
+		"version": "1",
+		"baseURI": "",
+		"columns": [],
+		"dataValidator": [],
+		"texts": [],
+		"transforms": [],
+		"nodes": [
+			{
+				"sparqlID": "?FILE",
+				"type": "http://arcos.rack/SOFTWARE#FILE",
+				"mapping": [],
+				"props": []
+			},
+			{
+				"sparqlID": "?FORMAT",
+				"type": "http://arcos.rack/SOFTWARE#FORMAT",
+				"mapping": [],
+				"props": []
+			}
+		]
+	}
+}


### PR DESCRIPTION
Fixes #68. After merge, we can add the following descriptions to the wiki for #67.
 
`Compilation Inputs.json`:

This query shows the inputs used in the compilation of the various executables,
shared libraries, etc. in the Turnstile example.

`Control Flow From Function.json`:

This query takes a runtime-specified function name, and shows the functions that
are called by the specified function. Try it out by entering "main" as the
function name.

`Files of a Given Format.json`:

This query takes a runtime-specified format name, and shows all the files of
that format involved in the Turnstile project. Try it out with different values
like `FORMAT-ElfFile`, `FORMAT-ZipFile`, and `FORMAT-CSourceFile`.