### PR TITLE
Rename CLASS to CLASS_DEFINITION for disambiguation.

### DIFF
--- a/RACK-Ontology/ontology/SOFTWARE.sadl
+++ b/RACK-Ontology/ontology/SOFTWARE.sadl
@@ -92,7 +92,7 @@ BINARY_BASIC_BLOCK
     (note "A basic block at the binary level.")
     is a COMPONENT_TYPE
     has uniqueIdentifier "BINARY_BASIC_BLOCK".
-CLASS
+CLASS_DEFINITION
     (note "A class in an object-oriented language.")
     is a COMPONENT_TYPE
     has uniqueIdentifier "CLASS".


### PR DESCRIPTION
Since "Class" is a pretty generic term, this simply makes it a little more unique to disambiguate intentional uses of this entity from generic uses of the term.