### PR TITLE
Adds identified explicit property name for wasGeneratedBy of HAZARD.

### DIFF
--- a/RACK-Ontology/OwlModels/HAZARD.owl
+++ b/RACK-Ontology/OwlModels/HAZARD.owl
@@ -24,6 +24,12 @@
     <rdfs:comment xml:lang="en">ACTIVITY that identifies potential sources of HAZARD whose risk must be evaluated</rdfs:comment>
     <rdfs:subClassOf rdf:resource="PROV-S#ACTIVITY"/>
   </owl:Class>
+  <owl:ObjectProperty rdf:ID="identified">
+    <rdfs:subPropertyOf rdf:resource="PROV-S#wasGeneratedBy"/>
+    <rdfs:comment xml:lang="en">how this HAZARD was identified</rdfs:comment>
+    <rdfs:range rdf:resource="#HAZARD_IDENTIFICATION"/>
+    <rdfs:domain rdf:resource="#HAZARD"/>
+  </owl:ObjectProperty>
   <owl:ObjectProperty rdf:ID="author">
     <rdfs:subPropertyOf rdf:resource="PROV-S#wasAssociatedWith"/>
     <rdfs:comment xml:lang="en">AGENT(s) who work on this ACTIVITY</rdfs:comment>

--- a/RACK-Ontology/ontology/HAZARD.sadl
+++ b/RACK-Ontology/ontology/HAZARD.sadl
@@ -10,6 +10,9 @@ HAZARD
 	source (note "ENTITY(s) that participate in causing this HAZARD") describes HAZARD with values of type ENTITY.
 	source is a type of wasDerivedFrom.
 
+   identified (note "how this HAZARD was identified") describes HAZARD with values of type HAZARD_IDENTIFICATION.
+   identified is a type of wasGeneratedBy.
+
 HAZARD_IDENTIFICATION
 	(note "ACTIVITY that identifies potential sources of HAZARD whose risk must be evaluated")
 	is a type of ACTIVITY.


### PR DESCRIPTION
Similar to other property renamings, this clarifies the connection
between HAZARD and HAZARD_IDENTIFICATION by providing an explicit
naming for this relationship.