### PR TITLE
Linting with Github Actions

### DIFF
--- a/.github/workflows/rack.yaml
+++ b/.github/workflows/rack.yaml
@@ -1,0 +1,40 @@
+name: Build
+on: [push]
+
+jobs:
+  lint:
+    name: Lint shell scripts and the RACK CLI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Lint shell scripts with ShellCheck
+        uses: ludeeus/action-shellcheck@master
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Cache RACK CLI development dependencies
+        uses: actions/cache@v2
+        with:
+          # This path is specific to Ubuntu
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('RACK-Ontology/cli/dev/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+            ${{ runner.os }}-
+
+      - name: Install development dependencies
+        run: |
+          pip install \
+            --quiet \
+            --requirement RACK-Ontology/cli/dev/requirements.txt
+
+      - shell: bash
+        name: Lint the RACK CLI
+        run: |
+          cd RACK-Ontology/cli
+          pylint .
+          mypy .

--- a/RACK-Ontology/cli/.pylintrc
+++ b/RACK-Ontology/cli/.pylintrc
@@ -1,0 +1,54 @@
+[MASTER]
+
+ignore=.git
+jobs=0
+suggestion-mode=yes
+
+[MESSAGES CONTROL]
+
+disable=all
+enable=bad-format-character,
+       bad-format-string-key,
+       bad-open-mode,
+       bad-string-format-type,
+       consider-using-get,
+       consider-using-join,
+       empty-docstring,
+       function-redefined,
+       not-in-loop,
+       redefined-builtin,
+       return-in-init,
+       too-few-format-args,
+       too-many-format-args,
+       truncated-format-string,
+       unnecessary-comprehension,
+       unused-argument,
+       unreachable,
+       unused-format-string-argument,
+       unused-format-string-key,
+       unused-import,
+       unused-variable,
+       using-constant-test
+
+[REPORTS]
+
+output-format=text
+reports=no
+score=no
+
+[BASIC]
+
+argument-naming-style=snake_case
+attr-naming-style=snake_case
+class-naming-style=PascalCase
+const-naming-style=UPPER_CASE
+function-naming-style=snake_case
+include-naming-hint=yes
+inlinevar-naming-style=snake_case
+method-naming-style=snake_case
+module-naming-style=snake_case
+variable-naming-style=snake_case
+
+[VARIABLES]
+
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io

--- a/RACK-Ontology/cli/dev/requirements.txt
+++ b/RACK-Ontology/cli/dev/requirements.txt
@@ -1,3 +1,4 @@
 mypy==0.782
+pylint==2.6.0
 pytest==6.0
 pytest-docker==0.8


### PR DESCRIPTION
This adds a "linting" CI job that runs a few tools:

- [ShellCheck](https://www.shellcheck.net/) on all the shell scripts
- [Mypy](http://mypy-lang.org/) on the RACK CLI
- [pylint](https://pylint.org/) on the RACK CLI

I've been developing this in parallel with my work on #104, but it happened to be ready sooner, so I figured I'd split it off as a separate PR.