### PR TITLE
Make various document types subtypes of collection, use content directly

### DIFF
--- a/RACK-Ontology/OwlModels/ARP-4754A.owl
+++ b/RACK-Ontology/OwlModels/ARP-4754A.owl
@@ -22,221 +22,221 @@
     <rdfs:comment xml:lang="en">This ontology was created from a SADL file 'ARP-4754A.sadl' and should not be directly edited.</rdfs:comment>
   </owl:Ontology>
   <j.1:SPECIFICATION rdf:ID="ARP-4754A">
-    <j.1:content>
+    <j.2:content>
       <j.1:SECTION rdf:ID="ARP-4754A-AppendixA">
-        <j.1:content>
-          <j.0:OBJECTIVE rdf:ID="ARP-4775-4.6">
-            <j.0:description>Validation compliance substantiation is provided.</j.0:description>
-            <j.2:uniqueIdentifier>ARP-4775-4.6</j.2:uniqueIdentifier>
-          </j.0:OBJECTIVE>
-        </j.1:content>
-        <j.1:content>
-          <j.0:OBJECTIVE rdf:ID="ARP-4778-5.3">
-            <j.0:description>Product implementation complies with aircraft, and system requirements.</j.0:description>
-            <j.2:uniqueIdentifier>ARP-4778-5.3</j.2:uniqueIdentifier>
-          </j.0:OBJECTIVE>
-        </j.1:content>
-        <j.1:content>
-          <j.0:OBJECTIVE rdf:ID="ARP-4779-5.4">
-            <j.0:description>Safety requirements are verified.</j.0:description>
-            <j.2:uniqueIdentifier>ARP-4779-5.4</j.2:uniqueIdentifier>
-          </j.0:OBJECTIVE>
-        </j.1:content>
-        <j.1:content>
-          <j.0:OBJECTIVE rdf:ID="ARP-4764-3.2">
-            <j.0:description>The preliminary aircraft safety assessment is performed.</j.0:description>
-            <j.2:uniqueIdentifier>ARP-4764-3.2</j.2:uniqueIdentifier>
-          </j.0:OBJECTIVE>
-        </j.1:content>
-        <j.1:content>
-          <j.0:OBJECTIVE rdf:ID="ARP-4774-4.5">
-            <j.0:description></j.0:description>
-            <j.2:uniqueIdentifier>ARP-4774-4.5</j.2:uniqueIdentifier>
-          </j.0:OBJECTIVE>
-        </j.1:content>
-        <j.1:content>
-          <j.0:OBJECTIVE rdf:ID="ARP-4780-5.5">
-            <j.0:description>Verification compliance substantiation is included.</j.0:description>
-            <j.2:uniqueIdentifier>ARP-4780-5.5</j.2:uniqueIdentifier>
-          </j.0:OBJECTIVE>
-        </j.1:content>
-        <j.1:content>
-          <j.0:OBJECTIVE rdf:ID="ARP-4758-2.3">
-            <j.0:description>System requirements including assumptions and system interfaces are defined.</j.0:description>
-            <j.2:uniqueIdentifier>ARP-4758-2.3</j.2:uniqueIdentifier>
-          </j.0:OBJECTIVE>
-        </j.1:content>
-        <j.1:content>
-          <j.0:OBJECTIVE rdf:ID="ARP-4763-3.1">
-            <j.0:description>The aircraft/system functional hazard assessment is performed.</j.0:description>
-            <j.2:uniqueIdentifier>ARP-4763-3.1</j.2:uniqueIdentifier>
-          </j.0:OBJECTIVE>
-        </j.1:content>
-        <j.1:content>
-          <j.0:OBJECTIVE rdf:ID="ARP-4754-1.1">
-            <j.0:description>System development and integral process activities are defined</j.0:description>
-            <j.2:uniqueIdentifier>ARP-4754-1.1</j.2:uniqueIdentifier>
-          </j.0:OBJECTIVE>
-        </j.1:content>
-        <j.1:content>
-          <j.0:OBJECTIVE rdf:ID="ARP-4783-6.2">
-            <j.0:description>Configuration baseline and derivatives are established.</j.0:description>
-            <j.2:uniqueIdentifier>ARP-4783-6.2</j.2:uniqueIdentifier>
-          </j.0:OBJECTIVE>
-        </j.1:content>
-        <j.1:content>
-          <j.0:OBJECTIVE rdf:ID="ARP-4757-2.2">
-            <j.0:description>Aircraft functions are allocated to systems</j.0:description>
-            <j.2:uniqueIdentifier>ARP-4757-2.2</j.2:uniqueIdentifier>
-          </j.0:OBJECTIVE>
-        </j.1:content>
-        <j.1:content>
-          <j.0:OBJECTIVE rdf:ID="ARP-4785-6.4">
-            <j.0:description>Archive and retrieval are established.</j.0:description>
-            <j.2:uniqueIdentifier>ARP-4785-6.4</j.2:uniqueIdentifier>
-          </j.0:OBJECTIVE>
-        </j.1:content>
-        <j.1:content>
-          <j.0:OBJECTIVE rdf:ID="ARP-4759-2.4">
-            <j.0:description>System derived requirements (including derived safety-related requirements) are defined and rationale explained</j.0:description>
-            <j.2:uniqueIdentifier>ARP-4759-2.4</j.2:uniqueIdentifier>
-          </j.0:OBJECTIVE>
-        </j.1:content>
-        <j.1:content>
-          <j.0:OBJECTIVE rdf:ID="ARP-4788-8.1">
-            <j.0:description>Compliance substantiation is provided.</j.0:description>
-            <j.2:uniqueIdentifier>ARP-4788-8.1</j.2:uniqueIdentifier>
-          </j.0:OBJECTIVE>
-        </j.1:content>
-        <j.1:content>
-          <j.0:OBJECTIVE rdf:ID="ARP-4761-2.6">
-            <j.0:description>System requirements are allocated to items.</j.0:description>
-            <j.2:uniqueIdentifier>ARP-4761-2.6</j.2:uniqueIdentifier>
-          </j.0:OBJECTIVE>
-        </j.1:content>
-        <j.1:content>
-          <j.0:OBJECTIVE rdf:ID="ARP-4765-3.3">
-            <j.0:description>The preliminary system safety assessment is performed.</j.0:description>
-            <j.2:uniqueIdentifier>ARP-4765-3.3</j.2:uniqueIdentifier>
-          </j.0:OBJECTIVE>
-        </j.1:content>
-        <j.1:content>
-          <j.0:OBJECTIVE rdf:ID="ARP-4760-2.5">
-            <j.0:description>System architecture is defined.</j.0:description>
-            <j.2:uniqueIdentifier>ARP-4760-2.5</j.2:uniqueIdentifier>
-          </j.0:OBJECTIVE>
-        </j.1:content>
-        <j.1:content>
-          <j.0:OBJECTIVE rdf:ID="ARP-4768-3.6">
-            <j.0:description>The system safety assessment is performed.</j.0:description>
-            <j.2:uniqueIdentifier>ARP-4768-3.6</j.2:uniqueIdentifier>
-          </j.0:OBJECTIVE>
-        </j.1:content>
-        <j.1:content>
-          <j.0:OBJECTIVE rdf:ID="ARP-4755-1.2">
-            <j.0:description>Transition criteria and inter-relationship among processes are defined</j.0:description>
-            <j.2:uniqueIdentifier>ARP-4755-1.2</j.2:uniqueIdentifier>
-          </j.0:OBJECTIVE>
-        </j.1:content>
-        <j.1:content>
-          <j.0:OBJECTIVE rdf:ID="ARP-4784-6.3">
-            <j.0:description>Problem reporting , change control, change review, and configuration status accounting are established.</j.0:description>
-            <j.2:uniqueIdentifier>ARP-4784-6.3</j.2:uniqueIdentifier>
-          </j.0:OBJECTIVE>
-        </j.1:content>
-        <j.1:content>
-          <j.0:OBJECTIVE rdf:ID="ARP-4770-4.1">
-            <j.0:description>Aircraft, system, items requirements are complete and correct.</j.0:description>
-            <j.2:uniqueIdentifier>ARP-4770-4.1</j.2:uniqueIdentifier>
-          </j.0:OBJECTIVE>
-        </j.1:content>
-        <j.1:content>
-          <j.0:OBJECTIVE rdf:ID="ARP-4769-3.7">
-            <j.0:description>Independence requirements in functions, systems and items are captured.</j.0:description>
-            <j.2:uniqueIdentifier>ARP-4769-3.7</j.2:uniqueIdentifier>
-          </j.0:OBJECTIVE>
-        </j.1:content>
-        <j.1:content>
-          <j.0:OBJECTIVE rdf:ID="ARP-4771-4.2">
-            <j.0:description>Assumptions are justified and validated.</j.0:description>
-            <j.2:uniqueIdentifier>ARP-4771-4.2</j.2:uniqueIdentifier>
-          </j.0:OBJECTIVE>
-        </j.1:content>
-        <j.1:content>
-          <j.0:OBJECTIVE rdf:ID="ARP-4767-3.5">
-            <j.0:description>The aircraft safety assessment is performed.</j.0:description>
-            <j.2:uniqueIdentifier>ARP-4767-3.5</j.2:uniqueIdentifier>
-          </j.0:OBJECTIVE>
-        </j.1:content>
-        <j.1:content>
-          <j.0:OBJECTIVE rdf:ID="ARP-4772-4.3">
-            <j.0:description>Derived requirements are justified and validated.</j.0:description>
-            <j.2:uniqueIdentifier>ARP-4772-4.3</j.2:uniqueIdentifier>
-          </j.0:OBJECTIVE>
-        </j.1:content>
-        <j.1:content>
-          <j.0:OBJECTIVE rdf:ID="ARP-4782-6.1">
-            <j.0:description>Configuration items are identified</j.0:description>
-            <j.2:uniqueIdentifier>ARP-4782-6.1</j.2:uniqueIdentifier>
-          </j.0:OBJECTIVE>
-        </j.1:content>
-        <j.1:content>
-          <j.0:OBJECTIVE rdf:ID="ARP-4777-5.2">
-            <j.0:description>Verification demonstrates intended function and confidence of no unintended function impacts to safety.</j.0:description>
-            <j.2:uniqueIdentifier>ARP-4777-5.2</j.2:uniqueIdentifier>
-          </j.0:OBJECTIVE>
-        </j.1:content>
-        <j.1:content>
-          <j.0:OBJECTIVE rdf:ID="ARP-4787-7.2">
-            <j.0:description>Development activities and processes are conducted in accordance with those plans.</j.0:description>
-            <j.2:uniqueIdentifier>ARP-4787-7.2</j.2:uniqueIdentifier>
-          </j.0:OBJECTIVE>
-        </j.1:content>
-        <j.1:content>
+        <j.2:content>
           <j.0:OBJECTIVE rdf:ID="ARP-4786-7.1">
             <j.0:description>Assurance is obtained that necessary plans are developed and maintained for all aspects of system certification.</j.0:description>
             <j.2:uniqueIdentifier>ARP-4786-7.1</j.2:uniqueIdentifier>
           </j.0:OBJECTIVE>
-        </j.1:content>
-        <j.1:content>
-          <j.0:OBJECTIVE rdf:ID="ARP-4766-3.4">
-            <j.0:description>The common cause analyses are performed.</j.0:description>
-            <j.2:uniqueIdentifier>ARP-4766-3.4</j.2:uniqueIdentifier>
-          </j.0:OBJECTIVE>
-        </j.1:content>
-        <j.1:content>
-          <j.0:OBJECTIVE rdf:ID="ARP-4773-4.4">
-            <j.0:description>Requirements are traceable.</j.0:description>
-            <j.2:uniqueIdentifier>ARP-4773-4.4</j.2:uniqueIdentifier>
-          </j.0:OBJECTIVE>
-        </j.1:content>
-        <j.1:content>
-          <j.0:OBJECTIVE rdf:ID="ARP-4776-5.1">
-            <j.0:description>Test or demonstration procedures are correct.</j.0:description>
-            <j.2:uniqueIdentifier>ARP-4776-5.1</j.2:uniqueIdentifier>
-          </j.0:OBJECTIVE>
-        </j.1:content>
-        <j.1:content>
-          <j.0:OBJECTIVE rdf:ID="ARP-4762-2.7">
-            <j.0:description>Appropriate item, system and aircraft integrations are performed.</j.0:description>
-            <j.2:uniqueIdentifier>ARP-4762-2.7</j.2:uniqueIdentifier>
-          </j.0:OBJECTIVE>
-        </j.1:content>
-        <j.1:title>PROCESS OBJECTIVES DATA</j.1:title>
-        <j.1:content>
-          <j.0:OBJECTIVE rdf:ID="ARP-4781-5.6">
-            <j.0:description>Assessment of deficiencies and their related impact on safety is identified.</j.0:description>
-            <j.2:uniqueIdentifier>ARP-4781-5.6</j.2:uniqueIdentifier>
-          </j.0:OBJECTIVE>
-        </j.1:content>
-        <j.1:content>
+        </j.2:content>
+        <j.2:content>
           <j.0:OBJECTIVE rdf:ID="ARP-4756-2.1">
             <j.0:description>Aircraft-level functions, functional requirements, functional interfaces and assumptions are defined</j.0:description>
             <j.2:uniqueIdentifier>ARP-4756-2.1</j.2:uniqueIdentifier>
           </j.0:OBJECTIVE>
-        </j.1:content>
+        </j.2:content>
+        <j.2:content>
+          <j.0:OBJECTIVE rdf:ID="ARP-4754-1.1">
+            <j.0:description>System development and integral process activities are defined</j.0:description>
+            <j.2:uniqueIdentifier>ARP-4754-1.1</j.2:uniqueIdentifier>
+          </j.0:OBJECTIVE>
+        </j.2:content>
+        <j.2:content>
+          <j.0:OBJECTIVE rdf:ID="ARP-4787-7.2">
+            <j.0:description>Development activities and processes are conducted in accordance with those plans.</j.0:description>
+            <j.2:uniqueIdentifier>ARP-4787-7.2</j.2:uniqueIdentifier>
+          </j.0:OBJECTIVE>
+        </j.2:content>
+        <j.2:content>
+          <j.0:OBJECTIVE rdf:ID="ARP-4776-5.1">
+            <j.0:description>Test or demonstration procedures are correct.</j.0:description>
+            <j.2:uniqueIdentifier>ARP-4776-5.1</j.2:uniqueIdentifier>
+          </j.0:OBJECTIVE>
+        </j.2:content>
+        <j.2:content>
+          <j.0:OBJECTIVE rdf:ID="ARP-4769-3.7">
+            <j.0:description>Independence requirements in functions, systems and items are captured.</j.0:description>
+            <j.2:uniqueIdentifier>ARP-4769-3.7</j.2:uniqueIdentifier>
+          </j.0:OBJECTIVE>
+        </j.2:content>
+        <j.2:content>
+          <j.0:OBJECTIVE rdf:ID="ARP-4768-3.6">
+            <j.0:description>The system safety assessment is performed.</j.0:description>
+            <j.2:uniqueIdentifier>ARP-4768-3.6</j.2:uniqueIdentifier>
+          </j.0:OBJECTIVE>
+        </j.2:content>
+        <j.2:content>
+          <j.0:OBJECTIVE rdf:ID="ARP-4766-3.4">
+            <j.0:description>The common cause analyses are performed.</j.0:description>
+            <j.2:uniqueIdentifier>ARP-4766-3.4</j.2:uniqueIdentifier>
+          </j.0:OBJECTIVE>
+        </j.2:content>
+        <j.2:content>
+          <j.0:OBJECTIVE rdf:ID="ARP-4781-5.6">
+            <j.0:description>Assessment of deficiencies and their related impact on safety is identified.</j.0:description>
+            <j.2:uniqueIdentifier>ARP-4781-5.6</j.2:uniqueIdentifier>
+          </j.0:OBJECTIVE>
+        </j.2:content>
+        <j.2:content>
+          <j.0:OBJECTIVE rdf:ID="ARP-4788-8.1">
+            <j.0:description>Compliance substantiation is provided.</j.0:description>
+            <j.2:uniqueIdentifier>ARP-4788-8.1</j.2:uniqueIdentifier>
+          </j.0:OBJECTIVE>
+        </j.2:content>
+        <j.2:content>
+          <j.0:OBJECTIVE rdf:ID="ARP-4767-3.5">
+            <j.0:description>The aircraft safety assessment is performed.</j.0:description>
+            <j.2:uniqueIdentifier>ARP-4767-3.5</j.2:uniqueIdentifier>
+          </j.0:OBJECTIVE>
+        </j.2:content>
+        <j.2:content>
+          <j.0:OBJECTIVE rdf:ID="ARP-4759-2.4">
+            <j.0:description>System derived requirements (including derived safety-related requirements) are defined and rationale explained</j.0:description>
+            <j.2:uniqueIdentifier>ARP-4759-2.4</j.2:uniqueIdentifier>
+          </j.0:OBJECTIVE>
+        </j.2:content>
+        <j.2:content>
+          <j.0:OBJECTIVE rdf:ID="ARP-4780-5.5">
+            <j.0:description>Verification compliance substantiation is included.</j.0:description>
+            <j.2:uniqueIdentifier>ARP-4780-5.5</j.2:uniqueIdentifier>
+          </j.0:OBJECTIVE>
+        </j.2:content>
+        <j.2:content>
+          <j.0:OBJECTIVE rdf:ID="ARP-4758-2.3">
+            <j.0:description>System requirements including assumptions and system interfaces are defined.</j.0:description>
+            <j.2:uniqueIdentifier>ARP-4758-2.3</j.2:uniqueIdentifier>
+          </j.0:OBJECTIVE>
+        </j.2:content>
+        <j.2:content>
+          <j.0:OBJECTIVE rdf:ID="ARP-4762-2.7">
+            <j.0:description>Appropriate item, system and aircraft integrations are performed.</j.0:description>
+            <j.2:uniqueIdentifier>ARP-4762-2.7</j.2:uniqueIdentifier>
+          </j.0:OBJECTIVE>
+        </j.2:content>
+        <j.2:content>
+          <j.0:OBJECTIVE rdf:ID="ARP-4772-4.3">
+            <j.0:description>Derived requirements are justified and validated.</j.0:description>
+            <j.2:uniqueIdentifier>ARP-4772-4.3</j.2:uniqueIdentifier>
+          </j.0:OBJECTIVE>
+        </j.2:content>
+        <j.2:content>
+          <j.0:OBJECTIVE rdf:ID="ARP-4783-6.2">
+            <j.0:description>Configuration baseline and derivatives are established.</j.0:description>
+            <j.2:uniqueIdentifier>ARP-4783-6.2</j.2:uniqueIdentifier>
+          </j.0:OBJECTIVE>
+        </j.2:content>
+        <j.2:content>
+          <j.0:OBJECTIVE rdf:ID="ARP-4775-4.6">
+            <j.0:description>Validation compliance substantiation is provided.</j.0:description>
+            <j.2:uniqueIdentifier>ARP-4775-4.6</j.2:uniqueIdentifier>
+          </j.0:OBJECTIVE>
+        </j.2:content>
+        <j.2:content>
+          <j.0:OBJECTIVE rdf:ID="ARP-4773-4.4">
+            <j.0:description>Requirements are traceable.</j.0:description>
+            <j.2:uniqueIdentifier>ARP-4773-4.4</j.2:uniqueIdentifier>
+          </j.0:OBJECTIVE>
+        </j.2:content>
+        <j.2:content>
+          <j.0:OBJECTIVE rdf:ID="ARP-4784-6.3">
+            <j.0:description>Problem reporting , change control, change review, and configuration status accounting are established.</j.0:description>
+            <j.2:uniqueIdentifier>ARP-4784-6.3</j.2:uniqueIdentifier>
+          </j.0:OBJECTIVE>
+        </j.2:content>
+        <j.2:content>
+          <j.0:OBJECTIVE rdf:ID="ARP-4779-5.4">
+            <j.0:description>Safety requirements are verified.</j.0:description>
+            <j.2:uniqueIdentifier>ARP-4779-5.4</j.2:uniqueIdentifier>
+          </j.0:OBJECTIVE>
+        </j.2:content>
+        <j.2:content>
+          <j.0:OBJECTIVE rdf:ID="ARP-4757-2.2">
+            <j.0:description>Aircraft functions are allocated to systems</j.0:description>
+            <j.2:uniqueIdentifier>ARP-4757-2.2</j.2:uniqueIdentifier>
+          </j.0:OBJECTIVE>
+        </j.2:content>
+        <j.2:content>
+          <j.0:OBJECTIVE rdf:ID="ARP-4761-2.6">
+            <j.0:description>System requirements are allocated to items.</j.0:description>
+            <j.2:uniqueIdentifier>ARP-4761-2.6</j.2:uniqueIdentifier>
+          </j.0:OBJECTIVE>
+        </j.2:content>
+        <j.2:content>
+          <j.0:OBJECTIVE rdf:ID="ARP-4774-4.5">
+            <j.0:description></j.0:description>
+            <j.2:uniqueIdentifier>ARP-4774-4.5</j.2:uniqueIdentifier>
+          </j.0:OBJECTIVE>
+        </j.2:content>
+        <j.2:content>
+          <j.0:OBJECTIVE rdf:ID="ARP-4785-6.4">
+            <j.0:description>Archive and retrieval are established.</j.0:description>
+            <j.2:uniqueIdentifier>ARP-4785-6.4</j.2:uniqueIdentifier>
+          </j.0:OBJECTIVE>
+        </j.2:content>
+        <j.2:content>
+          <j.0:OBJECTIVE rdf:ID="ARP-4782-6.1">
+            <j.0:description>Configuration items are identified</j.0:description>
+            <j.2:uniqueIdentifier>ARP-4782-6.1</j.2:uniqueIdentifier>
+          </j.0:OBJECTIVE>
+        </j.2:content>
+        <j.2:content>
+          <j.0:OBJECTIVE rdf:ID="ARP-4771-4.2">
+            <j.0:description>Assumptions are justified and validated.</j.0:description>
+            <j.2:uniqueIdentifier>ARP-4771-4.2</j.2:uniqueIdentifier>
+          </j.0:OBJECTIVE>
+        </j.2:content>
+        <j.2:content>
+          <j.0:OBJECTIVE rdf:ID="ARP-4778-5.3">
+            <j.0:description>Product implementation complies with aircraft, and system requirements.</j.0:description>
+            <j.2:uniqueIdentifier>ARP-4778-5.3</j.2:uniqueIdentifier>
+          </j.0:OBJECTIVE>
+        </j.2:content>
+        <j.2:content>
+          <j.0:OBJECTIVE rdf:ID="ARP-4777-5.2">
+            <j.0:description>Verification demonstrates intended function and confidence of no unintended function impacts to safety.</j.0:description>
+            <j.2:uniqueIdentifier>ARP-4777-5.2</j.2:uniqueIdentifier>
+          </j.0:OBJECTIVE>
+        </j.2:content>
+        <j.2:content>
+          <j.0:OBJECTIVE rdf:ID="ARP-4765-3.3">
+            <j.0:description>The preliminary system safety assessment is performed.</j.0:description>
+            <j.2:uniqueIdentifier>ARP-4765-3.3</j.2:uniqueIdentifier>
+          </j.0:OBJECTIVE>
+        </j.2:content>
+        <j.2:content>
+          <j.0:OBJECTIVE rdf:ID="ARP-4770-4.1">
+            <j.0:description>Aircraft, system, items requirements are complete and correct.</j.0:description>
+            <j.2:uniqueIdentifier>ARP-4770-4.1</j.2:uniqueIdentifier>
+          </j.0:OBJECTIVE>
+        </j.2:content>
+        <j.2:content>
+          <j.0:OBJECTIVE rdf:ID="ARP-4755-1.2">
+            <j.0:description>Transition criteria and inter-relationship among processes are defined</j.0:description>
+            <j.2:uniqueIdentifier>ARP-4755-1.2</j.2:uniqueIdentifier>
+          </j.0:OBJECTIVE>
+        </j.2:content>
+        <j.1:title>PROCESS OBJECTIVES DATA</j.1:title>
+        <j.2:content>
+          <j.0:OBJECTIVE rdf:ID="ARP-4764-3.2">
+            <j.0:description>The preliminary aircraft safety assessment is performed.</j.0:description>
+            <j.2:uniqueIdentifier>ARP-4764-3.2</j.2:uniqueIdentifier>
+          </j.0:OBJECTIVE>
+        </j.2:content>
+        <j.2:content>
+          <j.0:OBJECTIVE rdf:ID="ARP-4760-2.5">
+            <j.0:description>System architecture is defined.</j.0:description>
+            <j.2:uniqueIdentifier>ARP-4760-2.5</j.2:uniqueIdentifier>
+          </j.0:OBJECTIVE>
+        </j.2:content>
+        <j.2:content>
+          <j.0:OBJECTIVE rdf:ID="ARP-4763-3.1">
+            <j.0:description>The aircraft/system functional hazard assessment is performed.</j.0:description>
+            <j.2:uniqueIdentifier>ARP-4763-3.1</j.2:uniqueIdentifier>
+          </j.0:OBJECTIVE>
+        </j.2:content>
       </j.1:SECTION>
-    </j.1:content>
+    </j.2:content>
     <j.1:approvalAuthority>
       <j.2:AGENT rdf:ID="SAE"/>
     </j.1:approvalAuthority>

--- a/RACK-Ontology/OwlModels/DO-178C.owl
+++ b/RACK-Ontology/OwlModels/DO-178C.owl
@@ -22,487 +22,487 @@
     <rdfs:comment xml:lang="en">This ontology was created from a SADL file 'DO-178C.sadl' and should not be directly edited.</rdfs:comment>
   </owl:Ontology>
   <j.1:SPECIFICATION rdf:ID="DO-178C">
-    <j.1:content>
+    <j.2:content>
       <j.1:SECTION rdf:ID="DO-178C-AnnexA">
-        <j.1:content>
-          <j.1:SECTION rdf:ID="A-6">
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-6-5">
-                <j.0:description>Executable Object Code is compatible with target computer. </j.0:description>
-                <j.2:uniqueIdentifier>A-6-5</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-6-4">
-                <j.0:description>Executable Object Code is robust with low-level requirements. </j.0:description>
-                <j.2:uniqueIdentifier>A-6-4</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-6-3">
-                <j.0:description>Executable Object Code complies with low-level requirements. </j.0:description>
-                <j.2:uniqueIdentifier>A-6-3</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-6-2">
-                <j.0:description>Executable Object Code is robust with high-level requirements. </j.0:description>
-                <j.2:uniqueIdentifier>A-6-2</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-6-1">
-                <j.0:description>Executable Object Code complies with high-level requirements. </j.0:description>
-                <j.2:uniqueIdentifier>A-6-1</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:title>Verification of Outputs of Integration Process</j.1:title>
-          </j.1:SECTION>
-        </j.1:content>
-        <j.1:content>
-          <j.1:SECTION rdf:ID="A-10">
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-10-3">
-                <j.0:description>Compliance substantiation is provided. </j.0:description>
-                <j.2:uniqueIdentifier>A-10-3</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-10-2">
-                <j.0:description>The means of compliance is proposed and agreement with the Plan for Software Aspects of Certification is obtained. </j.0:description>
-                <j.2:uniqueIdentifier>A-10-2</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-10-1">
-                <j.0:description>Communication and understanding between the applicant and the certification authority is established. </j.0:description>
-                <j.2:uniqueIdentifier>A-10-1</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:title>Certification Liaison Process</j.1:title>
-          </j.1:SECTION>
-        </j.1:content>
-        <j.1:title>PROCESS OBJECTIVES AND OUTPUTS BY SOFTWARE LEVEL</j.1:title>
-        <j.1:content>
-          <j.1:SECTION rdf:ID="A-7">
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-7-6">
-                <j.0:description>Test coverage of software structure (decision coverage) is achieved. </j.0:description>
-                <j.2:uniqueIdentifier>A-7-6</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-7-2">
-                <j.0:description>Test results are correct and discrepancies explained. </j.0:description>
-                <j.2:uniqueIdentifier>A-7-2</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:title>Verification of Verification Process Results</j.1:title>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-7-5">
-                <j.0:description>Test coverage of software structure (modified condition/decision coverage) is achieved. </j.0:description>
-                <j.2:uniqueIdentifier>A-7-5</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-7-8">
-                <j.0:description>Test coverage of software structure (data coupling and control coupling) is achieved. </j.0:description>
-                <j.2:uniqueIdentifier>A-7-8</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-7-1">
-                <j.0:description>Test procedures are correct. </j.0:description>
-                <j.2:uniqueIdentifier>A-7-1</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-7-4">
-                <j.0:description>Test coverage of low-level requirements is achieved. </j.0:description>
-                <j.2:uniqueIdentifier>A-7-4</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-7-7">
-                <j.0:description>Test coverage of software structure (statement coverage) is achieved. </j.0:description>
-                <j.2:uniqueIdentifier>A-7-7</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-7-3">
-                <j.0:description>Test coverage of high-level requirements is achieved. </j.0:description>
-                <j.2:uniqueIdentifier>A-7-3</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-7-9">
-                <j.0:description>Verification of additional code, that cannot be traced to Source Code, is achieved. </j.0:description>
-                <j.2:uniqueIdentifier>A-7-9</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-          </j.1:SECTION>
-        </j.1:content>
-        <j.1:content>
-          <j.1:SECTION rdf:ID="A-1">
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-1-7">
-                <j.0:description>Development and revision of software plans are coordinated. </j.0:description>
-                <j.2:uniqueIdentifier>A-1-7</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-1-6">
-                <j.0:description>Software plans comply with this document. </j.0:description>
-                <j.2:uniqueIdentifier>A-1-6</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-1-5">
-                <j.0:description>Software development standards are defined. </j.0:description>
-                <j.2:uniqueIdentifier>A-1-5</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-1-4">
-                <j.0:description>Additional considerations are addressed. </j.0:description>
-                <j.2:uniqueIdentifier>A-1-4</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-1-3">
-                <j.0:description>Software life cycle environment is selected and defined. </j.0:description>
-                <j.2:uniqueIdentifier>A-1-3</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-1-2">
-                <j.0:description>The software life cycle(s), including the inter-relationships between the processes, their sequencing, feedback mechanisms, and transition criteria, is defined. </j.0:description>
-                <j.2:uniqueIdentifier>A-1-2</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-1-1">
-                <j.0:description>The activities of the software life cycle processes are defined. </j.0:description>
-                <j.2:uniqueIdentifier>A-1-1</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:title>Software Planning Process</j.1:title>
-          </j.1:SECTION>
-        </j.1:content>
-        <j.1:content>
+        <j.2:content>
           <j.1:SECTION rdf:ID="A-3">
-            <j.1:content>
+            <j.2:content>
               <j.0:OBJECTIVE rdf:ID="A-3-7">
                 <j.0:description>Algorithms are accurate. </j.0:description>
                 <j.2:uniqueIdentifier>A-3-7</j.2:uniqueIdentifier>
               </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
+            </j.2:content>
+            <j.2:content>
               <j.0:OBJECTIVE rdf:ID="A-3-6">
                 <j.0:description>High-level requirements are traceable to system requirements. </j.0:description>
                 <j.2:uniqueIdentifier>A-3-6</j.2:uniqueIdentifier>
               </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
+            </j.2:content>
+            <j.2:content>
               <j.0:OBJECTIVE rdf:ID="A-3-5">
                 <j.0:description>High-level requirements conform to standards. </j.0:description>
                 <j.2:uniqueIdentifier>A-3-5</j.2:uniqueIdentifier>
               </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
+            </j.2:content>
+            <j.2:content>
               <j.0:OBJECTIVE rdf:ID="A-3-4">
                 <j.0:description>High-level requirements are verifiable. </j.0:description>
                 <j.2:uniqueIdentifier>A-3-4</j.2:uniqueIdentifier>
               </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
+            </j.2:content>
+            <j.2:content>
               <j.0:OBJECTIVE rdf:ID="A-3-3">
                 <j.0:description>High-level requirements are compatible with target computer. </j.0:description>
                 <j.2:uniqueIdentifier>A-3-3</j.2:uniqueIdentifier>
               </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
+            </j.2:content>
+            <j.2:content>
               <j.0:OBJECTIVE rdf:ID="A-3-2">
                 <j.0:description>High-level requirements are accurate and consistent. </j.0:description>
                 <j.2:uniqueIdentifier>A-3-2</j.2:uniqueIdentifier>
               </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
+            </j.2:content>
+            <j.2:content>
               <j.0:OBJECTIVE rdf:ID="A-3-1">
                 <j.0:description>High-level requirements comply with system requirements. </j.0:description>
                 <j.2:uniqueIdentifier>A-3-1</j.2:uniqueIdentifier>
               </j.0:OBJECTIVE>
-            </j.1:content>
+            </j.2:content>
             <j.1:title>Verification of Outputs of Software Requirements Process</j.1:title>
           </j.1:SECTION>
-        </j.1:content>
-        <j.1:content>
-          <j.1:SECTION rdf:ID="A-9">
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-9-5">
-                <j.0:description>Assurance is obtained that software conformity review is conducted. </j.0:description>
-                <j.2:uniqueIdentifier>A-9-5</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-9-4">
-                <j.0:description>Assurance is obtained that transition criteria for the software life cycle processes are satisfied. </j.0:description>
-                <j.2:uniqueIdentifier>A-9-4</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-9-3">
-                <j.0:description>Assurance is obtained that software life cycle processes comply with approved software standards. </j.0:description>
-                <j.2:uniqueIdentifier>A-9-3</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-9-2">
-                <j.0:description>Assurance is obtained that software life cycle processes comply with approved software plans. </j.0:description>
-                <j.2:uniqueIdentifier>A-9-2</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-9-1">
-                <j.0:description>Assurance is obtained that software plans and standards are developed and reviewed for compliance with this document and for consistency. </j.0:description>
-                <j.2:uniqueIdentifier>A-9-1</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:title>Software Quality Assurance Process</j.1:title>
-          </j.1:SECTION>
-        </j.1:content>
-        <j.1:content>
-          <j.1:SECTION rdf:ID="A-8">
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-8-6">
-                <j.0:description>Software life cycle environment control is established. </j.0:description>
-                <j.2:uniqueIdentifier>A-8-6</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-8-5">
-                <j.0:description>Software load control is established. </j.0:description>
-                <j.2:uniqueIdentifier>A-8-5</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-8-4">
-                <j.0:description>Archive, retrieval, and release are established. </j.0:description>
-                <j.2:uniqueIdentifier>A-8-4</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-8-3">
-                <j.0:description>Problem reporting, change control, change review, and configuration status accounting are established. </j.0:description>
-                <j.2:uniqueIdentifier>A-8-3</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-8-2">
-                <j.0:description>Baselines and traceability are established. </j.0:description>
-                <j.2:uniqueIdentifier>A-8-2</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-8-1">
-                <j.0:description>Configuration items are identified. </j.0:description>
-                <j.2:uniqueIdentifier>A-8-1</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:title>Software Configuration Management Process</j.1:title>
-          </j.1:SECTION>
-        </j.1:content>
-        <j.1:content>
-          <j.1:SECTION rdf:ID="A-5">
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-5-3">
-                <j.0:description>Source Code is verifiable. </j.0:description>
-                <j.2:uniqueIdentifier>A-5-3</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-5-8">
-                <j.0:description>Parameter Data Item File is correct and complete </j.0:description>
-                <j.2:uniqueIdentifier>A-5-8</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-5-5">
-                <j.0:description>Source Code is traceable to low-level requirements. </j.0:description>
-                <j.2:uniqueIdentifier>A-5-5</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:title>Verification of Outputs of Software Coding &amp; Integration Processes</j.1:title>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-5-2">
-                <j.0:description>Source Code complies with software architecture. </j.0:description>
-                <j.2:uniqueIdentifier>A-5-2</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-5-4">
-                <j.0:description>Source Code conforms to standards. </j.0:description>
-                <j.2:uniqueIdentifier>A-5-4</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-5-6">
-                <j.0:description>Source Code is accurate and consistent. </j.0:description>
-                <j.2:uniqueIdentifier>A-5-6</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-5-1">
-                <j.0:description>Source Code complies with low-level requirements. </j.0:description>
-                <j.2:uniqueIdentifier>A-5-1</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-5-7">
-                <j.0:description>Output of software integration process is complete and correct. </j.0:description>
-                <j.2:uniqueIdentifier>A-5-7</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-5-9">
-                <j.0:description>Verification of Parameter Data Item File is achieved. </j.0:description>
-                <j.2:uniqueIdentifier>A-5-9</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-          </j.1:SECTION>
-        </j.1:content>
-        <j.1:content>
-          <j.1:SECTION rdf:ID="A-2">
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-2-7">
-                <j.0:description>Executable Object Code and Parameter Data Item Files, if any, are produced and loaded in the target computer. </j.0:description>
-                <j.2:uniqueIdentifier>A-2-7</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-2-6">
-                <j.0:description>Source Code is developed. </j.0:description>
-                <j.2:uniqueIdentifier>A-2-6</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-2-5">
-                <j.0:description>Derived lowlevel requirements are defined and provided to the system processes, including the system safety assessment process. </j.0:description>
-                <j.2:uniqueIdentifier>A-2-5</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-2-4">
-                <j.0:description>Low-level requirements are developed. </j.0:description>
-                <j.2:uniqueIdentifier>A-2-4</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-2-3">
-                <j.0:description>Software architecture is developed. </j.0:description>
-                <j.2:uniqueIdentifier>A-2-3</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-2-2">
-                <j.0:description>Derived highlevel requirements are defined and provided to the system processes, including the system safety assessment process. </j.0:description>
-                <j.2:uniqueIdentifier>A-2-2</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-2-1">
-                <j.0:description>High-level requirements are developed. </j.0:description>
-                <j.2:uniqueIdentifier>A-2-1</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:title>Software Development Process</j.1:title>
-          </j.1:SECTION>
-        </j.1:content>
-        <j.1:content>
+        </j.2:content>
+        <j.2:content>
           <j.1:SECTION rdf:ID="A-4">
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-4-1">
-                <j.0:description>Low-level requirements comply with high-level requirements. </j.0:description>
-                <j.2:uniqueIdentifier>A-4-1</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-4-3">
-                <j.0:description>Low-level requirements are compatible with target computer. </j.0:description>
-                <j.2:uniqueIdentifier>A-4-3</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-4-11">
-                <j.0:description>Software architecture is verifiable. </j.0:description>
-                <j.2:uniqueIdentifier>A-4-11</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-4-8">
-                <j.0:description>Software architecture is compatible with highlevel requirements. </j.0:description>
-                <j.2:uniqueIdentifier>A-4-8</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:title>Verification of Outputs of Software Design Process</j.1:title>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-4-5">
-                <j.0:description>Low-level requirements conform to standards. </j.0:description>
-                <j.2:uniqueIdentifier>A-4-5</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-4-7">
-                <j.0:description>Algorithms are accurate. </j.0:description>
-                <j.2:uniqueIdentifier>A-4-7</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-4-10">
-                <j.0:description>Software architecture is compatible with target computer. </j.0:description>
-                <j.2:uniqueIdentifier>A-4-10</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-4-2">
-                <j.0:description>Low-level requirements are accurate and consistent. </j.0:description>
-                <j.2:uniqueIdentifier>A-4-2</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
+            <j.2:content>
               <j.0:OBJECTIVE rdf:ID="A-4-4">
                 <j.0:description>Low-level requirements are verifiable. </j.0:description>
                 <j.2:uniqueIdentifier>A-4-4</j.2:uniqueIdentifier>
               </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-4-12">
-                <j.0:description>Software architecture conforms to standards. </j.0:description>
-                <j.2:uniqueIdentifier>A-4-12</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-4-9">
-                <j.0:description>Software architecture is consistent. </j.0:description>
-                <j.2:uniqueIdentifier>A-4-9</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="A-4-6">
-                <j.0:description>Low-level requirements are traceable to highlevel requirements. </j.0:description>
-                <j.2:uniqueIdentifier>A-4-6</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
+            </j.2:content>
+            <j.2:content>
               <j.0:OBJECTIVE rdf:ID="A-4-13">
                 <j.0:description>Software partitioning integrity is confirmed. </j.0:description>
                 <j.2:uniqueIdentifier>A-4-13</j.2:uniqueIdentifier>
               </j.0:OBJECTIVE>
-            </j.1:content>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-4-8">
+                <j.0:description>Software architecture is compatible with highlevel requirements. </j.0:description>
+                <j.2:uniqueIdentifier>A-4-8</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-4-3">
+                <j.0:description>Low-level requirements are compatible with target computer. </j.0:description>
+                <j.2:uniqueIdentifier>A-4-3</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-4-10">
+                <j.0:description>Software architecture is compatible with target computer. </j.0:description>
+                <j.2:uniqueIdentifier>A-4-10</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.1:title>Verification of Outputs of Software Design Process</j.1:title>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-4-6">
+                <j.0:description>Low-level requirements are traceable to highlevel requirements. </j.0:description>
+                <j.2:uniqueIdentifier>A-4-6</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-4-5">
+                <j.0:description>Low-level requirements conform to standards. </j.0:description>
+                <j.2:uniqueIdentifier>A-4-5</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-4-9">
+                <j.0:description>Software architecture is consistent. </j.0:description>
+                <j.2:uniqueIdentifier>A-4-9</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-4-12">
+                <j.0:description>Software architecture conforms to standards. </j.0:description>
+                <j.2:uniqueIdentifier>A-4-12</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-4-11">
+                <j.0:description>Software architecture is verifiable. </j.0:description>
+                <j.2:uniqueIdentifier>A-4-11</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-4-7">
+                <j.0:description>Algorithms are accurate. </j.0:description>
+                <j.2:uniqueIdentifier>A-4-7</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-4-2">
+                <j.0:description>Low-level requirements are accurate and consistent. </j.0:description>
+                <j.2:uniqueIdentifier>A-4-2</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-4-1">
+                <j.0:description>Low-level requirements comply with high-level requirements. </j.0:description>
+                <j.2:uniqueIdentifier>A-4-1</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
           </j.1:SECTION>
-        </j.1:content>
+        </j.2:content>
+        <j.2:content>
+          <j.1:SECTION rdf:ID="A-5">
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-5-9">
+                <j.0:description>Verification of Parameter Data Item File is achieved. </j.0:description>
+                <j.2:uniqueIdentifier>A-5-9</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-5-6">
+                <j.0:description>Source Code is accurate and consistent. </j.0:description>
+                <j.2:uniqueIdentifier>A-5-6</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-5-3">
+                <j.0:description>Source Code is verifiable. </j.0:description>
+                <j.2:uniqueIdentifier>A-5-3</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.1:title>Verification of Outputs of Software Coding &amp; Integration Processes</j.1:title>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-5-8">
+                <j.0:description>Parameter Data Item File is correct and complete </j.0:description>
+                <j.2:uniqueIdentifier>A-5-8</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-5-5">
+                <j.0:description>Source Code is traceable to low-level requirements. </j.0:description>
+                <j.2:uniqueIdentifier>A-5-5</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-5-2">
+                <j.0:description>Source Code complies with software architecture. </j.0:description>
+                <j.2:uniqueIdentifier>A-5-2</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-5-4">
+                <j.0:description>Source Code conforms to standards. </j.0:description>
+                <j.2:uniqueIdentifier>A-5-4</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-5-7">
+                <j.0:description>Output of software integration process is complete and correct. </j.0:description>
+                <j.2:uniqueIdentifier>A-5-7</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-5-1">
+                <j.0:description>Source Code complies with low-level requirements. </j.0:description>
+                <j.2:uniqueIdentifier>A-5-1</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+          </j.1:SECTION>
+        </j.2:content>
+        <j.1:title>PROCESS OBJECTIVES AND OUTPUTS BY SOFTWARE LEVEL</j.1:title>
+        <j.2:content>
+          <j.1:SECTION rdf:ID="A-6">
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-6-5">
+                <j.0:description>Executable Object Code is compatible with target computer. </j.0:description>
+                <j.2:uniqueIdentifier>A-6-5</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-6-4">
+                <j.0:description>Executable Object Code is robust with low-level requirements. </j.0:description>
+                <j.2:uniqueIdentifier>A-6-4</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-6-3">
+                <j.0:description>Executable Object Code complies with low-level requirements. </j.0:description>
+                <j.2:uniqueIdentifier>A-6-3</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-6-2">
+                <j.0:description>Executable Object Code is robust with high-level requirements. </j.0:description>
+                <j.2:uniqueIdentifier>A-6-2</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-6-1">
+                <j.0:description>Executable Object Code complies with high-level requirements. </j.0:description>
+                <j.2:uniqueIdentifier>A-6-1</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.1:title>Verification of Outputs of Integration Process</j.1:title>
+          </j.1:SECTION>
+        </j.2:content>
+        <j.2:content>
+          <j.1:SECTION rdf:ID="A-1">
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-1-7">
+                <j.0:description>Development and revision of software plans are coordinated. </j.0:description>
+                <j.2:uniqueIdentifier>A-1-7</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-1-6">
+                <j.0:description>Software plans comply with this document. </j.0:description>
+                <j.2:uniqueIdentifier>A-1-6</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-1-5">
+                <j.0:description>Software development standards are defined. </j.0:description>
+                <j.2:uniqueIdentifier>A-1-5</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-1-4">
+                <j.0:description>Additional considerations are addressed. </j.0:description>
+                <j.2:uniqueIdentifier>A-1-4</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-1-3">
+                <j.0:description>Software life cycle environment is selected and defined. </j.0:description>
+                <j.2:uniqueIdentifier>A-1-3</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-1-2">
+                <j.0:description>The software life cycle(s), including the inter-relationships between the processes, their sequencing, feedback mechanisms, and transition criteria, is defined. </j.0:description>
+                <j.2:uniqueIdentifier>A-1-2</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-1-1">
+                <j.0:description>The activities of the software life cycle processes are defined. </j.0:description>
+                <j.2:uniqueIdentifier>A-1-1</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.1:title>Software Planning Process</j.1:title>
+          </j.1:SECTION>
+        </j.2:content>
+        <j.2:content>
+          <j.1:SECTION rdf:ID="A-10">
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-10-3">
+                <j.0:description>Compliance substantiation is provided. </j.0:description>
+                <j.2:uniqueIdentifier>A-10-3</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-10-2">
+                <j.0:description>The means of compliance is proposed and agreement with the Plan for Software Aspects of Certification is obtained. </j.0:description>
+                <j.2:uniqueIdentifier>A-10-2</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-10-1">
+                <j.0:description>Communication and understanding between the applicant and the certification authority is established. </j.0:description>
+                <j.2:uniqueIdentifier>A-10-1</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.1:title>Certification Liaison Process</j.1:title>
+          </j.1:SECTION>
+        </j.2:content>
+        <j.2:content>
+          <j.1:SECTION rdf:ID="A-2">
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-2-7">
+                <j.0:description>Executable Object Code and Parameter Data Item Files, if any, are produced and loaded in the target computer. </j.0:description>
+                <j.2:uniqueIdentifier>A-2-7</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-2-6">
+                <j.0:description>Source Code is developed. </j.0:description>
+                <j.2:uniqueIdentifier>A-2-6</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-2-5">
+                <j.0:description>Derived lowlevel requirements are defined and provided to the system processes, including the system safety assessment process. </j.0:description>
+                <j.2:uniqueIdentifier>A-2-5</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-2-4">
+                <j.0:description>Low-level requirements are developed. </j.0:description>
+                <j.2:uniqueIdentifier>A-2-4</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-2-3">
+                <j.0:description>Software architecture is developed. </j.0:description>
+                <j.2:uniqueIdentifier>A-2-3</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-2-2">
+                <j.0:description>Derived highlevel requirements are defined and provided to the system processes, including the system safety assessment process. </j.0:description>
+                <j.2:uniqueIdentifier>A-2-2</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-2-1">
+                <j.0:description>High-level requirements are developed. </j.0:description>
+                <j.2:uniqueIdentifier>A-2-1</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.1:title>Software Development Process</j.1:title>
+          </j.1:SECTION>
+        </j.2:content>
+        <j.2:content>
+          <j.1:SECTION rdf:ID="A-7">
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-7-1">
+                <j.0:description>Test procedures are correct. </j.0:description>
+                <j.2:uniqueIdentifier>A-7-1</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-7-2">
+                <j.0:description>Test results are correct and discrepancies explained. </j.0:description>
+                <j.2:uniqueIdentifier>A-7-2</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-7-9">
+                <j.0:description>Verification of additional code, that cannot be traced to Source Code, is achieved. </j.0:description>
+                <j.2:uniqueIdentifier>A-7-9</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-7-3">
+                <j.0:description>Test coverage of high-level requirements is achieved. </j.0:description>
+                <j.2:uniqueIdentifier>A-7-3</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.1:title>Verification of Verification Process Results</j.1:title>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-7-4">
+                <j.0:description>Test coverage of low-level requirements is achieved. </j.0:description>
+                <j.2:uniqueIdentifier>A-7-4</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-7-5">
+                <j.0:description>Test coverage of software structure (modified condition/decision coverage) is achieved. </j.0:description>
+                <j.2:uniqueIdentifier>A-7-5</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-7-6">
+                <j.0:description>Test coverage of software structure (decision coverage) is achieved. </j.0:description>
+                <j.2:uniqueIdentifier>A-7-6</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-7-7">
+                <j.0:description>Test coverage of software structure (statement coverage) is achieved. </j.0:description>
+                <j.2:uniqueIdentifier>A-7-7</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-7-8">
+                <j.0:description>Test coverage of software structure (data coupling and control coupling) is achieved. </j.0:description>
+                <j.2:uniqueIdentifier>A-7-8</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+          </j.1:SECTION>
+        </j.2:content>
+        <j.2:content>
+          <j.1:SECTION rdf:ID="A-9">
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-9-5">
+                <j.0:description>Assurance is obtained that software conformity review is conducted. </j.0:description>
+                <j.2:uniqueIdentifier>A-9-5</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-9-4">
+                <j.0:description>Assurance is obtained that transition criteria for the software life cycle processes are satisfied. </j.0:description>
+                <j.2:uniqueIdentifier>A-9-4</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-9-3">
+                <j.0:description>Assurance is obtained that software life cycle processes comply with approved software standards. </j.0:description>
+                <j.2:uniqueIdentifier>A-9-3</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-9-2">
+                <j.0:description>Assurance is obtained that software life cycle processes comply with approved software plans. </j.0:description>
+                <j.2:uniqueIdentifier>A-9-2</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-9-1">
+                <j.0:description>Assurance is obtained that software plans and standards are developed and reviewed for compliance with this document and for consistency. </j.0:description>
+                <j.2:uniqueIdentifier>A-9-1</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.1:title>Software Quality Assurance Process</j.1:title>
+          </j.1:SECTION>
+        </j.2:content>
+        <j.2:content>
+          <j.1:SECTION rdf:ID="A-8">
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-8-6">
+                <j.0:description>Software life cycle environment control is established. </j.0:description>
+                <j.2:uniqueIdentifier>A-8-6</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-8-5">
+                <j.0:description>Software load control is established. </j.0:description>
+                <j.2:uniqueIdentifier>A-8-5</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-8-4">
+                <j.0:description>Archive, retrieval, and release are established. </j.0:description>
+                <j.2:uniqueIdentifier>A-8-4</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-8-3">
+                <j.0:description>Problem reporting, change control, change review, and configuration status accounting are established. </j.0:description>
+                <j.2:uniqueIdentifier>A-8-3</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-8-2">
+                <j.0:description>Baselines and traceability are established. </j.0:description>
+                <j.2:uniqueIdentifier>A-8-2</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="A-8-1">
+                <j.0:description>Configuration items are identified. </j.0:description>
+                <j.2:uniqueIdentifier>A-8-1</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.1:title>Software Configuration Management Process</j.1:title>
+          </j.1:SECTION>
+        </j.2:content>
       </j.1:SECTION>
-    </j.1:content>
+    </j.2:content>
     <j.1:approvalAuthority>
       <j.2:AGENT rdf:ID="RTCA"/>
     </j.1:approvalAuthority>

--- a/RACK-Ontology/OwlModels/DO-330.owl
+++ b/RACK-Ontology/OwlModels/DO-330.owl
@@ -22,522 +22,522 @@
     <rdfs:comment xml:lang="en">This ontology was created from a SADL file 'DO-330.sadl' and should not be directly edited.</rdfs:comment>
   </owl:Ontology>
   <j.1:SPECIFICATION rdf:ID="DO-330">
-    <j.1:content>
+    <j.2:content>
       <j.1:SECTION rdf:ID="DO-330-AnnexA">
-        <j.1:content>
-          <j.1:SECTION rdf:ID="T-9">
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-9-5">
-                <j.0:description>Tool conformity review is conducted. </j.0:description>
-                <j.2:uniqueIdentifier>T-9-5</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-9-4">
-                <j.0:description>Assurance is obtained that transition criteria for the tool life cycle processes are satisfied. </j.0:description>
-                <j.2:uniqueIdentifier>T-9-4</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-9-3">
-                <j.0:description>Assurance is obtained that tool processes comply with approved standards. </j.0:description>
-                <j.2:uniqueIdentifier>T-9-3</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-9-2">
-                <j.0:description>Assurance is obtained that tool processes comply with approved plans. </j.0:description>
-                <j.2:uniqueIdentifier>T-9-2</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-9-1">
-                <j.0:description>Assurance is obtained that tool plans and standards are developed and reviewed for consistency. </j.0:description>
-                <j.2:uniqueIdentifier>T-9-1</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:title>Tool Quality Assurance Process</j.1:title>
-          </j.1:SECTION>
-        </j.1:content>
-        <j.1:content>
-          <j.1:SECTION rdf:ID="T-3">
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-3-4">
-                <j.0:description>Tool Requirements define the behavior of the tool in response to error conditions. </j.0:description>
-                <j.2:uniqueIdentifier>T-3-4</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-3-2">
-                <j.0:description>Tool Requirements are accurate and consistent. </j.0:description>
-                <j.2:uniqueIdentifier>T-3-2</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-3-3">
-                <j.0:description>Requirements for compatibility with the tool operational environment are defined. </j.0:description>
-                <j.2:uniqueIdentifier>T-3-3</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-3-1">
-                <j.0:description>Tool Requirements comply with Tool Operational Requirements. </j.0:description>
-                <j.2:uniqueIdentifier>T-3-1</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-3-9">
-                <j.0:description>Algorithms are accurate. </j.0:description>
-                <j.2:uniqueIdentifier>T-3-9</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:title>Verification of Outputs of Tool Requirements Processes</j.1:title>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-3-8">
-                <j.0:description>Tool Requirements are traceable to Tool Operational Requirements. </j.0:description>
-                <j.2:uniqueIdentifier>T-3-8</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-3-7">
-                <j.0:description>Tool Requirements conform to Tool Requirements Standards. </j.0:description>
-                <j.2:uniqueIdentifier>T-3-7</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-3-6">
-                <j.0:description>Tool Requirements are verifiable. </j.0:description>
-                <j.2:uniqueIdentifier>T-3-6</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-3-5">
-                <j.0:description>Tool Requirements define user instructions and error messages. </j.0:description>
-                <j.2:uniqueIdentifier>T-3-5</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-          </j.1:SECTION>
-        </j.1:content>
-        <j.1:content>
-          <j.1:SECTION rdf:ID="T-5">
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-5-7">
-                <j.0:description>Output of tool integration process is complete and correct. </j.0:description>
-                <j.2:uniqueIdentifier>T-5-7</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-5-6">
-                <j.0:description>Source Code is accurate and consistent. </j.0:description>
-                <j.2:uniqueIdentifier>T-5-6</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-5-5">
-                <j.0:description>Tool Source Code is traceable to low-level tool requirements. </j.0:description>
-                <j.2:uniqueIdentifier>T-5-5</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-5-4">
-                <j.0:description>Tool Source Code conforms to Tool Code Standards. </j.0:description>
-                <j.2:uniqueIdentifier>T-5-4</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-5-3">
-                <j.0:description>Tool Source Code is verifiable. </j.0:description>
-                <j.2:uniqueIdentifier>T-5-3</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-5-2">
-                <j.0:description>Tool Source Code complies with tool architecture. </j.0:description>
-                <j.2:uniqueIdentifier>T-5-2</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-5-1">
-                <j.0:description>Tool Source Code complies with low-level tool requirements. </j.0:description>
-                <j.2:uniqueIdentifier>T-5-1</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:title>Verification of Outputs of Tool Coding &amp; Integration Process</j.1:title>
-          </j.1:SECTION>
-        </j.1:content>
-        <j.1:content>
-          <j.1:SECTION rdf:ID="T-4">
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-4-4">
-                <j.0:description>Low-level tool requirements conform to Tool Design Standards. </j.0:description>
-                <j.2:uniqueIdentifier>T-4-4</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-4-8">
-                <j.0:description>Tool architecture is consistent. </j.0:description>
-                <j.2:uniqueIdentifier>T-4-8</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-4-3">
-                <j.0:description>Low-level tool requirements are verifiable. </j.0:description>
-                <j.2:uniqueIdentifier>T-4-3</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-4-7">
-                <j.0:description>Tool architecture is compatible with Tool Requirements. </j.0:description>
-                <j.2:uniqueIdentifier>T-4-7</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-4-1">
-                <j.0:description>Low-Level Tool requirements comply with Tool Requirements. </j.0:description>
-                <j.2:uniqueIdentifier>T-4-1</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-4-2">
-                <j.0:description>Low-level tool requirements are accurate and consistent. </j.0:description>
-                <j.2:uniqueIdentifier>T-4-2</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-4-6">
-                <j.0:description>Algorithms are accurate. </j.0:description>
-                <j.2:uniqueIdentifier>T-4-6</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:title>Verification of Outputs of Tool Design Process</j.1:title>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-4-10">
-                <j.0:description>Protection mechanisms, if used, are confirmed. </j.0:description>
-                <j.2:uniqueIdentifier>T-4-10</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-4-11">
-                <j.0:description>External component interface is correctly and completely defined. </j.0:description>
-                <j.2:uniqueIdentifier>T-4-11</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-4-5">
-                <j.0:description>Low-level tool requirements are traceable to Tool Requirements. </j.0:description>
-                <j.2:uniqueIdentifier>T-4-5</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-4-9">
-                <j.0:description>Tool architecture conforms to Tool Design Standards. </j.0:description>
-                <j.2:uniqueIdentifier>T-4-9</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-          </j.1:SECTION>
-        </j.1:content>
-        <j.1:content>
-          <j.1:SECTION rdf:ID="T-1">
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-1-7">
-                <j.0:description>Development and revision of tool plans are coordinated. </j.0:description>
-                <j.2:uniqueIdentifier>T-1-7</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-1-6">
-                <j.0:description>Tool plans comply with this document. </j.0:description>
-                <j.2:uniqueIdentifier>T-1-6</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-1-5">
-                <j.0:description>Tool development standards are defined. </j.0:description>
-                <j.2:uniqueIdentifier>T-1-5</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-1-4">
-                <j.0:description>Additional considerations are addressed. </j.0:description>
-                <j.2:uniqueIdentifier>T-1-4</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-1-3">
-                <j.0:description>Tool development environment is selected and defined. </j.0:description>
-                <j.2:uniqueIdentifier>T-1-3</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-1-2">
-                <j.0:description>Transition criteria, inter-relationships, and sequencing among processes of tool processes are defined. </j.0:description>
-                <j.2:uniqueIdentifier>T-1-2</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-1-1">
-                <j.0:description>Tool development and integral processes are defined. </j.0:description>
-                <j.2:uniqueIdentifier>T-1-1</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:title>Tool Planning Process</j.1:title>
-          </j.1:SECTION>
-        </j.1:content>
-        <j.1:title>TOOL QUALIFICATION OBJECTIVES</j.1:title>
-        <j.1:content>
-          <j.1:SECTION rdf:ID="T-6">
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-6-4">
-                <j.0:description>Tool Executable Object Code is robust with low-level tool requirements. </j.0:description>
-                <j.2:uniqueIdentifier>T-6-4</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-6-3">
-                <j.0:description>Tool Executable Object Code complies with low-level tool requirements. </j.0:description>
-                <j.2:uniqueIdentifier>T-6-3</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-6-2">
-                <j.0:description>Tool Executable Object Code is robust with Tool Requirements. </j.0:description>
-                <j.2:uniqueIdentifier>T-6-2</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-6-1">
-                <j.0:description>Tool Executable Object Code complies with Tool Requirements. </j.0:description>
-                <j.2:uniqueIdentifier>T-6-1</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:title>Testing of Outputs of Integration Process</j.1:title>
-          </j.1:SECTION>
-        </j.1:content>
-        <j.1:content>
+        <j.2:content>
           <j.1:SECTION rdf:ID="T-2">
             <j.1:title>Tool Development Processes</j.1:title>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-2-2">
-                <j.0:description>Derived tool requirements are defined. </j.0:description>
-                <j.2:uniqueIdentifier>T-2-2</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-2-6">
-                <j.0:description>Tool Source Code is developed. </j.0:description>
-                <j.2:uniqueIdentifier>T-2-6</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
+            <j.2:content>
               <j.0:OBJECTIVE rdf:ID="T-2-7">
                 <j.0:description>Tool Executable Object Code is produced. </j.0:description>
                 <j.2:uniqueIdentifier>T-2-7</j.2:uniqueIdentifier>
               </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-2-1">
-                <j.0:description>Tool Requirements are developed. </j.0:description>
-                <j.2:uniqueIdentifier>T-2-1</j.2:uniqueIdentifier>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-2-6">
+                <j.0:description>Tool Source Code is developed. </j.0:description>
+                <j.2:uniqueIdentifier>T-2-6</j.2:uniqueIdentifier>
               </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-2-4">
-                <j.0:description>Low-level tool requirements are developed. </j.0:description>
-                <j.2:uniqueIdentifier>T-2-4</j.2:uniqueIdentifier>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-2-2">
+                <j.0:description>Derived tool requirements are defined. </j.0:description>
+                <j.2:uniqueIdentifier>T-2-2</j.2:uniqueIdentifier>
               </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
+            </j.2:content>
+            <j.2:content>
               <j.0:OBJECTIVE rdf:ID="T-2-5">
                 <j.0:description>Derived low-level tool requirements are defined. </j.0:description>
                 <j.2:uniqueIdentifier>T-2-5</j.2:uniqueIdentifier>
               </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-2-8">
-                <j.0:description>Tool is installed in the tool verification environment(s). </j.0:description>
-                <j.2:uniqueIdentifier>T-2-8</j.2:uniqueIdentifier>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-2-1">
+                <j.0:description>Tool Requirements are developed. </j.0:description>
+                <j.2:uniqueIdentifier>T-2-1</j.2:uniqueIdentifier>
               </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-2-4">
+                <j.0:description>Low-level tool requirements are developed. </j.0:description>
+                <j.2:uniqueIdentifier>T-2-4</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
               <j.0:OBJECTIVE rdf:ID="T-2-3">
                 <j.0:description>Tool architecture is developed. </j.0:description>
                 <j.2:uniqueIdentifier>T-2-3</j.2:uniqueIdentifier>
               </j.0:OBJECTIVE>
-            </j.1:content>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-2-8">
+                <j.0:description>Tool is installed in the tool verification environment(s). </j.0:description>
+                <j.2:uniqueIdentifier>T-2-8</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
           </j.1:SECTION>
-        </j.1:content>
-        <j.1:content>
-          <j.1:SECTION rdf:ID="T-7">
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-7-2">
-                <j.0:description>Test results are correct and discrepancies explained. </j.0:description>
-                <j.2:uniqueIdentifier>T-7-2</j.2:uniqueIdentifier>
+        </j.2:content>
+        <j.2:content>
+          <j.1:SECTION rdf:ID="T-9">
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-9-5">
+                <j.0:description>Tool conformity review is conducted. </j.0:description>
+                <j.2:uniqueIdentifier>T-9-5</j.2:uniqueIdentifier>
               </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-7-7">
-                <j.0:description>Analysis of requirements based testing (structural coverage to the level of decision coverage) is achieved. </j.0:description>
-                <j.2:uniqueIdentifier>T-7-7</j.2:uniqueIdentifier>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-9-4">
+                <j.0:description>Assurance is obtained that transition criteria for the tool life cycle processes are satisfied. </j.0:description>
+                <j.2:uniqueIdentifier>T-9-4</j.2:uniqueIdentifier>
               </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-7-8">
-                <j.0:description>Analysis of requirements based testing (structural coverage to the level of statement coverage) is achieved. </j.0:description>
-                <j.2:uniqueIdentifier>T-7-8</j.2:uniqueIdentifier>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-9-3">
+                <j.0:description>Assurance is obtained that tool processes comply with approved standards. </j.0:description>
+                <j.2:uniqueIdentifier>T-9-3</j.2:uniqueIdentifier>
               </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-7-3">
-                <j.0:description>Test coverage of Tool Requirements is achieved. </j.0:description>
-                <j.2:uniqueIdentifier>T-7-3</j.2:uniqueIdentifier>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-9-2">
+                <j.0:description>Assurance is obtained that tool processes comply with approved plans. </j.0:description>
+                <j.2:uniqueIdentifier>T-9-2</j.2:uniqueIdentifier>
               </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-7-9">
-                <j.0:description>Analysis of requirements based testing (data coupling and control coupling) is achieved. </j.0:description>
-                <j.2:uniqueIdentifier>T-7-9</j.2:uniqueIdentifier>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-9-1">
+                <j.0:description>Assurance is obtained that tool plans and standards are developed and reviewed for consistency. </j.0:description>
+                <j.2:uniqueIdentifier>T-9-1</j.2:uniqueIdentifier>
               </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-7-4">
-                <j.0:description>Test coverage of low-level tool requirements is achieved. </j.0:description>
-                <j.2:uniqueIdentifier>T-7-4</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-7-5">
-                <j.0:description>Analysis of requirements based testing of external components is achieved. </j.0:description>
-                <j.2:uniqueIdentifier>T-7-5</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:title>Verification of Ouptuts of Tool Testing</j.1:title>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-7-6">
-                <j.0:description>Analysis of requirements based testing (structural coverage to the level of MC/DC) is achieved. </j.0:description>
-                <j.2:uniqueIdentifier>T-7-6</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-7-1">
-                <j.0:description>Test procedures are correct. </j.0:description>
-                <j.2:uniqueIdentifier>T-7-1</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
+            </j.2:content>
+            <j.1:title>Tool Quality Assurance Process</j.1:title>
           </j.1:SECTION>
-        </j.1:content>
-        <j.1:content>
+        </j.2:content>
+        <j.2:content>
           <j.1:SECTION rdf:ID="T-10">
-            <j.1:content>
+            <j.2:content>
               <j.0:OBJECTIVE rdf:ID="T-10-4">
                 <j.0:description>Impact of known problems on the Tool Operational Requirements is identified and analyzed. </j.0:description>
                 <j.2:uniqueIdentifier>T-10-4</j.2:uniqueIdentifier>
               </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
+            </j.2:content>
+            <j.2:content>
               <j.0:OBJECTIVE rdf:ID="T-10-3">
                 <j.0:description>Compliance substantiation is provided. </j.0:description>
                 <j.2:uniqueIdentifier>T-10-3</j.2:uniqueIdentifier>
               </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
+            </j.2:content>
+            <j.2:content>
               <j.0:OBJECTIVE rdf:ID="T-10-2">
                 <j.0:description>The means of compliance is proposed and agreement is obtained. </j.0:description>
                 <j.2:uniqueIdentifier>T-10-2</j.2:uniqueIdentifier>
               </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
+            </j.2:content>
+            <j.2:content>
               <j.0:OBJECTIVE rdf:ID="T-10-1">
                 <j.0:description>Communication and understanding between the applicant and the certification authority is established. </j.0:description>
                 <j.2:uniqueIdentifier>T-10-1</j.2:uniqueIdentifier>
               </j.0:OBJECTIVE>
-            </j.1:content>
+            </j.2:content>
             <j.1:title>Tool Qualification Liaison Process</j.1:title>
           </j.1:SECTION>
-        </j.1:content>
-        <j.1:content>
-          <j.1:SECTION rdf:ID="T-8">
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-8-5">
-                <j.0:description>Tool life cycle environment control is established. </j.0:description>
-                <j.2:uniqueIdentifier>T-8-5</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-8-4">
-                <j.0:description>Archive, retrieval, and release are established. </j.0:description>
-                <j.2:uniqueIdentifier>T-8-4</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-8-3">
-                <j.0:description>Problem reporting, change control, change review, and configuration status accounting are established. </j.0:description>
-                <j.2:uniqueIdentifier>T-8-3</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-8-2">
-                <j.0:description>Baselines and traceability are established. </j.0:description>
-                <j.2:uniqueIdentifier>T-8-2</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
-              <j.0:OBJECTIVE rdf:ID="T-8-1">
-                <j.0:description>Configuration items are identified. </j.0:description>
-                <j.2:uniqueIdentifier>T-8-1</j.2:uniqueIdentifier>
-              </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:title>Tool Configuration Management Process</j.1:title>
-          </j.1:SECTION>
-        </j.1:content>
-        <j.1:content>
+        </j.2:content>
+        <j.2:content>
           <j.1:SECTION rdf:ID="T-0">
-            <j.1:content>
+            <j.2:content>
               <j.0:OBJECTIVE rdf:ID="T-0-7">
                 <j.0:description>Software life cycle process needs are met by the tool. </j.0:description>
                 <j.2:uniqueIdentifier>T-0-7</j.2:uniqueIdentifier>
               </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
+            </j.2:content>
+            <j.2:content>
               <j.0:OBJECTIVE rdf:ID="T-0-6">
                 <j.0:description>Tool Operational Requirements are sufficient and correct. </j.0:description>
                 <j.2:uniqueIdentifier>T-0-6</j.2:uniqueIdentifier>
               </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
+            </j.2:content>
+            <j.2:content>
               <j.0:OBJECTIVE rdf:ID="T-0-5">
                 <j.0:description>Tool operation complies with the Tool Operational Requirements. </j.0:description>
                 <j.2:uniqueIdentifier>T-0-5</j.2:uniqueIdentifier>
               </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
+            </j.2:content>
+            <j.2:content>
               <j.0:OBJECTIVE rdf:ID="T-0-4">
                 <j.0:description>Tool Operational Requirements are complete, accurate, verifiable, and consistent. </j.0:description>
                 <j.2:uniqueIdentifier>T-0-4</j.2:uniqueIdentifier>
               </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
+            </j.2:content>
+            <j.2:content>
               <j.0:OBJECTIVE rdf:ID="T-0-3">
                 <j.0:description>Tool Executable Object Code is installed in the tool operational environment. </j.0:description>
                 <j.2:uniqueIdentifier>T-0-3</j.2:uniqueIdentifier>
               </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
+            </j.2:content>
+            <j.2:content>
               <j.0:OBJECTIVE rdf:ID="T-0-2">
                 <j.0:description>Tool Operational Requirements are defined. </j.0:description>
                 <j.2:uniqueIdentifier>T-0-2</j.2:uniqueIdentifier>
               </j.0:OBJECTIVE>
-            </j.1:content>
-            <j.1:content>
+            </j.2:content>
+            <j.2:content>
               <j.0:OBJECTIVE rdf:ID="T-0-1">
                 <j.0:description>The tool qualification need is established. </j.0:description>
                 <j.2:uniqueIdentifier>T-0-1</j.2:uniqueIdentifier>
               </j.0:OBJECTIVE>
-            </j.1:content>
+            </j.2:content>
             <j.1:title>Tool Operational Processes</j.1:title>
           </j.1:SECTION>
-        </j.1:content>
+        </j.2:content>
+        <j.2:content>
+          <j.1:SECTION rdf:ID="T-7">
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-7-3">
+                <j.0:description>Test coverage of Tool Requirements is achieved. </j.0:description>
+                <j.2:uniqueIdentifier>T-7-3</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-7-5">
+                <j.0:description>Analysis of requirements based testing of external components is achieved. </j.0:description>
+                <j.2:uniqueIdentifier>T-7-5</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-7-4">
+                <j.0:description>Test coverage of low-level tool requirements is achieved. </j.0:description>
+                <j.2:uniqueIdentifier>T-7-4</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-7-2">
+                <j.0:description>Test results are correct and discrepancies explained. </j.0:description>
+                <j.2:uniqueIdentifier>T-7-2</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-7-1">
+                <j.0:description>Test procedures are correct. </j.0:description>
+                <j.2:uniqueIdentifier>T-7-1</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-7-7">
+                <j.0:description>Analysis of requirements based testing (structural coverage to the level of decision coverage) is achieved. </j.0:description>
+                <j.2:uniqueIdentifier>T-7-7</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-7-9">
+                <j.0:description>Analysis of requirements based testing (data coupling and control coupling) is achieved. </j.0:description>
+                <j.2:uniqueIdentifier>T-7-9</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-7-6">
+                <j.0:description>Analysis of requirements based testing (structural coverage to the level of MC/DC) is achieved. </j.0:description>
+                <j.2:uniqueIdentifier>T-7-6</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.1:title>Verification of Ouptuts of Tool Testing</j.1:title>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-7-8">
+                <j.0:description>Analysis of requirements based testing (structural coverage to the level of statement coverage) is achieved. </j.0:description>
+                <j.2:uniqueIdentifier>T-7-8</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+          </j.1:SECTION>
+        </j.2:content>
+        <j.2:content>
+          <j.1:SECTION rdf:ID="T-5">
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-5-7">
+                <j.0:description>Output of tool integration process is complete and correct. </j.0:description>
+                <j.2:uniqueIdentifier>T-5-7</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-5-6">
+                <j.0:description>Source Code is accurate and consistent. </j.0:description>
+                <j.2:uniqueIdentifier>T-5-6</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-5-5">
+                <j.0:description>Tool Source Code is traceable to low-level tool requirements. </j.0:description>
+                <j.2:uniqueIdentifier>T-5-5</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-5-4">
+                <j.0:description>Tool Source Code conforms to Tool Code Standards. </j.0:description>
+                <j.2:uniqueIdentifier>T-5-4</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-5-3">
+                <j.0:description>Tool Source Code is verifiable. </j.0:description>
+                <j.2:uniqueIdentifier>T-5-3</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-5-2">
+                <j.0:description>Tool Source Code complies with tool architecture. </j.0:description>
+                <j.2:uniqueIdentifier>T-5-2</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-5-1">
+                <j.0:description>Tool Source Code complies with low-level tool requirements. </j.0:description>
+                <j.2:uniqueIdentifier>T-5-1</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.1:title>Verification of Outputs of Tool Coding &amp; Integration Process</j.1:title>
+          </j.1:SECTION>
+        </j.2:content>
+        <j.2:content>
+          <j.1:SECTION rdf:ID="T-3">
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-3-4">
+                <j.0:description>Tool Requirements define the behavior of the tool in response to error conditions. </j.0:description>
+                <j.2:uniqueIdentifier>T-3-4</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-3-1">
+                <j.0:description>Tool Requirements comply with Tool Operational Requirements. </j.0:description>
+                <j.2:uniqueIdentifier>T-3-1</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-3-2">
+                <j.0:description>Tool Requirements are accurate and consistent. </j.0:description>
+                <j.2:uniqueIdentifier>T-3-2</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-3-8">
+                <j.0:description>Tool Requirements are traceable to Tool Operational Requirements. </j.0:description>
+                <j.2:uniqueIdentifier>T-3-8</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-3-9">
+                <j.0:description>Algorithms are accurate. </j.0:description>
+                <j.2:uniqueIdentifier>T-3-9</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.1:title>Verification of Outputs of Tool Requirements Processes</j.1:title>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-3-5">
+                <j.0:description>Tool Requirements define user instructions and error messages. </j.0:description>
+                <j.2:uniqueIdentifier>T-3-5</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-3-7">
+                <j.0:description>Tool Requirements conform to Tool Requirements Standards. </j.0:description>
+                <j.2:uniqueIdentifier>T-3-7</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-3-3">
+                <j.0:description>Requirements for compatibility with the tool operational environment are defined. </j.0:description>
+                <j.2:uniqueIdentifier>T-3-3</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-3-6">
+                <j.0:description>Tool Requirements are verifiable. </j.0:description>
+                <j.2:uniqueIdentifier>T-3-6</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+          </j.1:SECTION>
+        </j.2:content>
+        <j.2:content>
+          <j.1:SECTION rdf:ID="T-8">
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-8-5">
+                <j.0:description>Tool life cycle environment control is established. </j.0:description>
+                <j.2:uniqueIdentifier>T-8-5</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-8-4">
+                <j.0:description>Archive, retrieval, and release are established. </j.0:description>
+                <j.2:uniqueIdentifier>T-8-4</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-8-3">
+                <j.0:description>Problem reporting, change control, change review, and configuration status accounting are established. </j.0:description>
+                <j.2:uniqueIdentifier>T-8-3</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-8-2">
+                <j.0:description>Baselines and traceability are established. </j.0:description>
+                <j.2:uniqueIdentifier>T-8-2</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-8-1">
+                <j.0:description>Configuration items are identified. </j.0:description>
+                <j.2:uniqueIdentifier>T-8-1</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.1:title>Tool Configuration Management Process</j.1:title>
+          </j.1:SECTION>
+        </j.2:content>
+        <j.1:title>TOOL QUALIFICATION OBJECTIVES</j.1:title>
+        <j.2:content>
+          <j.1:SECTION rdf:ID="T-6">
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-6-4">
+                <j.0:description>Tool Executable Object Code is robust with low-level tool requirements. </j.0:description>
+                <j.2:uniqueIdentifier>T-6-4</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-6-3">
+                <j.0:description>Tool Executable Object Code complies with low-level tool requirements. </j.0:description>
+                <j.2:uniqueIdentifier>T-6-3</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-6-2">
+                <j.0:description>Tool Executable Object Code is robust with Tool Requirements. </j.0:description>
+                <j.2:uniqueIdentifier>T-6-2</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-6-1">
+                <j.0:description>Tool Executable Object Code complies with Tool Requirements. </j.0:description>
+                <j.2:uniqueIdentifier>T-6-1</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.1:title>Testing of Outputs of Integration Process</j.1:title>
+          </j.1:SECTION>
+        </j.2:content>
+        <j.2:content>
+          <j.1:SECTION rdf:ID="T-4">
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-4-2">
+                <j.0:description>Low-level tool requirements are accurate and consistent. </j.0:description>
+                <j.2:uniqueIdentifier>T-4-2</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-4-7">
+                <j.0:description>Tool architecture is compatible with Tool Requirements. </j.0:description>
+                <j.2:uniqueIdentifier>T-4-7</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-4-3">
+                <j.0:description>Low-level tool requirements are verifiable. </j.0:description>
+                <j.2:uniqueIdentifier>T-4-3</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-4-8">
+                <j.0:description>Tool architecture is consistent. </j.0:description>
+                <j.2:uniqueIdentifier>T-4-8</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-4-6">
+                <j.0:description>Algorithms are accurate. </j.0:description>
+                <j.2:uniqueIdentifier>T-4-6</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-4-10">
+                <j.0:description>Protection mechanisms, if used, are confirmed. </j.0:description>
+                <j.2:uniqueIdentifier>T-4-10</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.1:title>Verification of Outputs of Tool Design Process</j.1:title>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-4-1">
+                <j.0:description>Low-Level Tool requirements comply with Tool Requirements. </j.0:description>
+                <j.2:uniqueIdentifier>T-4-1</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-4-4">
+                <j.0:description>Low-level tool requirements conform to Tool Design Standards. </j.0:description>
+                <j.2:uniqueIdentifier>T-4-4</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-4-9">
+                <j.0:description>Tool architecture conforms to Tool Design Standards. </j.0:description>
+                <j.2:uniqueIdentifier>T-4-9</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-4-11">
+                <j.0:description>External component interface is correctly and completely defined. </j.0:description>
+                <j.2:uniqueIdentifier>T-4-11</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-4-5">
+                <j.0:description>Low-level tool requirements are traceable to Tool Requirements. </j.0:description>
+                <j.2:uniqueIdentifier>T-4-5</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+          </j.1:SECTION>
+        </j.2:content>
+        <j.2:content>
+          <j.1:SECTION rdf:ID="T-1">
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-1-7">
+                <j.0:description>Development and revision of tool plans are coordinated. </j.0:description>
+                <j.2:uniqueIdentifier>T-1-7</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-1-6">
+                <j.0:description>Tool plans comply with this document. </j.0:description>
+                <j.2:uniqueIdentifier>T-1-6</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-1-5">
+                <j.0:description>Tool development standards are defined. </j.0:description>
+                <j.2:uniqueIdentifier>T-1-5</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-1-4">
+                <j.0:description>Additional considerations are addressed. </j.0:description>
+                <j.2:uniqueIdentifier>T-1-4</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-1-3">
+                <j.0:description>Tool development environment is selected and defined. </j.0:description>
+                <j.2:uniqueIdentifier>T-1-3</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-1-2">
+                <j.0:description>Transition criteria, inter-relationships, and sequencing among processes of tool processes are defined. </j.0:description>
+                <j.2:uniqueIdentifier>T-1-2</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.2:content>
+              <j.0:OBJECTIVE rdf:ID="T-1-1">
+                <j.0:description>Tool development and integral processes are defined. </j.0:description>
+                <j.2:uniqueIdentifier>T-1-1</j.2:uniqueIdentifier>
+              </j.0:OBJECTIVE>
+            </j.2:content>
+            <j.1:title>Tool Planning Process</j.1:title>
+          </j.1:SECTION>
+        </j.2:content>
       </j.1:SECTION>
-    </j.1:content>
+    </j.2:content>
     <j.1:approvalAuthority>
       <j.2:AGENT rdf:ID="RTCA"/>
     </j.1:approvalAuthority>

--- a/RACK-Ontology/OwlModels/DOCUMENT.owl
+++ b/RACK-Ontology/OwlModels/DOCUMENT.owl
@@ -18,15 +18,15 @@
   </owl:Ontology>
   <owl:Class rdf:ID="REQUEST">
     <rdfs:comment xml:lang="en">A REQUEST initiates a defined course of action or changed to fulfill a need.</rdfs:comment>
-    <rdfs:subClassOf rdf:resource="PROV-S#ENTITY"/>
+    <rdfs:subClassOf rdf:resource="PROV-S#COLLECTION"/>
   </owl:Class>
   <owl:Class rdf:ID="SECTION">
     <rdfs:comment xml:lang="en">A SECTION is generic grouping of ENTITYs with a document</rdfs:comment>
-    <rdfs:subClassOf rdf:resource="PROV-S#ENTITY"/>
+    <rdfs:subClassOf rdf:resource="PROV-S#COLLECTION"/>
   </owl:Class>
   <owl:Class rdf:ID="DESCRIPTION">
     <rdfs:comment xml:lang="en">A DESCRIPTION represents a planned or actual concept, function, design or object.</rdfs:comment>
-    <rdfs:subClassOf rdf:resource="PROV-S#ENTITY"/>
+    <rdfs:subClassOf rdf:resource="PROV-S#COLLECTION"/>
   </owl:Class>
   <owl:Class rdf:ID="DOC_STATUS">
     <owl:equivalentClass>
@@ -41,19 +41,19 @@
   </owl:Class>
   <owl:Class rdf:ID="REPORT">
     <rdfs:comment xml:lang="en">A REPORT describes the results of activities such as investigations, observations, assessments, or test.</rdfs:comment>
-    <rdfs:subClassOf rdf:resource="PROV-S#ENTITY"/>
+    <rdfs:subClassOf rdf:resource="PROV-S#COLLECTION"/>
   </owl:Class>
   <owl:Class rdf:ID="SPECIFICATION">
     <rdfs:comment xml:lang="en">A SPECIFICATION identifies, in a complete, precise, and verifiable manner, the requirements, design, behavior, or other expected characteristics of a system, service or process.</rdfs:comment>
-    <rdfs:subClassOf rdf:resource="PROV-S#ENTITY"/>
+    <rdfs:subClassOf rdf:resource="PROV-S#COLLECTION"/>
   </owl:Class>
   <owl:Class rdf:ID="PLAN">
     <rdfs:comment xml:lang="en">A PLAN presents a systematic course of action for achieving a declared purpose, including when, how, and by whom specified activities are to be performed. </rdfs:comment>
-    <rdfs:subClassOf rdf:resource="PROV-S#ENTITY"/>
+    <rdfs:subClassOf rdf:resource="PROV-S#COLLECTION"/>
   </owl:Class>
   <owl:Class rdf:ID="PROCEDURE">
     <rdfs:comment xml:lang="en">A PROCEDURE presents an ordered series of steps to perform a process, activity, or task</rdfs:comment>
-    <rdfs:subClassOf rdf:resource="PROV-S#ENTITY"/>
+    <rdfs:subClassOf rdf:resource="PROV-S#COLLECTION"/>
   </owl:Class>
   <owl:ObjectProperty rdf:ID="approvalAuthority">
     <rdfs:domain>
@@ -73,24 +73,6 @@
     <rdfs:subPropertyOf rdf:resource="PROV-S#wasGeneratedBy"/>
     <rdfs:range rdf:resource="PROV-S#AGENT"/>
     <rdfs:domain rdf:resource="#REQUEST"/>
-  </owl:ObjectProperty>
-  <owl:ObjectProperty rdf:ID="content">
-    <rdfs:domain>
-      <owl:Class>
-        <owl:unionOf rdf:parseType="Collection">
-          <owl:Class rdf:about="#DESCRIPTION"/>
-          <owl:Class rdf:about="#PLAN"/>
-          <owl:Class rdf:about="#PROCEDURE"/>
-          <owl:Class rdf:about="#REPORT"/>
-          <owl:Class rdf:about="#REQUEST"/>
-          <owl:Class rdf:about="#SPECIFICATION"/>
-          <owl:Class rdf:about="#SECTION"/>
-        </owl:unionOf>
-      </owl:Class>
-    </rdfs:domain>
-    <rdfs:comment xml:lang="en">Constituent ENTITYs that are contained in a document.</rdfs:comment>
-    <rdfs:range rdf:resource="PROV-S#ENTITY"/>
-    <rdfs:subPropertyOf rdf:resource="PROV-S#hadMember"/>
   </owl:ObjectProperty>
   <owl:ObjectProperty rdf:ID="references">
     <rdfs:domain>

--- a/RACK-Ontology/OwlModels/MIL-STD-881D-AppxA.owl
+++ b/RACK-Ontology/OwlModels/MIL-STD-881D-AppxA.owl
@@ -339,26 +339,26 @@
     <j.2:uniqueIdentifier>DataDeliverables1TonSpecify-1.10.1</j.2:uniqueIdentifier>
   </j.3:SYSTEM>
   <rdf:Description rdf:about="MIL-STD-881D#MIL-STD-881D">
-    <j.1:content>
+    <j.2:content>
       <j.1:SECTION rdf:ID="A.4">
         <j.1:title>DEFINITIONS</j.1:title>
       </j.1:SECTION>
-    </j.1:content>
-    <j.1:content>
+    </j.2:content>
+    <j.2:content>
       <j.1:SECTION rdf:ID="A.3">
         <j.1:title>WORK BREAKDOWN STRUCTURE LEVELS</j.1:title>
       </j.1:SECTION>
-    </j.1:content>
-    <j.1:content>
+    </j.2:content>
+    <j.2:content>
       <j.1:SECTION rdf:ID="A.2">
         <j.1:title>APPLICABLE DOCUMENTS</j.1:title>
       </j.1:SECTION>
-    </j.1:content>
-    <j.1:content>
+    </j.2:content>
+    <j.2:content>
       <j.1:SECTION rdf:ID="A.1">
         <j.1:title>SCOPE</j.1:title>
       </j.1:SECTION>
-    </j.1:content>
+    </j.2:content>
   </rdf:Description>
   <j.3:SYSTEM rdf:ID="CybersecuritySystemsEngineering-1.6.3">
     <j.0:wbs>1.6.3</j.0:wbs>

--- a/RACK-Ontology/OwlModels/MIL-STD-881D-AppxB.owl
+++ b/RACK-Ontology/OwlModels/MIL-STD-881D-AppxB.owl
@@ -306,26 +306,26 @@
     <j.2:uniqueIdentifier>SupportandHandlingEquipmentAirframeHullVehicle-1.8.2.1</j.2:uniqueIdentifier>
   </j.3:SYSTEM>
   <rdf:Description rdf:about="MIL-STD-881D#MIL-STD-881D">
-    <j.1:content>
+    <j.2:content>
       <j.1:SECTION rdf:ID="B.4">
         <j.1:title>DEFINITIONS</j.1:title>
       </j.1:SECTION>
-    </j.1:content>
-    <j.1:content>
+    </j.2:content>
+    <j.2:content>
       <j.1:SECTION rdf:ID="B.3">
         <j.1:title>WORK BREAKDOWN STRUCTURE LEVELS</j.1:title>
       </j.1:SECTION>
-    </j.1:content>
-    <j.1:content>
+    </j.2:content>
+    <j.2:content>
       <j.1:SECTION rdf:ID="B.2">
         <j.1:title>APPLICABLE DOCUMENTS</j.1:title>
       </j.1:SECTION>
-    </j.1:content>
-    <j.1:content>
+    </j.2:content>
+    <j.2:content>
       <j.1:SECTION rdf:ID="B.1">
         <j.1:title>SCOPE</j.1:title>
       </j.1:SECTION>
-    </j.1:content>
+    </j.2:content>
   </rdf:Description>
   <j.3:SYSTEM rdf:ID="SupportandHandlingEquipmentOtherMajorSubsystems1TonSpecify-1.9.2.4">
     <j.0:wbs>1.9.2.4</j.0:wbs>

--- a/RACK-Ontology/OwlModels/MIL-STD-881D-AppxC.owl
+++ b/RACK-Ontology/OwlModels/MIL-STD-881D-AppxC.owl
@@ -409,26 +409,26 @@
     <j.2:uniqueIdentifier>PropulsionIntegrationAssemblyTestandCheckout-1.2.3.1</j.2:uniqueIdentifier>
   </j.3:SYSTEM>
   <rdf:Description rdf:about="MIL-STD-881D#MIL-STD-881D">
-    <j.1:content>
+    <j.2:content>
       <j.1:SECTION rdf:ID="C.4">
         <j.1:title>DEFINITIONS</j.1:title>
       </j.1:SECTION>
-    </j.1:content>
-    <j.1:content>
+    </j.2:content>
+    <j.2:content>
       <j.1:SECTION rdf:ID="C.3">
         <j.1:title>WORK BREAKDOWN STRUCTURE LEVELS</j.1:title>
       </j.1:SECTION>
-    </j.1:content>
-    <j.1:content>
+    </j.2:content>
+    <j.2:content>
       <j.1:SECTION rdf:ID="C.2">
         <j.1:title>APPLICABLE DOCUMENTS</j.1:title>
       </j.1:SECTION>
-    </j.1:content>
-    <j.1:content>
+    </j.2:content>
+    <j.2:content>
       <j.1:SECTION rdf:ID="C.1">
         <j.1:title>SCOPE</j.1:title>
       </j.1:SECTION>
-    </j.1:content>
+    </j.2:content>
   </rdf:Description>
   <j.3:SYSTEM rdf:ID="MissileOrdnanceSystemSoftwareRelease1TonSpecify-1.5">
     <j.0:wbs>1.5</j.0:wbs>

--- a/RACK-Ontology/OwlModels/MIL-STD-881D-AppxD.owl
+++ b/RACK-Ontology/OwlModels/MIL-STD-881D-AppxD.owl
@@ -395,26 +395,26 @@
     <j.2:uniqueIdentifier>Aero-StructuresNon-StageRelated-1.2.2</j.2:uniqueIdentifier>
   </j.3:SYSTEM>
   <rdf:Description rdf:about="MIL-STD-881D#MIL-STD-881D">
-    <j.1:content>
+    <j.2:content>
       <j.1:SECTION rdf:ID="D.4">
         <j.1:title>DEFINITIONS</j.1:title>
       </j.1:SECTION>
-    </j.1:content>
-    <j.1:content>
+    </j.2:content>
+    <j.2:content>
       <j.1:SECTION rdf:ID="D.3">
         <j.1:title>WORK BREAKDOWN STRUCTURE LEVELS</j.1:title>
       </j.1:SECTION>
-    </j.1:content>
-    <j.1:content>
+    </j.2:content>
+    <j.2:content>
       <j.1:SECTION rdf:ID="D.2">
         <j.1:title>APPLICABLE DOCUMENTS</j.1:title>
       </j.1:SECTION>
-    </j.1:content>
-    <j.1:content>
+    </j.2:content>
+    <j.2:content>
       <j.1:SECTION rdf:ID="D.1">
         <j.1:title>SCOPE</j.1:title>
       </j.1:SECTION>
-    </j.1:content>
+    </j.2:content>
   </rdf:Description>
   <j.3:SYSTEM rdf:ID="PropulsionSystem-1.2.5.1.3">
     <j.0:wbs>1.2.5.1.3</j.0:wbs>

--- a/RACK-Ontology/OwlModels/MIL-STD-881D.owl
+++ b/RACK-Ontology/OwlModels/MIL-STD-881D.owl
@@ -1,15 +1,16 @@
 <rdf:RDF
     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-    xmlns:sadlbasemodel="http://sadl.org/sadlbasemodel"
-    xmlns:sys="http://arcos.rack/SYSTEM"
     xmlns:m881D="http://arcos.rack/MIL-STD-881D/MIL-STD-881D#"
     xmlns:D="http://arcos.rack/DOCUMENT"
-    xmlns:owl="http://www.w3.org/2002/07/owl#"
     xmlns:sadlimplicitmodel="http://sadl.org/sadlimplicitmodel"
-    xmlns:builtinfunctions="http://sadl.org/builtinfunctions"
     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
     xmlns:Pr="http://arcos.rack/PROCESS"
     xmlns:j.0="http://arcos.rack/DOCUMENT#"
+    xmlns:sadlbasemodel="http://sadl.org/sadlbasemodel"
+    xmlns:sys="http://arcos.rack/SYSTEM"
+    xmlns:j.1="http://arcos.rack/PROV-S#"
+    xmlns:owl="http://www.w3.org/2002/07/owl#"
+    xmlns:builtinfunctions="http://sadl.org/builtinfunctions"
     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
   xml:base="http://arcos.rack/MIL-STD-881D/MIL-STD-881D">
   <owl:Ontology rdf:about="">
@@ -28,44 +29,44 @@
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
   </owl:FunctionalProperty>
   <j.0:SPECIFICATION rdf:ID="MIL-STD-881D">
-    <j.0:content>
-      <j.0:SECTION rdf:ID="MIL-STD-881D-AppxJ"/>
-    </j.0:content>
-    <j.0:content>
+    <j.1:content>
       <j.0:SECTION rdf:ID="MIL-STD-881D-AppxE"/>
-    </j.0:content>
-    <j.0:content>
+    </j.1:content>
+    <j.1:content>
       <j.0:SECTION rdf:ID="MIL-STD-881D-AppxH"/>
-    </j.0:content>
-    <j.0:content>
+    </j.1:content>
+    <j.1:content>
+      <j.0:SECTION rdf:ID="MIL-STD-881D-AppxB"/>
+    </j.1:content>
+    <j.1:content>
       <j.0:SECTION rdf:ID="MIL-STD-881D-AppxC"/>
-    </j.0:content>
-    <j.0:content>
-      <j.0:SECTION rdf:ID="MIL-STD-881D-AppxF"/>
-    </j.0:content>
-    <j.0:content>
+    </j.1:content>
+    <j.1:content>
       <j.0:SECTION rdf:ID="MIL-STD-881D-AppxK"/>
-    </j.0:content>
-    <j.0:content>
+    </j.1:content>
+    <j.1:content>
+      <j.0:SECTION rdf:ID="MIL-STD-881D-AppxF"/>
+    </j.1:content>
+    <j.1:content>
+      <j.0:SECTION rdf:ID="MIL-STD-881D-AppxL"/>
+    </j.1:content>
+    <j.1:content>
+      <j.0:SECTION rdf:ID="MIL-STD-881D-AppxG"/>
+    </j.1:content>
+    <j.1:content>
       <j.0:SECTION rdf:ID="MIL-STD-881D-AppxA"/>
-    </j.0:content>
-    <j.0:content>
-      <j.0:SECTION rdf:ID="MIL-STD-881D-AppxD"/>
-    </j.0:content>
+    </j.1:content>
     <j.0:dateOfIssue rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
     >2018-04-09</j.0:dateOfIssue>
-    <j.0:content>
-      <j.0:SECTION rdf:ID="MIL-STD-881D-AppxI"/>
-    </j.0:content>
-    <j.0:content>
-      <j.0:SECTION rdf:ID="MIL-STD-881D-AppxL"/>
-    </j.0:content>
     <j.0:status rdf:resource="/DOCUMENT#Released"/>
-    <j.0:content>
-      <j.0:SECTION rdf:ID="MIL-STD-881D-AppxG"/>
-    </j.0:content>
-    <j.0:content>
-      <j.0:SECTION rdf:ID="MIL-STD-881D-AppxB"/>
-    </j.0:content>
+    <j.1:content>
+      <j.0:SECTION rdf:ID="MIL-STD-881D-AppxI"/>
+    </j.1:content>
+    <j.1:content>
+      <j.0:SECTION rdf:ID="MIL-STD-881D-AppxD"/>
+    </j.1:content>
+    <j.1:content>
+      <j.0:SECTION rdf:ID="MIL-STD-881D-AppxJ"/>
+    </j.1:content>
   </j.0:SPECIFICATION>
 </rdf:RDF>

--- a/RACK-Ontology/OwlModels/PROV-S.owl
+++ b/RACK-Ontology/OwlModels/PROV-S.owl
@@ -75,11 +75,6 @@
     <rdfs:range rdf:resource="#ACTIVITY"/>
     <rdfs:domain rdf:resource="#ENTITY"/>
   </owl:ObjectProperty>
-  <owl:ObjectProperty rdf:ID="hadMember">
-    <rdfs:comment xml:lang="en">A collection is an entity that provides a structure to some constituents, which are themselves entities. These constituents are said to be member of the collections.</rdfs:comment>
-    <rdfs:range rdf:resource="#ENTITY"/>
-    <rdfs:domain rdf:resource="#COLLECTION"/>
-  </owl:ObjectProperty>
   <owl:ObjectProperty rdf:about="#field">
     <rdfs:domain rdf:resource="#ATTRIBUTE"/>
     <rdfs:comment xml:lang="en">extensible field</rdfs:comment>
@@ -114,6 +109,11 @@
     <rdfs:comment xml:lang="en">An activity association is an assignment of responsibility to an agent for an activity, indicating that the agent had a role in the activity. It further allows for a plan to be specified, which is the plan intended by the agent to achieve some goals in the context of this activity.</rdfs:comment>
     <rdfs:range rdf:resource="#AGENT"/>
     <rdfs:domain rdf:resource="#ACTIVITY"/>
+  </owl:ObjectProperty>
+  <owl:ObjectProperty rdf:ID="content">
+    <rdfs:comment xml:lang="en">A collection is an entity that provides a structure to some constituents, which are themselves entities. These constituents are said to be member of the collections.</rdfs:comment>
+    <rdfs:range rdf:resource="#ENTITY"/>
+    <rdfs:domain rdf:resource="#COLLECTION"/>
   </owl:ObjectProperty>
   <owl:ObjectProperty rdf:ID="actedOnBehalfOf">
     <rdfs:comment xml:lang="en">Delegation is the assignment of authority and responsibility to an agent (by itself or by another agent) to carry out a specific activity as a delegate or representative, while the agent it acts on behalf of retains some responsibility for the outcome of the delegated work.</rdfs:comment>

--- a/RACK-Ontology/ontology/DOCUMENT.sadl
+++ b/RACK-Ontology/ontology/DOCUMENT.sadl
@@ -4,7 +4,7 @@ import "http://arcos.rack/PROV-S".
 
 
 
-DESCRIPTION (note "A DESCRIPTION represents a planned or actual concept, function, design or object.") is a type of ENTITY.
+DESCRIPTION (note "A DESCRIPTION represents a planned or actual concept, function, design or object.") is a type of COLLECTION.
     dateOfIssue (note "Release date for the document.") describes DESCRIPTION with values of type date.
     
     status (note "Identifies the maturity of the document, In_Development, Released, Withdrawn.") describes DESCRIPTION with values of type DOC_STATUS.
@@ -15,13 +15,7 @@ DESCRIPTION (note "A DESCRIPTION represents a planned or actual concept, functio
     references (note "Source Materials used in the development of a document.") describes DESCRIPTION with values of type ENTITY.
     references is a type of wasDerivedFrom.
 
-    content (note "Constituent ENTITYs that are contained in a document.") describes DESCRIPTION with values of type ENTITY.
-    content is a type of hadMember.
-    
-    
-    
-
-PLAN (note "A PLAN presents a systematic course of action for achieving a declared purpose, including when, how, and by whom specified activities are to be performed. ")is a type of ENTITY.
+PLAN (note "A PLAN presents a systematic course of action for achieving a declared purpose, including when, how, and by whom specified activities are to be performed. ")is a type of COLLECTION.
     dateOfIssue describes PLAN with values of type date.
     
     status describes PLAN with values of type DOC_STATUS.
@@ -35,10 +29,7 @@ PLAN (note "A PLAN presents a systematic course of action for achieving a declar
     references describes PLAN with values of type ENTITY.
     references is a type of wasDerivedFrom.
 
-    content describes PLAN with values of type ENTITY.
-    content is a type of hadMember.
-
-PROCEDURE (note "A PROCEDURE presents an ordered series of steps to perform a process, activity, or task") is a type of ENTITY.
+PROCEDURE (note "A PROCEDURE presents an ordered series of steps to perform a process, activity, or task") is a type of COLLECTION.
     dateOfIssue describes PROCEDURE with values of type date.
     
     status describes PROCEDURE with values of type DOC_STATUS.
@@ -49,10 +40,7 @@ PROCEDURE (note "A PROCEDURE presents an ordered series of steps to perform a pr
     approvalAuthority describes PROCEDURE with values of type AGENT.
     approvalAuthority is a type of wasGeneratedBy.
 
-    content describes PROCEDURE with values of type ENTITY.
-    content is a type of hadMember.
-
-REPORT (note "A REPORT describes the results of activities such as investigations, observations, assessments, or test.") is a type of ENTITY.
+REPORT (note "A REPORT describes the results of activities such as investigations, observations, assessments, or test.") is a type of COLLECTION.
     dateOfIssue describes REPORT with values of type date.
     
     status describes REPORT with values of type DOC_STATUS.
@@ -60,10 +48,7 @@ REPORT (note "A REPORT describes the results of activities such as investigation
     issuingOrganization describes REPORT with values of type AGENT.
     issuingOrganization is a type of wasGeneratedBy.
 
-    content describes REPORT with values of type ENTITY.
-    content is a type of hadMember.
-
-REQUEST (note "A REQUEST initiates a defined course of action or changed to fulfill a need.") is a type of ENTITY.
+REQUEST (note "A REQUEST initiates a defined course of action or changed to fulfill a need.") is a type of COLLECTION.
     dateOfInitiation describes REQUEST with values of type date.
     
     status describes REQUEST with values of type DOC_STATUS.
@@ -71,10 +56,7 @@ REQUEST (note "A REQUEST initiates a defined course of action or changed to fulf
     originatorOfRequest describes REQUEST with values of type AGENT.
     originatorOfRequest is a type of wasGeneratedBy.
 
-    content describes REQUEST with values of type ENTITY.
-    content is a type of hadMember.
-
-SPECIFICATION (note "A SPECIFICATION identifies, in a complete, precise, and verifiable manner, the requirements, design, behavior, or other expected characteristics of a system, service or process.") is a type of ENTITY.
+SPECIFICATION (note "A SPECIFICATION identifies, in a complete, precise, and verifiable manner, the requirements, design, behavior, or other expected characteristics of a system, service or process.") is a type of COLLECTION.
     dateOfIssue describes SPECIFICATION with values of type date.
     
     status describes SPECIFICATION with values of type DOC_STATUS.
@@ -88,14 +70,8 @@ SPECIFICATION (note "A SPECIFICATION identifies, in a complete, precise, and ver
     references describes SPECIFICATION with values of type ENTITY.
     references is a type of wasDerivedFrom.
     
-    content describes SPECIFICATION with values of type ENTITY.
-    content is a type of hadMember.
-    
-SECTION (note "A SECTION is generic grouping of ENTITYs with a document") is a type of ENTITY.
+SECTION (note "A SECTION is generic grouping of ENTITYs with a document") is a type of COLLECTION.
 
-	title describes SECTION with values of type string.
-
-    content describes SECTION with values of type ENTITY.
-    content is a type of hadMember.    
+	title describes SECTION with values of type string.  
 
 DOC_STATUS is a class, must be one of {In_Development, Released, Withdrawn}.

--- a/RACK-Ontology/ontology/PROV-S.sadl
+++ b/RACK-Ontology/ontology/PROV-S.sadl
@@ -16,7 +16,7 @@ ENTITY (note "An entity is a physical, digital, conceptual, or other kind of thi
 
 COLLECTION (note "A collection is an entity that provides a structure to some constituents, which are themselves entities. These constituents are said to be member of the collections.")
     is a type of ENTITY.
-	hadMember (note "A collection is an entity that provides a structure to some constituents, which are themselves entities. These constituents are said to be member of the collections.") describes COLLECTION with values of type ENTITY.
+	content (note "A collection is an entity that provides a structure to some constituents, which are themselves entities. These constituents are said to be member of the collections.") describes COLLECTION with values of type ENTITY.
 
 AGENT (note "An agent is something that bears some form of responsibility for an activity taking place, for the existence of an entity, or for another agent's activity.")
     is a type of THING.


### PR DESCRIPTION
Previously content was a subtype of hadMember which meant that every instance of a document with content was implicitly an instance of collection with no further distinctions being made about the things being contained.

If we are planning on further subtyping these documents it where they are going to have multiple subtypes of content then it would probably make sense to reintroduce the content subtypes at that point.

Fixes #147 