### PR TITLE
ci: Lint the ontology using the Prolog tooling

### DIFF
--- a/.github/workflows/rack-continuous.yaml
+++ b/.github/workflows/rack-continuous.yaml
@@ -49,3 +49,14 @@ jobs:
           cd RACK-Ontology/cli
           pylint .
           mypy .
+
+      - shell: bash
+        name: Lint the ontology
+        continue-on-error: true
+        run: |
+          sudo apt-add-repository ppa:swi-prolog/stable
+          sudo apt-get update -qq --yes
+          sudo apt-get install -qq --yes swi-prolog
+
+          cd RACK-Ontology
+          ./assist/bin/check


### PR DESCRIPTION
For now, this doesn't cause any fatal errors. In a follow-up, we should concurrently:

- Extend the tool to exit with a nonzero status when it emits warnings
- Fix all the errors