### PR TITLE
Promote FILE to be a top-level sadl file, add fileParent

### DIFF
--- a/RACK-Ontology/OwlModels/CounterApplication.owl
+++ b/RACK-Ontology/OwlModels/CounterApplication.owl
@@ -11,17 +11,19 @@
     xmlns:sys="http://arcos.rack/SYSTEM#"
     xmlns:owl="http://www.w3.org/2002/07/owl#"
     xmlns:trnstl="http://TurnstileSystem/Turnstiles#"
+    xmlns:file="http://arcos.rack/FILE#"
     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
   xml:base="http://TurnstileSystem/CounterApplication">
   <owl:Ontology rdf:about="">
+    <owl:imports rdf:resource="http://sadl.org/sadlbasemodel"/>
     <owl:imports rdf:resource="Turnstiles"/>
     <owl:imports rdf:resource="http://arcos.rack/SOFTWARE"/>
-    <owl:imports rdf:resource="http://arcos.rack/SYSTEM"/>
-    <owl:imports rdf:resource="http://arcos.rack/AGENTS"/>
-    <owl:imports rdf:resource="http://sadl.org/builtinfunctions"/>
     <owl:imports rdf:resource="http://sadl.org/sadlimplicitmodel"/>
-    <owl:imports rdf:resource="http://sadl.org/sadlbasemodel"/>
     <rdfs:comment xml:lang="en">This ontology was created from a SADL file 'CounterApplication.sadl' and should not be directly edited.</rdfs:comment>
+    <owl:imports rdf:resource="http://arcos.rack/SYSTEM"/>
+    <owl:imports rdf:resource="http://sadl.org/builtinfunctions"/>
+    <owl:imports rdf:resource="http://arcos.rack/FILE"/>
+    <owl:imports rdf:resource="http://arcos.rack/AGENTS"/>
   </owl:Ontology>
   <sys:SYSTEM rdf:ID="ExecutiveThread">
     <sys:partOf rdf:resource="Turnstiles#CounterApplication"/>
@@ -45,35 +47,35 @@
     <j.0:identifier>InputThread</j.0:identifier>
     <j.0:dataInsertedBy rdf:resource="#Mockup"/>
   </sys:SYSTEM>
-  <sw:FORMAT rdf:ID="RpmFile">
+  <file:FORMAT rdf:ID="RpmFile">
     <j.0:dataInsertedBy rdf:resource="#Mockup"/>
     <j.0:identifier>FORMAT-RpmFile</j.0:identifier>
     <rdfs:comment xml:lang="en">RedHat Package Manager archive</rdfs:comment>
-  </sw:FORMAT>
+  </file:FORMAT>
   <sw:COMPONENT rdf:ID="main_function">
     <sw:definedIn>
-      <sw:FILE rdf:ID="counter_c">
-        <sw:fileFormat>
-          <sw:FORMAT rdf:ID="CSourceFile">
+      <file:FILE rdf:ID="counter_c">
+        <file:fileFormat>
+          <file:FORMAT rdf:ID="CSourceFile">
             <j.0:dataInsertedBy rdf:resource="#Mockup"/>
             <j.0:identifier>FORMAT-CSourceFile</j.0:identifier>
             <rdfs:comment xml:lang="en">A C language source file</rdfs:comment>
-          </sw:FORMAT>
-        </sw:fileFormat>
+          </file:FORMAT>
+        </file:fileFormat>
         <j.0:dataInsertedBy rdf:resource="#Mockup"/>
-        <sw:filename>counter.c</sw:filename>
+        <file:filename>counter.c</file:filename>
         <j.0:identifier>counter_c</j.0:identifier>
-      </sw:FILE>
+      </file:FILE>
     </sw:definedIn>
     <sw:controlFlowsToUnconditionally>
       <sw:COMPONENT rdf:ID="output_function">
         <sw:definedIn>
-          <sw:FILE rdf:ID="output_c">
-            <sw:fileFormat rdf:resource="#CSourceFile"/>
+          <file:FILE rdf:ID="output_c">
+            <file:fileFormat rdf:resource="#CSourceFile"/>
             <j.0:dataInsertedBy rdf:resource="#Mockup"/>
-            <sw:filename>output.c</sw:filename>
+            <file:filename>output.c</file:filename>
             <j.0:identifier>output_c</j.0:identifier>
-          </sw:FILE>
+          </file:FILE>
         </sw:definedIn>
         <sw:valueType>void()</sw:valueType>
         <sw:name>output</sw:name>
@@ -85,12 +87,12 @@
     <sw:controlFlowsToUnconditionally>
       <sw:COMPONENT rdf:ID="input_function">
         <sw:definedIn>
-          <sw:FILE rdf:ID="input_c">
-            <sw:fileFormat rdf:resource="#CSourceFile"/>
+          <file:FILE rdf:ID="input_c">
+            <file:fileFormat rdf:resource="#CSourceFile"/>
             <j.0:dataInsertedBy rdf:resource="#Mockup"/>
-            <sw:filename>input.c</sw:filename>
+            <file:filename>input.c</file:filename>
             <j.0:identifier>input_c</j.0:identifier>
-          </sw:FILE>
+          </file:FILE>
         </sw:definedIn>
         <sw:valueType>void()</sw:valueType>
         <sw:name>input</sw:name>
@@ -105,98 +107,98 @@
     <sw:componentType rdf:resource="http://arcos.rack/SOFTWARE#SOURCE_FUNCTION"/>
     <j.0:identifier>main_function</j.0:identifier>
   </sw:COMPONENT>
-  <sw:FORMAT rdf:ID="ZipFile">
+  <file:FORMAT rdf:ID="ZipFile">
     <j.0:dataInsertedBy rdf:resource="#Mockup"/>
     <j.0:identifier>FORMAT-ZipFile</j.0:identifier>
     <rdfs:comment xml:lang="en">Compressed file archive</rdfs:comment>
-  </sw:FORMAT>
-  <sw:FILE rdf:ID="dist_tar">
-    <sw:fileFormat>
-      <sw:FORMAT rdf:ID="TarFile">
+  </file:FORMAT>
+  <file:FILE rdf:ID="dist_tar">
+    <file:fileFormat>
+      <file:FORMAT rdf:ID="TarFile">
         <j.0:dataInsertedBy rdf:resource="#Mockup"/>
         <j.0:identifier>FORMAT-TarFile</j.0:identifier>
         <rdfs:comment xml:lang="en">File archive</rdfs:comment>
-      </sw:FORMAT>
-    </sw:fileFormat>
+      </file:FORMAT>
+    </file:fileFormat>
     <j.0:wasGeneratedBy>
       <sw:PACKAGE rdf:ID="tarPackaging">
         <sw:packageInput>
-          <sw:FILE rdf:ID="counter_exe">
-            <sw:fileFormat>
-              <sw:FORMAT rdf:ID="ElfFile">
+          <file:FILE rdf:ID="counter_exe">
+            <file:fileFormat>
+              <file:FORMAT rdf:ID="ElfFile">
                 <j.0:dataInsertedBy rdf:resource="#Mockup"/>
                 <j.0:identifier>FORMAT-ElfFile</j.0:identifier>
                 <rdfs:comment xml:lang="en">ELF object, shared-object, executable</rdfs:comment>
-              </sw:FORMAT>
-            </sw:fileFormat>
-            <sw:createBy>
+              </file:FORMAT>
+            </file:fileFormat>
+            <file:createBy>
               <sw:COMPILE rdf:ID="counter_exe_Compiling">
                 <sw:compileInput>
-                  <sw:FILE rdf:ID="counter_h">
-                    <sw:fileFormat rdf:resource="#CSourceFile"/>
+                  <file:FILE rdf:ID="counter_h">
+                    <file:fileFormat rdf:resource="#CSourceFile"/>
                     <j.0:dataInsertedBy rdf:resource="#Mockup"/>
-                    <sw:filename>counter.h</sw:filename>
+                    <file:filename>counter.h</file:filename>
                     <j.0:identifier>counter_h</j.0:identifier>
-                  </sw:FILE>
+                  </file:FILE>
                 </sw:compileInput>
                 <sw:compileInput rdf:resource="#counter_c"/>
                 <sw:compileInput>
-                  <sw:FILE rdf:ID="libhw_so">
-                    <sw:fileFormat rdf:resource="#ElfFile"/>
-                    <sw:createBy>
+                  <file:FILE rdf:ID="libhw_so">
+                    <file:fileFormat rdf:resource="#ElfFile"/>
+                    <file:createBy>
                       <sw:COMPILE rdf:ID="libhw_so_Compiling">
                         <sw:compileInput>
-                          <sw:FILE rdf:ID="hw_o">
-                            <sw:fileFormat rdf:resource="#ElfFile"/>
-                            <sw:createBy>
+                          <file:FILE rdf:ID="hw_o">
+                            <file:fileFormat rdf:resource="#ElfFile"/>
+                            <file:createBy>
                               <sw:COMPILE rdf:ID="hw_o_Compiling">
                                 <sw:compileInput>
-                                  <sw:FILE rdf:ID="hw_h">
-                                    <sw:fileFormat rdf:resource="#CSourceFile"/>
+                                  <file:FILE rdf:ID="hw_h">
+                                    <file:fileFormat rdf:resource="#CSourceFile"/>
                                     <j.0:dataInsertedBy rdf:resource="#Mockup"/>
-                                    <sw:filename>hw.h</sw:filename>
+                                    <file:filename>hw.h</file:filename>
                                     <j.0:identifier>hw_h</j.0:identifier>
-                                  </sw:FILE>
+                                  </file:FILE>
                                 </sw:compileInput>
                                 <sw:compileInput>
-                                  <sw:FILE rdf:ID="hw_c">
-                                    <sw:fileFormat rdf:resource="#CSourceFile"/>
+                                  <file:FILE rdf:ID="hw_c">
+                                    <file:fileFormat rdf:resource="#CSourceFile"/>
                                     <j.0:dataInsertedBy rdf:resource="#Mockup"/>
-                                    <sw:filename>hw.c</sw:filename>
+                                    <file:filename>hw.c</file:filename>
                                     <j.0:identifier>hw_c</j.0:identifier>
-                                  </sw:FILE>
+                                  </file:FILE>
                                 </sw:compileInput>
                                 <sw:compiledBy>
-                                  <sw:FILE rdf:ID="cc">
+                                  <file:FILE rdf:ID="cc">
                                     <j.0:dataInsertedBy rdf:resource="#Mockup"/>
-                                    <sw:fileFormat rdf:resource="#ElfFile"/>
-                                    <sw:filename>cc</sw:filename>
+                                    <file:fileFormat rdf:resource="#ElfFile"/>
+                                    <file:filename>cc</file:filename>
                                     <j.0:identifier>cc</j.0:identifier>
-                                  </sw:FILE>
+                                  </file:FILE>
                                 </sw:compiledBy>
                                 <j.0:dataInsertedBy rdf:resource="#Mockup"/>
                                 <j.0:identifier>hw_o_Compiling</j.0:identifier>
                               </sw:COMPILE>
-                            </sw:createBy>
+                            </file:createBy>
                             <j.0:dataInsertedBy rdf:resource="#Mockup"/>
-                            <sw:filename>hw.o</sw:filename>
+                            <file:filename>hw.o</file:filename>
                             <j.0:identifier>hw_o</j.0:identifier>
-                          </sw:FILE>
+                          </file:FILE>
                         </sw:compileInput>
                         <sw:compiledBy rdf:resource="#cc"/>
                         <j.0:dataInsertedBy rdf:resource="#Mockup"/>
                         <j.0:identifier>libhw_so_Compiling</j.0:identifier>
                       </sw:COMPILE>
-                    </sw:createBy>
+                    </file:createBy>
                     <j.0:dataInsertedBy rdf:resource="#Mockup"/>
-                    <sw:filename>libhw.so</sw:filename>
+                    <file:filename>libhw.so</file:filename>
                     <j.0:identifier>libhw_so</j.0:identifier>
-                  </sw:FILE>
+                  </file:FILE>
                 </sw:compileInput>
                 <sw:compileInput>
-                  <sw:FILE rdf:ID="output_o">
-                    <sw:fileFormat rdf:resource="#ElfFile"/>
-                    <sw:createBy>
+                  <file:FILE rdf:ID="output_o">
+                    <file:fileFormat rdf:resource="#ElfFile"/>
+                    <file:createBy>
                       <sw:COMPILE rdf:ID="output_o_Compiling">
                         <j.0:hasAttribute>
                           <j.0:ATTRIBUTE>
@@ -216,88 +218,88 @@
                         </j.0:hasAttribute>
                         <sw:compiledBy rdf:resource="#cc"/>
                         <sw:compileInput>
-                          <sw:FILE rdf:ID="output_h">
-                            <sw:fileFormat rdf:resource="#CSourceFile"/>
+                          <file:FILE rdf:ID="output_h">
+                            <file:fileFormat rdf:resource="#CSourceFile"/>
                             <j.0:dataInsertedBy rdf:resource="#Mockup"/>
-                            <sw:filename>output.h</sw:filename>
+                            <file:filename>output.h</file:filename>
                             <j.0:identifier>output_h</j.0:identifier>
-                          </sw:FILE>
+                          </file:FILE>
                         </sw:compileInput>
                         <sw:compileInput rdf:resource="#output_c"/>
                         <j.0:dataInsertedBy rdf:resource="#Mockup"/>
                         <j.0:identifier>output_o_Compiling</j.0:identifier>
                       </sw:COMPILE>
-                    </sw:createBy>
+                    </file:createBy>
                     <j.0:dataInsertedBy rdf:resource="#Mockup"/>
-                    <sw:filename>output.o</sw:filename>
+                    <file:filename>output.o</file:filename>
                     <j.0:identifier>output_o</j.0:identifier>
-                  </sw:FILE>
+                  </file:FILE>
                 </sw:compileInput>
                 <sw:compileInput>
-                  <sw:FILE rdf:ID="input_o">
-                    <sw:fileFormat rdf:resource="#ElfFile"/>
-                    <sw:createBy>
+                  <file:FILE rdf:ID="input_o">
+                    <file:fileFormat rdf:resource="#ElfFile"/>
+                    <file:createBy>
                       <sw:COMPILE rdf:ID="input_o_Compiling">
                         <sw:compileInput>
-                          <sw:FILE rdf:ID="input_h">
-                            <sw:fileFormat rdf:resource="#CSourceFile"/>
+                          <file:FILE rdf:ID="input_h">
+                            <file:fileFormat rdf:resource="#CSourceFile"/>
                             <j.0:dataInsertedBy rdf:resource="#Mockup"/>
-                            <sw:filename>input.h</sw:filename>
+                            <file:filename>input.h</file:filename>
                             <j.0:identifier>input_h</j.0:identifier>
-                          </sw:FILE>
+                          </file:FILE>
                         </sw:compileInput>
                         <sw:compileInput rdf:resource="#input_c"/>
                         <sw:compiledBy rdf:resource="#cc"/>
                         <j.0:dataInsertedBy rdf:resource="#Mockup"/>
                         <j.0:identifier>input_o_Compiling</j.0:identifier>
                       </sw:COMPILE>
-                    </sw:createBy>
+                    </file:createBy>
                     <j.0:dataInsertedBy rdf:resource="#Mockup"/>
-                    <sw:filename>input.o</sw:filename>
+                    <file:filename>input.o</file:filename>
                     <j.0:identifier>input_o</j.0:identifier>
-                  </sw:FILE>
+                  </file:FILE>
                 </sw:compileInput>
                 <sw:compiledBy rdf:resource="#cc"/>
                 <j.0:dataInsertedBy rdf:resource="#Mockup"/>
                 <j.0:identifier>counter_exe_Compiling</j.0:identifier>
               </sw:COMPILE>
-            </sw:createBy>
+            </file:createBy>
             <j.0:dataInsertedBy rdf:resource="#Mockup"/>
-            <sw:filename>counter.exe</sw:filename>
+            <file:filename>counter.exe</file:filename>
             <j.0:identifier>counter_exe</j.0:identifier>
-          </sw:FILE>
+          </file:FILE>
         </sw:packageInput>
         <sw:packageInput rdf:resource="#libhw_so"/>
         <sw:packageInput>
-          <sw:FILE rdf:ID="conf_json">
-            <sw:fileFormat>
-              <sw:FORMAT rdf:ID="JsonFile">
+          <file:FILE rdf:ID="conf_json">
+            <file:fileFormat>
+              <file:FORMAT rdf:ID="JsonFile">
                 <j.0:dataInsertedBy rdf:resource="#Mockup"/>
                 <j.0:identifier>FORMAT-JsonFile</j.0:identifier>
                 <rdfs:comment xml:lang="en">JSON data</rdfs:comment>
-              </sw:FORMAT>
-            </sw:fileFormat>
+              </file:FORMAT>
+            </file:fileFormat>
             <j.0:dataInsertedBy rdf:resource="#Mockup"/>
-            <sw:filename>conf.json</sw:filename>
+            <file:filename>conf.json</file:filename>
             <j.0:identifier>conf_json</j.0:identifier>
-          </sw:FILE>
+          </file:FILE>
         </sw:packageInput>
         <sw:packagedBy>
-          <sw:FILE rdf:ID="tar">
+          <file:FILE rdf:ID="tar">
             <j.0:dataInsertedBy rdf:resource="#Mockup"/>
-            <sw:fileFormat rdf:resource="#ElfFile"/>
-            <sw:filename>tar</sw:filename>
+            <file:fileFormat rdf:resource="#ElfFile"/>
+            <file:filename>tar</file:filename>
             <j.0:identifier>tar</j.0:identifier>
-          </sw:FILE>
+          </file:FILE>
         </sw:packagedBy>
         <j.0:dataInsertedBy rdf:resource="#Mockup"/>
         <j.0:identifier>tarPackaging</j.0:identifier>
       </sw:PACKAGE>
     </j.0:wasGeneratedBy>
     <j.0:dataInsertedBy rdf:resource="#Mockup"/>
-    <sw:filename>dist.tar</sw:filename>
+    <file:filename>dist.tar</file:filename>
     <j.0:identifier>dist_tar</j.0:identifier>
-  </sw:FILE>
+  </file:FILE>
   <sys:SYSTEM rdf:ID="OutputThread">
     <sys:partOf rdf:resource="Turnstiles#CounterApplication"/>
     <j.0:identifier>OutputThread</j.0:identifier>
@@ -305,20 +307,20 @@
   </sys:SYSTEM>
   <sw:COMPILE rdf:ID="test_exe_Compiling">
     <sw:compileInput>
-      <sw:FILE rdf:ID="test_h">
-        <sw:fileFormat rdf:resource="#CSourceFile"/>
+      <file:FILE rdf:ID="test_h">
+        <file:fileFormat rdf:resource="#CSourceFile"/>
         <j.0:dataInsertedBy rdf:resource="#Mockup"/>
-        <sw:filename>test.h</sw:filename>
+        <file:filename>test.h</file:filename>
         <j.0:identifier>test_h</j.0:identifier>
-      </sw:FILE>
+      </file:FILE>
     </sw:compileInput>
     <sw:compileInput>
-      <sw:FILE rdf:ID="test_c">
-        <sw:fileFormat rdf:resource="#CSourceFile"/>
+      <file:FILE rdf:ID="test_c">
+        <file:fileFormat rdf:resource="#CSourceFile"/>
         <j.0:dataInsertedBy rdf:resource="#Mockup"/>
-        <sw:filename>test.c</sw:filename>
+        <file:filename>test.c</file:filename>
         <j.0:identifier>test_c</j.0:identifier>
-      </sw:FILE>
+      </file:FILE>
     </sw:compileInput>
     <sw:compiledBy rdf:resource="#cc"/>
     <j.0:dataInsertedBy rdf:resource="#Mockup"/>

--- a/RACK-Ontology/models/TurnstileSystem/CounterApplication.sadl
+++ b/RACK-Ontology/models/TurnstileSystem/CounterApplication.sadl
@@ -14,6 +14,7 @@ uri "http://TurnstileSystem/CounterApplication" alias trnstlsys.
 import "http://arcos.rack/AGENTS".
 import "http://arcos.rack/SYSTEM".
 import "http://arcos.rack/SOFTWARE".
+import "http://arcos.rack/FILE".
 import "http://TurnstileSystem/Turnstiles".
 
 Galois is an ORGANIZATION

--- a/RACK-Ontology/ontology/FILE.sadl
+++ b/RACK-Ontology/ontology/FILE.sadl
@@ -1,0 +1,47 @@
+/* Copyright (c) 2020, General Electric Company, Galois, Inc.
+ *
+ * All Rights Reserved
+ *
+ * This material is based upon work supported by the Defense Advanced Research
+ * Projects Agency (DARPA) under Contract No. FA8750-20-C-0203.
+ *
+ * Any opinions, findings and conclusions or recommendations expressed in this
+ * material are those of the author(s) and do not necessarily reflect the views
+ * of the Defense Advanced Research Projects Agency (DARPA).
+ */
+
+uri "http://arcos.rack/FILE" alias file.
+import "http://arcos.rack/PROV-S".
+
+fileParent (note "The file an ENTITY is defined in") describes ENTITY with values of type FILE.
+
+FILE
+    (note "A file in the system")
+	is a type of ENTITY.
+	filename (note "A logical file path relative to the container of the file.") describes FILE with values of type string.
+
+	fileFormat (note "The byte-level encoding of a file") describes FILE with values of type FORMAT.
+
+    satisfies (note "ENTITY(s) (e.g. REQUIREMENT) that this code file participates in satisfying") describes FILE with values of type ENTITY.
+    satisfies is a type of wasDerivedFrom.
+
+    createBy (note "FILE_CREATION ACTIVITY that created this file") describes FILE with values of type FILE_CREATION.
+    createBy is a type of wasGeneratedBy.
+    
+    fileHash (note "Hash of the file contents") describes FILE with values of type FILE_HASH.
+
+FORMAT
+    (note "The data format of a FILE")
+    is a type of THING.
+
+FILE_CREATION
+   (note "An ACTIVITY that produces a FILE")
+   is a type of ACTIVITY.
+
+FILE_HASH
+    (note "A hash identifying a FILE")
+    is a type of THING,
+    described by hashType  with a single value of type HASH_TYPE,
+    described by hashValue with a single value of type string.
+
+HASH_TYPE is a type of THING, must be one of { MD5, SHA1, SHA2_256, SHA2_512 }.

--- a/RACK-Ontology/ontology/SOFTWARE.sadl
+++ b/RACK-Ontology/ontology/SOFTWARE.sadl
@@ -12,27 +12,7 @@
 
 uri "http://arcos.rack/SOFTWARE" alias sw.
 import "http://arcos.rack/PROV-S".
-
-FILE
-    (note "A file in the system")
-	is a type of ENTITY.
-	filename (note "A logical file path relative to the container of the file.") describes FILE with values of type string.
-
-	fileFormat (note "The byte-level encoding of a file") describes FILE with values of type FORMAT.
-
-    satisfies (note "ENTITY(s) (e.g. REQUIREMENT) that this code file participates in satisfying") describes FILE with values of type ENTITY.
-    satisfies is a type of wasDerivedFrom.
-
-    createBy (note "FILE_CREATION ACTIVITY that created this file") describes FILE with values of type FILE_CREATION.
-    createBy is a type of wasGeneratedBy.
-
-FORMAT
-    (note "The data format of a FILE")
-    is a type of THING.
-
-FILE_CREATION
-   (note "An ACTIVITY that produces a FILE")
-   is a type of ACTIVITY.
+import "http://arcos.rack/FILE".
 
 CODE_DEVELOPMENT
 	(note "An ACTIVITY that produces source code FILEs")


### PR DESCRIPTION
fileParent provides a way to specify the file that any entity in
the system is contained within. This will allow us to tie software,
executables, reports, documents, etc back to concrete files.
Files themselves might be contained in other archive files.