### PR TITLE
ci: Lint every branch, not just master

### DIFF
--- a/.github/workflows/rack-continuous.yaml
+++ b/.github/workflows/rack-continuous.yaml
@@ -1,12 +1,7 @@
 # Lints the RACK source
 
 name: RACK continous lint
-
-on:
-  pull_request:
-    branches: [ master ]
-  push:
-    branches: [ master ]
+on: [push]
 
 jobs:
   lint:


### PR DESCRIPTION
It's nice to have CI feedback on branches other than master, for instance so you
can know if the linters will fail before making a pull request and requesting a
review.

There's little downside, because the linting step is very fast.