### PR TITLE
Reinstate documentation on how to use `act`

### DIFF
--- a/.github/workflows/rack-continuous.yaml
+++ b/.github/workflows/rack-continuous.yaml
@@ -11,7 +11,8 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Lint shell scripts with ShellCheck
-        uses: ludeeus/action-shellcheck@master
+        # This action is composite on master which `act` can't yet handle.
+        uses: ludeeus/action-shellcheck@fcee962fee3f87888d7992ab0560232aef368e89
         env:
           SHELLCHECK_OPTS: -e SC1008
         with:

--- a/rack-box/README.md
+++ b/rack-box/README.md
@@ -157,3 +157,46 @@ changes, etc.
 Note that creating a GitHub release tags the RACK repo automatically,
 but we need to manually tag the RACK wiki with the same tag in advance
 since its pages must go into the rack-box image too.
+
+## Using `act` to Run CI Locally
+
+The [`act`][act] tool can be used to run (an
+approximation of) the Github Actions workflow locally:
+
+- Download a binary release of Packer for Ubuntu, and place the `packer`
+  executable in the `rack-box/` directory.
+- Install `act`
+- Generate a Github [personal access token][PAT] (PAT)
+- Create a `.secrets` file containing `GITHUB_TOKEN=<your-github-PAT-here>`
+- Run `act --secret-file .secrets -P ubuntu-latest=nektos/act-environments-ubuntu:18.04`
+
+The Docker image `nektos/act-environments-ubuntu:18.04` is quite large
+(approximately 18GB), so (1) you'll need enough free disk space to store it and
+(2) the first execution of `act` takes a while because it downloads this image.
+
+Only the "lint" job can be run this way, `act`
+[does not yet support Ubuntu 20.04](https://github.com/nektos/act-environments/issues/4).
+
+### Troubleshooting
+
+#### "volume is in use"
+
+If you see a message like this:
+```
+Error: Error response from daemon: remove act-Build-Lint-shell-scripts-and-the-RACK-CLI: volume is in use
+```
+You can forcibly stop and remove the `act` Docker containers and their volumes:
+```bash
+docker stop $(docker ps -a | grep "nektos/act-environments-ubuntu:18.04" | awk '{print $1}')
+docker rm $(docker ps -a | grep "nektos/act-environments-ubuntu:18.04" | awk '{print $1}')
+docker volume rm $(docker volume ls --filter dangling=true | grep -o -E "act-.+$")
+```
+There may also be a more precise solution to this issue, but the above works.
+
+#### "permission denied while trying to connect to the Docker daemon socket"
+
+`act` needs to be run with enough privileges to run Docker containers. Try
+`sudo -g docker act ...` (or an equivalent invocation for your OS/distro).
+
+[act]: (https://github.com/nektos/act)
+[PAT]: https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token


### PR DESCRIPTION
I accidentally left this out of #181. Not sure if we are still in a code freeze, otherwise I would probably just push this to `master` since it's already been there.