### PR TITLE
ci: Always build RACK-box image, only publish from master branch

### DIFF
--- a/.github/workflows/rack-box-continuous.yml
+++ b/.github/workflows/rack-box-continuous.yml
@@ -5,9 +5,7 @@
 
 name: RACK-in-a-Box continous build
 
-on:
-  push:
-    branches: [ master ]
+on: [push]
 
 jobs:
   build:
@@ -115,10 +113,12 @@ jobs:
         packer build -var version=dev rack-box-docker.json
 
     - name: Login to Docker Hub
+      if: github.base_ref == 'master'
       uses: docker/login-action@v1
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     - name: Push rack-box image to Docker Hub
+      if: github.base_ref == 'master'
       run: docker push interran/rack-box:dev


### PR DESCRIPTION
Same reasoning as #190. The trade-off is a bit different here, in that the `build` job takes ~8min instead of the ~2min that the `lint` job. This will get even slower as we add tests (see issues linked from #104). However, I think it's really valuable to have an "always green" main branch, and having the tests run on PRs is a good way to accomplish this. An "always green" main branch makes tools like `git bisect` more helpful, in that the build and tests can be expected to pass on every commit. Additionally, if the branch you release from is always green, it makes it easier to produce reliable hotfix releases: you will only have to fix the bug you want to address, and not whatever else happens to be causing a CI failure.