### PR TITLE
Test RACK-box in CI with Pytest

### DIFF
--- a/.github/workflows/rack-box-continuous.yml
+++ b/.github/workflows/rack-box-continuous.yml
@@ -85,7 +85,7 @@ jobs:
         python3 setup.py --quiet install
         find venv/bin -type f | xargs perl -p -i -e 's|${{ github.workspace }}|/home/ubuntu|g'
         cd ${{ github.workspace }}
-        tar cfz RACK/rack-box/files/rack.tar.gz --exclude=.git --exclude=.github --exclude=rack-box --exclude=tools RACK
+        tar cfz RACK/rack-box/files/rack.tar.gz --exclude=.git --exclude=.github --exclude=rack-box --exclude=tests --exclude=tools RACK
 
     - name: Generate RACK documentation
       if: steps.cache-rack-doc.outputs.cache-hit != 'true'
@@ -111,6 +111,23 @@ jobs:
       run: |
         cd RACK/rack-box
         packer build -var version=dev rack-box-docker.json
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Install RACK CLI
+      run: |
+        cd RACK/RACK-Ontology/cli
+        python3 -m pip install -r requirements.txt
+        python3 setup.py --quiet install
+
+    - name: Test rack-box image
+      run: |
+        cd RACK
+        python3 -m pip install -r tests/requirements.txt
+        pytest tests
 
     - name: Login to Docker Hub
       if: github.base_ref == 'master'

--- a/.github/workflows/rack-continuous.yaml
+++ b/.github/workflows/rack-continuous.yaml
@@ -47,6 +47,13 @@ jobs:
           mypy .
 
       - shell: bash
+        name: Lint the RACK-box test suite
+        run: |
+          cd tests
+          pylint .
+          mypy .
+
+      - shell: bash
         name: Lint the ontology
         continue-on-error: true
         run: |

--- a/rack-box/README.md
+++ b/rack-box/README.md
@@ -87,7 +87,7 @@ pip3 install -r requirements.txt
 python3 setup.py --quiet install
 find venv/bin -type f | xargs perl -p -i -e "s|$HOME|/home/ubuntu|g"
 cd $HOME
-tar cfz RACK/rack-box/files/rack.tar.gz --exclude=.git --exclude=.github --exclude=rack-box --exclude=tools RACK
+tar cfz RACK/rack-box/files/rack.tar.gz --exclude=.git --exclude=.github --exclude=rack-box --exclude=tests --exclude=tools RACK
 ```
 
 The reason for the find | xargs commands is to allow the isolated

--- a/tests/.pylintrc
+++ b/tests/.pylintrc
@@ -1,0 +1,54 @@
+[MASTER]
+
+ignore=.git
+jobs=0
+suggestion-mode=yes
+
+[MESSAGES CONTROL]
+
+disable=all
+enable=bad-format-character,
+       bad-format-string-key,
+       bad-open-mode,
+       bad-string-format-type,
+       consider-using-get,
+       consider-using-join,
+       empty-docstring,
+       function-redefined,
+       not-in-loop,
+       redefined-builtin,
+       return-in-init,
+       too-few-format-args,
+       too-many-format-args,
+       truncated-format-string,
+       unnecessary-comprehension,
+       unused-argument,
+       unreachable,
+       unused-format-string-argument,
+       unused-format-string-key,
+       unused-import,
+       unused-variable,
+       using-constant-test
+
+[REPORTS]
+
+output-format=text
+reports=no
+score=no
+
+[BASIC]
+
+argument-naming-style=snake_case
+attr-naming-style=snake_case
+class-naming-style=PascalCase
+const-naming-style=UPPER_CASE
+function-naming-style=snake_case
+include-naming-hint=yes
+inlinevar-naming-style=snake_case
+method-naming-style=snake_case
+module-naming-style=snake_case
+variable-naming-style=snake_case
+
+[VARIABLES]
+
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,9 @@
+# RACK Tests
+
+This directory contains tests of the RACK-Box Docker image. These tests are driven by `pytest` and are run in CI.
+
+To run them locally, first [install the RACK CLI](../RACK-Ontology/cli), then (with that virtual environment active) run
+```bash
+python3 -m pip --use-feature=2020-resolver install -r tests/requirements.txt
+pytest
+```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2020, General Electric Company and Galois, Inc.
+"""Pytest fixtures and configuration"""
+
+import pytest
+
+from time import sleep
+
+import requests
+from semtk3 import set_host
+
+
+def check(url: str) -> bool:
+    try:
+        response = requests.post(url + ":12059/serviceInfo/ping")
+        return "yes" in response.text
+    except Exception as e:
+        print(e)
+        return False
+
+
+@pytest.fixture(scope="session")
+def rack_in_a_box(docker_ip, docker_services) -> str:  # type: ignore
+    """Ensure that RACK-in-a-box is up and responsive."""
+    url = "http://{}".format(docker_ip)
+    set_host(url)
+    # TODO(lb): For some reason, check_services always returns false.
+    # docker_services.wait_until_responsive(
+    #     timeout=240.0, pause=0.1, check=lambda: check_services()
+    # )
+    docker_services.wait_until_responsive(
+        timeout=240.0, pause=1.0, check=lambda: check(url)
+    )
+    sleep(20)
+    return url

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,0 +1,9 @@
+---
+version: '2'
+services:
+  rack:
+    image: "interran/rack-box:dev"
+    ports:
+      - "80:8000"
+      - "3030:3030"
+      - "12050-12092:12050-12092"

--- a/tests/mypy.ini
+++ b/tests/mypy.ini
@@ -1,0 +1,8 @@
+[mypy]
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+ignore_missing_imports = True
+no_implicit_optional = True
+warn_redundant_casts = True
+warn_unused_configs = True
+warn_unused_ignores = True

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,3 @@
+pytest==5.4.3
+pytest-docker==0.8
+requests==2.24.0

--- a/tests/test_invariant_nodegroups.py
+++ b/tests/test_invariant_nodegroups.py
@@ -1,0 +1,12 @@
+import pytest
+
+import semtk3
+import rack
+
+
+@pytest.mark.xfail(reason="See discussion on RACK#193")
+def test_invariant_nodegroups(rack_in_a_box: str) -> None:
+    # There is some duplication here with rack.run_count_query, but not a lot.
+    semtk3.SEMTK3_CONN_OVERRIDE = rack.sparql_connection(rack_in_a_box, rack.DEFAULT_DATA_GRAPH, None)
+    semtk_table = semtk3.count_by_id("query nonuniqueIdentifiers")
+    assert 0 == int(semtk_table.get_rows()[0][0])


### PR DESCRIPTION
This PR creates a directory in which we can stash tests we want to run against RACK-box. As an example, this includes tests mentioned in #193.

Remaining TODOs:

- [ ] Should pass :smile: 
- [x] Run Mypy, pylint on the test Python code
- [x] Exclude `tests/` directory from the RACK tarball that is fed to Packer