### PR TITLE
ci: Install RACK on the Github Actions runner, test with Pytest

### DIFF
--- a/.github/workflows/rack-box-continuous.yml
+++ b/.github/workflows/rack-box-continuous.yml
@@ -70,7 +70,7 @@ jobs:
         tar cfz RACK/rack-box/files/rack-cli.tar.gz RACK/cli/{setup-rack.sh,wheels}
 
     - name: Package RACK ontology and data
-      run: tar cfz RACK/rack-box/files/rack.tar.gz --exclude=.git --exclude=.github --exclude=assist --exclude=cli --exclude=rack-box --exclude=tools RACK
+      run: tar cfz RACK/rack-box/files/rack.tar.gz --exclude=.git --exclude=.github --exclude=assist --exclude=cli --exclude=rack-box --exclude=tools --exclude=tests RACK
 
     - name: Check out RACK wiki
       uses: actions/checkout@v2

--- a/.github/workflows/rack-box-release.yml
+++ b/.github/workflows/rack-box-release.yml
@@ -90,7 +90,7 @@ jobs:
         tar cfz RACK/rack-box/files/rack-cli.tar.gz RACK/cli/{setup-rack.sh,wheels}
 
     - name: Package RACK ontology and data
-      run: tar cfz RACK/rack-box/files/rack.tar.gz --exclude=.git --exclude=.github --exclude=assist --exclude=cli --exclude=rack-box --exclude=tools RACK
+      run: tar cfz RACK/rack-box/files/rack.tar.gz --exclude=.git --exclude=.github --exclude=assist --exclude=cli --exclude=rack-box --exclude=tools --exclude=tests RACK
 
     - name: Check out RACK wiki
       uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,76 @@
+name: Test RACK
+
+on:
+  pull_request:
+    branches: [ '*' ]
+  push:
+    branches: [ '*' ]
+    tags-ignore: [ '*' ]
+
+jobs:
+  test:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Check out RACK source
+      uses: actions/checkout@v2
+      with:
+        repository: ge-high-assurance/RACK
+        token: ${{ secrets.RACK_CI_PAT }}
+        path: RACK
+
+    - name: Download Fuseki distribution
+      if: steps.cache-fuseki.outputs.cache-hit != 'true'
+      run: curl -LSs https://apache.claz.org/jena/binaries/apache-jena-fuseki-3.16.0.tar.gz -o RACK/rack-box/files/fuseki.tar.gz
+
+    - name: Download SemTK distribution
+      run: curl -LSs https://github.com/ge-semtk/semtk/releases/download/v2.3.0-20201103/semtk-opensource-v2.3.0-20201103-dist.tar.gz -o RACK/rack-box/files/semtk.tar.gz
+
+    - name: Cache RACK CLI dependencies
+      uses: actions/cache@v2
+      with:
+        # This path is specific to Ubuntu
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('RACK/cli/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+          ${{ runner.os }}-
+
+    - name: Package RACK CLI
+      run: |
+        cd RACK/cli
+        python3 -m pip install --upgrade pip setuptools wheel
+        python3 -m pip wheel --wheel-dir=wheels -r requirements.txt
+        python3 -m pip wheel --wheel-dir=wheels .
+        cd ${{ github.workspace }}
+        tar cfz RACK/rack-box/files/rack-cli.tar.gz RACK/cli/{setup-rack.sh,wheels}
+
+    - name: Package RACK ontology and data
+      run: |
+        tar cfz RACK/rack-box/files/rack.tar.gz --exclude=.git --exclude=.github --exclude=assist --exclude=cli --exclude=rack-box --exclude=tests --exclude=tools RACK
+
+    - name: Download SemTK distribution
+      if: steps.cache-semtk.outputs.cache-hit != 'true'
+      run: curl -LSs 'https://oss.sonatype.org/service/local/artifact/maven/content?r=snapshots&g=com.ge.research.semtk&a=distribution&v=2.2.2-SNAPSHOT&c=bin&e=tar.gz' -o RACK/rack-box/files/semtk.tar.gz
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    - name: Install RACK
+      run: |
+        cd RACK/rack-box
+        touch ./files/{documentation.html,index.html,style.css,systemctl3.py}
+        mkdir -p /tmp/files
+        for f in ./files/*; do
+          ln -s $(realpath ${f}) /tmp/files/$(basename ${f})
+        done
+        sudo bash ./scripts/install.sh ${USER}
+
+    - name: Run tests
+      run: |
+        cd RACK
+        python3 -m pip install cli/wheels/*.whl
+        python3 -m pip install -r tests/requirements.txt
+        python3 -m pytest tests

--- a/rack-box/README.md
+++ b/rack-box/README.md
@@ -37,7 +37,7 @@ subdirectory before building your rack-box images:
 - `files/rack.tar.gz`: A copy of the RACK ontology and data (clone
   this repo and run `tar cfz RACK/rack-box/files/rack.tar.gz
   --exclude=.git --exclude=.github --exclude=assist --exclude=cli
-  --exclude=rack-box --exclude=tools RACK`)
+  --exclude=rack-box --exclude=tools --exclude=tests RACK`)
 
 - `files/documentation.html`: RACK documentation (clone RACK.wiki, run
   `gwtc -t RACK-in-a-Box RACK.wiki/` using [Github Wikito
@@ -91,7 +91,7 @@ pip3 wheel --wheel-dir=wheels -r requirements.txt
 pip3 wheel --wheel-dir=wheels .
 python3 -m pip install ./wheels/*.whl
 cd $HOME
-tar cfz RACK/rack-box/files/rack-cli.tar.gz RACK/RACK-Ontology/cli/{setup-rack.sh,wheels}
+tar cfz RACK/rack-box/files/rack-cli.tar.gz RACK/cli/{setup-rack.sh,wheels}
 ```
 
 ## Build the rack-box images

--- a/rack-box/scripts/install.sh
+++ b/rack-box/scripts/install.sh
@@ -3,7 +3,7 @@
 # Exit if anything goes wrong
 
 set -eo pipefail
-export USER=ubuntu
+export USER=${1:-ubuntu}
 cd /tmp/files
 
 # Execute this part of the script only if we're building a Docker image
@@ -26,22 +26,23 @@ if [ "${PACKER_BUILDER_TYPE}" == "docker" ]; then
 
     # Create user
 
-    adduser --disabled-password --gecos '' $USER
+    adduser --disabled-password --gecos '' "${USER}"
 
 fi
 
 # Unpack Fuseki, RACK, and SemTK distributions
 
+mkdir -p "/home/${USER}"
 tar xfzC fuseki.tar.gz /opt
 rm fuseki.tar.gz
 mv /opt/apache-jena-fuseki-3.16.0 /opt/fuseki
-tar xfzC rack.tar.gz /home/${USER}
+tar xfzC rack.tar.gz "/home/${USER}"
 rm rack.tar.gz
-tar xfzC rack-cli.tar.gz /home/${USER}
+tar xfzC rack-cli.tar.gz "/home/${USER}"
 rm rack-cli.tar.gz
-tar xfzC semtk.tar.gz /home/${USER}
+tar xfzC semtk.tar.gz "/home/${USER}"
 rm semtk.tar.gz
-mv ENV_OVERRIDE /home/${USER}/semtk-opensource
+mv ENV_OVERRIDE "/home/${USER}/semtk-opensource"
 
 # Set up and start Fuseki system service
 
@@ -54,7 +55,7 @@ systemctl start fuseki
 
 # Initialize SemTK environment variables
 
-cd /home/${USER}/semtk-opensource
+cd "/home/${USER}/semtk-opensource"
 chmod 755 ./*.sh
 export SERVER_ADDRESS=localhost
 export SERVICE_HOST=localhost
@@ -76,13 +77,14 @@ done
 # Install the RACK landing page and SemTK webapps
 
 export WEBAPPS=/var/www/html
-./updateWebapps.sh ${WEBAPPS}
-mv /tmp/files/{documentation.html,index.html,style.css} ${WEBAPPS}
+mkdir -p "${WEBAPPS}"
+./updateWebapps.sh "${WEBAPPS}"
+mv /tmp/files/{documentation.html,index.html,style.css} "${WEBAPPS}"
 
 # Change file ownerships since all SemTK code runs as non-root ${USER}
 
-chown -R ${USER}.${USER} /home/${USER}
-chown -R ${USER}.${USER} ${WEBAPPS}
+chown -R "${USER}.${USER}" "/home/${USER}"
+chown -R "${USER}.${USER}" "${WEBAPPS}"
 
 # Wait for Fuseki to become ready
 
@@ -130,6 +132,6 @@ done
 
 # Setup the RACK dataset using the RACK CLI
 
-cd /home/${USER}/RACK/cli/
+cd "/home/${USER}/RACK/cli/"
 python3 -m pip install ./wheels/*.whl
 ./setup-rack.sh

--- a/tests/.pylintrc
+++ b/tests/.pylintrc
@@ -1,0 +1,54 @@
+[MASTER]
+
+ignore=.git
+jobs=0
+suggestion-mode=yes
+
+[MESSAGES CONTROL]
+
+disable=all
+enable=bad-format-character,
+       bad-format-string-key,
+       bad-open-mode,
+       bad-string-format-type,
+       consider-using-get,
+       consider-using-join,
+       empty-docstring,
+       function-redefined,
+       not-in-loop,
+       redefined-builtin,
+       return-in-init,
+       too-few-format-args,
+       too-many-format-args,
+       truncated-format-string,
+       unnecessary-comprehension,
+       unused-argument,
+       unreachable,
+       unused-format-string-argument,
+       unused-format-string-key,
+       unused-import,
+       unused-variable,
+       using-constant-test
+
+[REPORTS]
+
+output-format=text
+reports=no
+score=no
+
+[BASIC]
+
+argument-naming-style=snake_case
+attr-naming-style=snake_case
+class-naming-style=PascalCase
+const-naming-style=UPPER_CASE
+function-naming-style=snake_case
+include-naming-hint=yes
+inlinevar-naming-style=snake_case
+method-naming-style=snake_case
+module-naming-style=snake_case
+variable-naming-style=snake_case
+
+[VARIABLES]
+
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,9 @@
+# RACK Tests
+
+This directory contains tests of the RACK-Box Docker image. These tests are driven by `pytest` and are run in CI.
+
+To run them locally, first [install the RACK CLI](../RACK-Ontology/cli), then (with that virtual environment active) run
+```bash
+python3 -m pip --use-feature=2020-resolver install -r tests/requirements.txt
+pytest
+```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2020, General Electric Company and Galois, Inc.
+"""Pytest fixtures and configuration"""
+
+import pytest
+
+from time import sleep
+from os import getenv
+
+import requests
+from semtk3 import set_host
+
+
+def check(url: str) -> bool:
+    try:
+        response = requests.post(url + ":12059/serviceInfo/ping")
+        return "yes" in response.text
+    except Exception as e:
+        print(e)
+        return False
+
+
+TIMEOUT = 240.0
+PAUSE = 1.0
+AFTER = 20
+
+
+if getenv("RACK_BOX_FIXTURE") is not None:
+
+    @pytest.fixture(scope="session")
+    def rack_url(docker_ip, docker_services) -> str:  # type: ignore
+        """Ensure that RACK-in-a-box is up and responsive."""
+        url = "http://{}".format(docker_ip)
+        set_host(url)
+        # TODO(lb): For some reason, check_services always returns false.
+        # docker_services.wait_until_responsive(
+        #     timeout=240.0, pause=0.1, check=lambda: check_services()
+        # )
+        docker_services.wait_until_responsive(
+            timeout=TIMEOUT, pause=PAUSE, check=lambda: check(url)
+        )
+        sleep(AFTER)
+        return url
+
+else:
+
+    @pytest.fixture(scope="session")
+    def rack_url() -> str:
+        """Ensure that RACK-in-a-box is up and responsive."""
+        url = "http://localhost"
+        set_host(url)
+        counter = 0
+        while not check(url):
+            if counter > TIMEOUT:
+                break
+            sleep(PAUSE)
+            counter += 1
+        sleep(AFTER)
+        return url

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,0 +1,9 @@
+---
+version: '2'
+services:
+  rack:
+    image: "interran/rack-box:dev"
+    ports:
+      - "80:8000"
+      - "3030:3030"
+      - "12050-12092:12050-12092"

--- a/tests/mypy.ini
+++ b/tests/mypy.ini
@@ -1,0 +1,8 @@
+[mypy]
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+ignore_missing_imports = True
+no_implicit_optional = True
+warn_redundant_casts = True
+warn_unused_configs = True
+warn_unused_ignores = True

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,3 @@
+pytest==5.4.3
+pytest-docker==0.8
+requests==2.24.0

--- a/tests/test_invariant_nodegroups.py
+++ b/tests/test_invariant_nodegroups.py
@@ -1,0 +1,12 @@
+import pytest
+
+import semtk3
+import rack
+
+
+@pytest.mark.xfail(reason="See discussion on RACK#193")
+def test_invariant_nodegroups(rack_url: str) -> None:
+    # There is some duplication here with rack.run_count_query, but not a lot.
+    semtk3.SEMTK3_CONN_OVERRIDE = rack.sparql_connection(rack_url, rack.DEFAULT_DATA_GRAPH, None)
+    semtk_table = semtk3.count_by_id("query nonuniqueIdentifiers")
+    assert 0 == int(semtk_table.get_rows()[0][0])


### PR DESCRIPTION
Based on #201, but with tests run natively on the Actions runner. Fixes #204.

There is a speed-up over the strategy in #201 (first build the RACK-box image, then run it, and run tests against it).

- The installation step takes ~6:30 in Packer/Docker, and only ~3:40 on the Github Actions runner.
- We also don't have to cache, download, or build documentation files, saving a few seconds
- This method only waits for the SemTK services to start up once, not twice (saving ~1min or so)

It's possible that we would see more of a speed up if we used Docker's layering system more agressively, but this would come with an additional maintenance burden.

One remaining concern is whether the tests would always report the same results when run against the Github runner as they would when run on the official RACK-Box image. I plan to address this by running scheduled CI jobs that run the same test suite against the RACK-Box container (you can see the seeds of that in the `conftest.py` file in this PR).