### PR TITLE
Tweak RACK CI workflows

### DIFF
--- a/.github/workflows/rack-box-continuous.yml
+++ b/.github/workflows/rack-box-continuous.yml
@@ -7,7 +7,7 @@ name: RACK-in-a-Box continous build
 
 on:
   pull_request:
-    branches: [ master ]
+    branches: [ '*' ]
   push:
     branches: [ '*' ]
     tags-ignore: [ '*' ]
@@ -85,12 +85,12 @@ jobs:
         packer build -var version=dev rack-box-docker.json
 
     - name: Login to Docker Hub
-      if: github.base_ref == 'master'
+      if: github.base_ref == 'master' && github.event_name == 'push'
       uses: docker/login-action@v1
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     - name: Push rack-box image to Docker Hub
-      if: github.base_ref == 'master'
+      if: github.base_ref == 'master' && github.event_name == 'push'
       run: docker push gehighassurance/rack-box:dev

--- a/.github/workflows/rack-box-continuous.yml
+++ b/.github/workflows/rack-box-continuous.yml
@@ -1,11 +1,14 @@
-# Builds a Docker image upon each push to master:
+# Builds a Docker image upon every push (while ignoring tag-only pushes):
 #  - Caches files needed to build rack-box images
 #  - Builds rack-box:dev Docker image
 #  - Pushes rack-box:dev image to Docker Hub
 
 name: RACK-in-a-Box continous build
 
-on: [push]
+on:
+  push:
+    branches: [ '*' ]
+    tags-ignore: [ '*' ]
 
 jobs:
   build:

--- a/.github/workflows/rack-box-continuous.yml
+++ b/.github/workflows/rack-box-continuous.yml
@@ -6,6 +6,8 @@
 name: RACK-in-a-Box continous build
 
 on:
+  pull_request:
+    branches: [ master ]
   push:
     branches: [ '*' ]
     tags-ignore: [ '*' ]

--- a/.github/workflows/rack-box-continuous.yml
+++ b/.github/workflows/rack-box-continuous.yml
@@ -49,10 +49,16 @@ jobs:
       with:
         # This path is specific to Ubuntu
         path: ~/.cache/pip
+        # Look to see if there is a cache hit for the corresponding requirements file
         key: ${{ runner.os }}-pip-${{ hashFiles('RACK/cli/requirements.txt') }}
         restore-keys: |
           ${{ runner.os }}-pip-
           ${{ runner.os }}-
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
 
     - name: Package RACK CLI
       run: |

--- a/.github/workflows/rack-box-continuous.yml
+++ b/.github/workflows/rack-box-continuous.yml
@@ -63,6 +63,7 @@ jobs:
     - name: Package RACK CLI
       run: |
         cd RACK/cli
+        python3 -m pip install --upgrade pip setuptools wheel
         pip3 wheel --wheel-dir=wheels -r requirements.txt
         pip3 wheel --wheel-dir=wheels .
         cd ${{ github.workspace }}

--- a/.github/workflows/rack-box-continuous.yml
+++ b/.github/workflows/rack-box-continuous.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.x'
+        python-version: 3.8
 
     - name: Package RACK CLI
       run: |

--- a/.github/workflows/rack-box-continuous.yml
+++ b/.github/workflows/rack-box-continuous.yml
@@ -22,13 +22,6 @@ jobs:
         token: ${{ secrets.RACK_CI_PAT }}
         path: RACK
 
-    - name: Check out RACK wiki
-      uses: actions/checkout@v2
-      with:
-        repository: ge-high-assurance/RACK.wiki
-        token: ${{ secrets.RACK_CI_PAT }}
-        path: RACK.wiki
-
     - name: Cache Fuseki distribution
       uses: actions/cache@v2
       id: cache-fuseki
@@ -36,15 +29,20 @@ jobs:
         path: RACK/rack-box/files/fuseki.tar.gz
         key: fuseki-3.16.0
 
-    - name: Cache RACK CLI
-      uses: actions/cache@v2
-      id: cache-rack-cli
-      with:
-        path: RACK/rack-box/files/rack-cli.tar.gz
-        key: rack-cli-${{ hashFiles('RACK/cli/**') }}
+    - name: Download Fuseki distribution
+      if: steps.cache-fuseki.outputs.cache-hit != 'true'
+      run: curl -LSs https://apache.claz.org/jena/binaries/apache-jena-fuseki-3.16.0.tar.gz -o RACK/rack-box/files/fuseki.tar.gz
+
+    - name: Download SemTK distribution
+      run: curl -LSs https://github.com/ge-semtk/semtk/releases/download/v2.3.0-20201103/semtk-opensource-v2.3.0-20201103-dist.tar.gz -o RACK/rack-box/files/semtk.tar.gz
+
+    - name: Download style spreadsheet
+      run: curl -LSs https://github.com/KrauseFx/markdown-to-html-github-style/raw/master/style.css -o RACK/rack-box/files/style.css
+
+    - name: Download systemctl script
+      run: curl -LSs https://github.com/gdraheim/docker-systemctl-replacement/raw/v1.5.4260/files/docker/systemctl3.py -o RACK/rack-box/files/systemctl3.py
 
     - name: Cache RACK CLI dependencies
-      if: steps.cache-rack-cli.outputs.cache-hit != 'true'
       uses: actions/cache@v2
       with:
         # This path is specific to Ubuntu
@@ -54,49 +52,7 @@ jobs:
           ${{ runner.os }}-pip-
           ${{ runner.os }}-
 
-    - name: Cache RACK ontology and data
-      uses: actions/cache@v2
-      id: cache-rack-ontology
-      with:
-        path: RACK/rack-box/files/rack.tar.gz
-        key: rack-ontology-${{ hashFiles('RACK/RACK-Ontology/**', 'RACK/nodegroups/**') }}
-
-    - name: Cache RACK documentation
-      uses: actions/cache@v2
-      id: cache-rack-doc
-      with:
-        path: |
-          RACK/rack-box/files/documentation.html
-          RACK/rack-box/files/index.html
-        key: rack-doc-${{ hashFiles('RACK.wiki/*.md') }}
-
-    - name: Cache SemTK distribution
-      uses: actions/cache@v2
-      id: cache-semtk
-      with:
-        path: RACK/rack-box/files/semtk.tar.gz
-        key: semtk-2.2.2-SNAPSHOT-v3
-
-    - name: Cache style spreadsheet
-      uses: actions/cache@v2
-      id: cache-style
-      with:
-        path: RACK/rack-box/files/style.css
-        key: style-db9e23f
-
-    - name: Cache systemctl script
-      uses: actions/cache@v2
-      id: cache-systemctl
-      with:
-        path: RACK/rack-box/files/systemctl3.py
-        key: systemctl-1.5.4260
-
-    - name: Download Fuseki distribution
-      if: steps.cache-fuseki.outputs.cache-hit != 'true'
-      run: curl -LSs https://apache.claz.org/jena/binaries/apache-jena-fuseki-3.16.0.tar.gz -o RACK/rack-box/files/fuseki.tar.gz
-
     - name: Package RACK CLI
-      if: steps.cache-rack-cli.outputs.cache-hit != 'true'
       run: |
         cd RACK/cli
         pip3 wheel --wheel-dir=wheels -r requirements.txt
@@ -105,29 +61,21 @@ jobs:
         tar cfz RACK/rack-box/files/rack-cli.tar.gz RACK/cli/{setup-rack.sh,wheels}
 
     - name: Package RACK ontology and data
-      if: steps.cache-rack-ontology.outputs.cache-hit != 'true'
-      run: |
-        tar cfz RACK/rack-box/files/rack.tar.gz --exclude=.git --exclude=.github --exclude=assist --exclude=cli --exclude=rack-box --exclude=tools RACK
+      run: tar cfz RACK/rack-box/files/rack.tar.gz --exclude=.git --exclude=.github --exclude=assist --exclude=cli --exclude=rack-box --exclude=tools RACK
+
+    - name: Check out RACK wiki
+      uses: actions/checkout@v2
+      with:
+        repository: ge-high-assurance/RACK.wiki
+        token: ${{ secrets.RACK_CI_PAT }}
+        path: RACK.wiki
 
     - name: Generate RACK documentation
-      if: steps.cache-rack-doc.outputs.cache-hit != 'true'
       run: |
         sudo npm install -g github-wikito-converter markdown-to-html
         gwtc -t RACK-in-a-Box RACK.wiki
         markdown -t RACK-in-a-box -s style.css RACK.wiki/Welcome.md > index.html
         mv documentation.html index.html RACK/rack-box/files
-
-    - name: Download SemTK distribution
-      if: steps.cache-semtk.outputs.cache-hit != 'true'
-      run: curl -LSs 'https://oss.sonatype.org/service/local/artifact/maven/content?r=snapshots&g=com.ge.research.semtk&a=distribution&v=2.2.2-SNAPSHOT&c=bin&e=tar.gz' -o RACK/rack-box/files/semtk.tar.gz
-
-    - name: Download style spreadsheet
-      if: steps.cache-style.outputs.cache-hit != 'true'
-      run: curl -LSs https://github.com/KrauseFx/markdown-to-html-github-style/raw/master/style.css -o RACK/rack-box/files/style.css
-
-    - name: Download systemctl script
-      if: steps.cache-systemctl.outputs.cache-hit != 'true'
-      run: curl -LSs https://github.com/gdraheim/docker-systemctl-replacement/raw/v1.5.4260/files/docker/systemctl3.py -o RACK/rack-box/files/systemctl3.py
 
     - name: Build rack-box image
       run: |
@@ -143,4 +91,4 @@ jobs:
 
     - name: Push rack-box image to Docker Hub
       if: github.base_ref == 'master'
-      run: docker push interran/rack-box:dev
+      run: docker push gehighassurance/rack-box:dev

--- a/.github/workflows/rack-box-release.yml
+++ b/.github/workflows/rack-box-release.yml
@@ -69,10 +69,16 @@ jobs:
       with:
         # This path is specific to Ubuntu
         path: ~/.cache/pip
+        # Look to see if there is a cache hit for the corresponding requirements file
         key: ${{ runner.os }}-pip-${{ hashFiles('RACK/cli/requirements.txt') }}
         restore-keys: |
           ${{ runner.os }}-pip-
           ${{ runner.os }}-
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
 
     - name: Package RACK CLI
       run: |

--- a/.github/workflows/rack-box-release.yml
+++ b/.github/workflows/rack-box-release.yml
@@ -83,6 +83,7 @@ jobs:
     - name: Package RACK CLI
       run: |
         cd RACK/cli
+        python3 -m pip install --upgrade pip setuptools wheel
         pip3 wheel --wheel-dir=wheels -r requirements.txt
         pip3 wheel --wheel-dir=wheels .
         cd ${{ github.workspace }}

--- a/.github/workflows/rack-box-release.yml
+++ b/.github/workflows/rack-box-release.yml
@@ -78,7 +78,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.x'
+        python-version: 3.8
 
     - name: Package RACK CLI
       run: |

--- a/.github/workflows/rack-box-release.yml
+++ b/.github/workflows/rack-box-release.yml
@@ -139,9 +139,9 @@ jobs:
       run:
         shell: ${{ matrix.shell }}
 
-# Unfortunately, ubuntu-latest can't run virtualbox (VT-x is not
-# available: VERR_VMK_NO_VMX) and windows-latest can't run Hyper-V
-# https://github.com/actions/virtual-environments/issues/183#issuecomment-706244929
+    # Unfortunately, ubuntu-latest can't run virtualbox (VT-x is not
+    # available: VERR_VMK_NO_VMX) and windows-latest can't run Hyper-V
+    # https://github.com/actions/virtual-environments/issues/183#issuecomment-706244929
 
     strategy:
       fail-fast: false
@@ -218,7 +218,7 @@ jobs:
         path: RACK/rack-box/packer_cache/e30b34e4d3c536763868a42bb9d5b8f14af297b8.iso
         key: ubuntu-20.04.1
 
-# Doesn't work on windows-latest (nested virtualization is unsupported)
+    # Doesn't work on windows-latest (nested virtualization is unsupported)
     - name: Enable Hyper-V
       if: matrix.builder == 'hyperv' && matrix.os == 'windows-latest'
       shell: powershell
@@ -226,7 +226,7 @@ jobs:
         Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Hyper-V -All
         Add-WindowsFeature RSAT-Hyper-V-Tools -IncludeAllSubFeature
 
-# Doesn't work on ubuntu-20.04 (nested virtualization is unsupported)
+    # Doesn't work on ubuntu-20.04 (nested virtualization is unsupported)
     - name: Install VirtualBox
       if: matrix.builder == 'virtualbox' && matrix.os == 'ubuntu-20.04'
       run: sudo apt-get install -y virtualbox

--- a/.github/workflows/rack-box-release.yml
+++ b/.github/workflows/rack-box-release.yml
@@ -11,8 +11,29 @@ on:
     types: [ published ]
 
 jobs:
-  setup:
-    runs-on: ubuntu-20.04
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+# docker works on all, but ubuntu is cheapest
+        - builder: docker
+          os: ubuntu-20.04
+          shell: bash
+# hyperv isn't supported yet (https://github.com/actions/virtual-environments/issues/183#issuecomment-706244929)
+#        - builder: hyperv
+#          os: windows-latest
+#          shell: msys2 {0}
+# virtualbox works only on macos (VT-x is not available: VERR_VMK_NO_VMX)
+        - builder: virtualbox
+          os: macos-latest
+          shell: bash
+
+    name: build ${{ matrix.builder }} ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: ${{ matrix.shell }}
 
     steps:
     - name: Check out RACK source
@@ -23,14 +44,6 @@ jobs:
         token: ${{ secrets.RACK_CI_PAT }}
         path: RACK
 
-    - name: Check out RACK wiki
-      uses: actions/checkout@v2
-      with:
-        repository: ge-high-assurance/RACK.wiki
-        ref: ${{ github.event.release.tag_name }}
-        token: ${{ secrets.RACK_CI_PAT }}
-        path: RACK.wiki
-
     - name: Cache Fuseki distribution
       uses: actions/cache@v2
       id: cache-fuseki
@@ -38,15 +51,20 @@ jobs:
         path: RACK/rack-box/files/fuseki.tar.gz
         key: fuseki-3.16.0
 
-    - name: Cache RACK CLI
-      uses: actions/cache@v2
-      id: cache-rack-cli
-      with:
-        path: RACK/rack-box/files/rack-cli.tar.gz
-        key: rack-cli-${{ hashFiles('RACK/cli/**') }}
+    - name: Download Fuseki distribution
+      if: steps.cache-fuseki.outputs.cache-hit != 'true'
+      run: curl -LSs https://apache.claz.org/jena/binaries/apache-jena-fuseki-3.16.0.tar.gz -o RACK/rack-box/files/fuseki.tar.gz
+
+    - name: Download SemTK distribution
+      run: curl -LSs https://github.com/ge-semtk/semtk/releases/download/v2.3.0-20201103/semtk-opensource-v2.3.0-20201103-dist.tar.gz -o RACK/rack-box/files/semtk.tar.gz
+
+    - name: Download style spreadsheet
+      run: curl -LSs https://github.com/KrauseFx/markdown-to-html-github-style/raw/master/style.css -o RACK/rack-box/files/style.css
+
+    - name: Download systemctl script
+      run: curl -LSs https://github.com/gdraheim/docker-systemctl-replacement/raw/v1.5.4260/files/docker/systemctl3.py -o RACK/rack-box/files/systemctl3.py
 
     - name: Cache RACK CLI dependencies
-      if: steps.cache-rack-cli.outputs.cache-hit != 'true'
       uses: actions/cache@v2
       with:
         # This path is specific to Ubuntu
@@ -56,49 +74,7 @@ jobs:
           ${{ runner.os }}-pip-
           ${{ runner.os }}-
 
-    - name: Cache RACK ontology and data
-      uses: actions/cache@v2
-      id: cache-rack-ontology
-      with:
-        path: RACK/rack-box/files/rack.tar.gz
-        key: rack-ontology-${{ hashFiles('RACK/RACK-Ontology/**', 'RACK/nodegroups/**') }}
-
-    - name: Cache RACK documentation
-      uses: actions/cache@v2
-      id: cache-rack-doc
-      with:
-        path: |
-          RACK/rack-box/files/documentation.html
-          RACK/rack-box/files/index.html
-        key: rack-doc-${{ hashFiles('RACK.wiki/*.md') }}
-
-    - name: Cache SemTK distribution
-      uses: actions/cache@v2
-      id: cache-semtk
-      with:
-        path: RACK/rack-box/files/semtk.tar.gz
-        key: semtk-2.2.2-SNAPSHOT-v3
-
-    - name: Cache style spreadsheet
-      uses: actions/cache@v2
-      id: cache-style
-      with:
-        path: RACK/rack-box/files/style.css
-        key: style-db9e23f
-
-    - name: Cache systemctl script
-      uses: actions/cache@v2
-      id: cache-systemctl
-      with:
-        path: RACK/rack-box/files/systemctl3.py
-        key: systemctl-1.5.4260
-
-    - name: Download Fuseki distribution
-      if: steps.cache-fuseki.outputs.cache-hit != 'true'
-      run: curl -LSs https://apache.claz.org/jena/binaries/apache-jena-fuseki-3.16.0.tar.gz -o RACK/rack-box/files/fuseki.tar.gz
-
     - name: Package RACK CLI
-      if: steps.cache-rack-cli.outputs.cache-hit != 'true'
       run: |
         cd RACK/cli
         pip3 wheel --wheel-dir=wheels -r requirements.txt
@@ -107,108 +83,35 @@ jobs:
         tar cfz RACK/rack-box/files/rack-cli.tar.gz RACK/cli/{setup-rack.sh,wheels}
 
     - name: Package RACK ontology and data
-      if: steps.cache-rack-ontology.outputs.cache-hit != 'true'
-      run: |
-        tar cfz RACK/rack-box/files/rack.tar.gz --exclude=.git --exclude=.github --exclude=assist --exclude=cli --exclude=rack-box --exclude=tools RACK
+      run: tar cfz RACK/rack-box/files/rack.tar.gz --exclude=.git --exclude=.github --exclude=assist --exclude=cli --exclude=rack-box --exclude=tools RACK
+
+    - name: Check out RACK wiki
+      uses: actions/checkout@v2
+      with:
+        repository: ge-high-assurance/RACK.wiki
+        ref: ${{ github.event.release.tag_name }}
+        token: ${{ secrets.RACK_CI_PAT }}
+        path: RACK.wiki
 
     - name: Generate RACK documentation
-      if: steps.cache-rack-doc.outputs.cache-hit != 'true'
       run: |
         sudo npm install -g github-wikito-converter markdown-to-html
         gwtc -t RACK-in-a-Box RACK.wiki
         markdown -t RACK-in-a-box -s style.css RACK.wiki/Welcome.md > index.html
         mv documentation.html index.html RACK/rack-box/files
 
-    - name: Download SemTK distribution
-      if: steps.cache-semtk.outputs.cache-hit != 'true'
-      run: curl -LSs 'https://oss.sonatype.org/service/local/artifact/maven/content?r=snapshots&g=com.ge.research.semtk&a=distribution&v=2.2.2-SNAPSHOT&c=bin&e=tar.gz' -o RACK/rack-box/files/semtk.tar.gz
+    # Skip since windows-latest doesn't support nested virtualization yet
+    - name: Enable Hyper-V
+      if: matrix.builder == 'hyperv' && matrix.os == 'windows-latest'
+      shell: powershell
+      run: |
+        Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Hyper-V -All
+        Add-WindowsFeature RSAT-Hyper-V-Tools -IncludeAllSubFeature
 
-    - name: Download style spreadsheet
-      if: steps.cache-style.outputs.cache-hit != 'true'
-      run: curl -LSs https://github.com/KrauseFx/markdown-to-html-github-style/raw/master/style.css -o RACK/rack-box/files/style.css
-
-    - name: Download systemctl script
-      if: steps.cache-systemctl.outputs.cache-hit != 'true'
-      run: curl -LSs https://github.com/gdraheim/docker-systemctl-replacement/raw/v1.5.4260/files/docker/systemctl3.py -o RACK/rack-box/files/systemctl3.py
-
-  build:
-    name: build ${{ matrix.builder }} ${{ matrix.os }}
-    needs: setup
-    runs-on: ${{ matrix.os }}
-    defaults:
-      run:
-        shell: ${{ matrix.shell }}
-
-    # Unfortunately, ubuntu-latest can't run virtualbox (VT-x is not
-    # available: VERR_VMK_NO_VMX) and windows-latest can't run Hyper-V
-    # https://github.com/actions/virtual-environments/issues/183#issuecomment-706244929
-
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-        - builder: docker
-          os: ubuntu-20.04
-          shell: bash
-        - builder: virtualbox
-          os: macos-latest
-          shell: bash
-#        - builder: hyperv
-#          os: windows-latest
-#          shell: msys2 {0}
-
-    steps:
-    - name: Check out RACK source
-      uses: actions/checkout@v2
-      with:
-        repository: ge-high-assurance/RACK
-        ref: ${{ github.event.release.tag_name }}
-        token: ${{ secrets.RACK_CI_PAT }}
-        path: RACK
-
-    - name: Cache Fuseki distribution
-      uses: actions/cache@v2
-      id: cache-fuseki
-      with:
-        path: RACK/rack-box/files/fuseki.tar.gz
-        key: fuseki-3.16.0
-
-    - name: Cache RACK CLI
-      uses: actions/cache@v2
-      id: cache-rack-cli
-      with:
-        path: RACK/rack-box/files/rack.tar.gz
-        key: rack-cli-${{ hashFiles('RACK/RACK-Ontology/**', 'RACK/nodegroups/**') }}
-
-    - name: Cache RACK documentation
-      uses: actions/cache@v2
-      id: cache-rack-doc
-      with:
-        path: |
-          RACK/rack-box/files/documentation.html
-          RACK/rack-box/files/index.html
-        key: rack-doc-${{ hashFiles('RACK.wiki/*.md') }}
-
-    - name: Cache SemTK distribution
-      uses: actions/cache@v2
-      id: cache-semtk
-      with:
-        path: RACK/rack-box/files/semtk.tar.gz
-        key: semtk-2.2.2-SNAPSHOT-v3
-
-    - name: Cache style spreadsheet
-      uses: actions/cache@v2
-      id: cache-style
-      with:
-        path: RACK/rack-box/files/style.css
-        key: style-db9e23f
-
-    - name: Cache systemctl script
-      uses: actions/cache@v2
-      id: cache-systemctl
-      with:
-        path: RACK/rack-box/files/systemctl3.py
-        key: systemctl-1.5.4260
+    # Skip since ubuntu-20.04 doesn't support nested virtualization yet
+    - name: Install VirtualBox
+      if: matrix.builder == 'virtualbox' && matrix.os == 'ubuntu-20.04'
+      run: sudo apt-get install -y virtualbox
 
     - name: Cache Ubuntu ISO
       if: matrix.builder != 'docker'
@@ -217,19 +120,6 @@ jobs:
       with:
         path: RACK/rack-box/packer_cache/e30b34e4d3c536763868a42bb9d5b8f14af297b8.iso
         key: ubuntu-20.04.1
-
-    # Doesn't work on windows-latest (nested virtualization is unsupported)
-    - name: Enable Hyper-V
-      if: matrix.builder == 'hyperv' && matrix.os == 'windows-latest'
-      shell: powershell
-      run: |
-        Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Hyper-V -All
-        Add-WindowsFeature RSAT-Hyper-V-Tools -IncludeAllSubFeature
-
-    # Doesn't work on ubuntu-20.04 (nested virtualization is unsupported)
-    - name: Install VirtualBox
-      if: matrix.builder == 'virtualbox' && matrix.os == 'ubuntu-20.04'
-      run: sudo apt-get install -y virtualbox
 
     - name: Build rack-box image
       run: |
@@ -247,7 +137,7 @@ jobs:
 
     - name: Push rack-box image to Docker Hub
       if: matrix.builder == 'docker'
-      run: docker push interran/rack-box:${{ github.event.release.tag_name }}
+      run: docker push gehighassurance/rack-box:${{ github.event.release.tag_name }}
 
     - name: Split rack-box image
       if: matrix.builder != 'docker'

--- a/.github/workflows/rack-continuous.yaml
+++ b/.github/workflows/rack-continuous.yaml
@@ -12,48 +12,39 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check out RACK source
-        uses: actions/checkout@v2
+    - name: Check out RACK source
+      uses: actions/checkout@v2
 
-      - name: Lint shell scripts with ShellCheck
-        # This action is composite on master which `act` can't yet handle.
-        uses: ludeeus/action-shellcheck@fcee962fee3f87888d7992ab0560232aef368e89
-        env:
-          SHELLCHECK_OPTS: -e SC1008
+    - name: Cache development dependencies
+      uses: actions/cache@v2
+      with:
+        # This path is specific to Ubuntu
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('cli/dev/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+          ${{ runner.os }}-
 
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.x'
+    - name: Install development dependencies
+      run: pip3 install -q -r cli/dev/requirements.txt
 
-      - name: Cache RACK CLI development dependencies
-        uses: actions/cache@v2
-        with:
-          # This path is specific to Ubuntu
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('cli/dev/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-            ${{ runner.os }}-
+    - name: Lint RACK CLI
+      run: |
+        cd cli
+        pylint .
+        mypy .
 
-      - name: Install development dependencies
-        run: |
-          pip install \
-            --quiet \
-            --requirement cli/dev/requirements.txt
+    - name: Lint RACK Ontology
+      continue-on-error: true
+      run: |
+        sudo apt-add-repository ppa:swi-prolog/stable
+        sudo apt-get update -qq --yes
+        sudo apt-get install -qq --yes swi-prolog
+        cd RACK-Ontology
+        ../assist/bin/check
 
-      - name: Lint the RACK CLI
-        run: |
-          cd cli
-          pylint .
-          mypy .
-
-      - name: Lint the ontology
-        continue-on-error: true
-        run: |
-          sudo apt-add-repository ppa:swi-prolog/stable
-          sudo apt-get update -qq --yes
-          sudo apt-get install -qq --yes swi-prolog
-
-          cd RACK-Ontology
-          ../assist/bin/check
+    - name: Lint shell scripts
+      # This action is composite on master which `act` can't yet handle.
+      uses: ludeeus/action-shellcheck@fcee962fee3f87888d7992ab0560232aef368e89
+      env:
+        SHELLCHECK_OPTS: -e SC1008

--- a/.github/workflows/rack-continuous.yaml
+++ b/.github/workflows/rack-continuous.yaml
@@ -22,10 +22,16 @@ jobs:
       with:
         # This path is specific to Ubuntu
         path: ~/.cache/pip
+        # Look to see if there is a cache hit for the corresponding requirements file
         key: ${{ runner.os }}-pip-${{ hashFiles('cli/dev/requirements.txt') }}
         restore-keys: |
           ${{ runner.os }}-pip-
           ${{ runner.os }}-
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
 
     - name: Install development dependencies
       run: pip3 install -q -r cli/dev/requirements.txt

--- a/.github/workflows/rack-continuous.yaml
+++ b/.github/workflows/rack-continuous.yaml
@@ -1,22 +1,25 @@
-# Lints the RACK source
+# Lints the RACK source upon every push (while ignoring tag-only pushes)
 
 name: RACK continous lint
-on: [push]
+
+on:
+  push:
+    branches: [ '*' ]
+    tags-ignore: [ '*' ]
 
 jobs:
   lint:
-    name: Lint shell scripts and the RACK CLI
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v2
+      - name: Check out RACK source
+        uses: actions/checkout@v2
 
       - name: Lint shell scripts with ShellCheck
         # This action is composite on master which `act` can't yet handle.
         uses: ludeeus/action-shellcheck@fcee962fee3f87888d7992ab0560232aef368e89
         env:
           SHELLCHECK_OPTS: -e SC1008
-        with:
-          ignore: packer
 
       - name: Set up Python
         uses: actions/setup-python@v2
@@ -39,15 +42,13 @@ jobs:
             --quiet \
             --requirement cli/dev/requirements.txt
 
-      - shell: bash
-        name: Lint the RACK CLI
+      - name: Lint the RACK CLI
         run: |
           cd cli
           pylint .
           mypy .
 
-      - shell: bash
-        name: Lint the ontology
+      - name: Lint the ontology
         continue-on-error: true
         run: |
           sudo apt-add-repository ppa:swi-prolog/stable

--- a/.github/workflows/rack-continuous.yaml
+++ b/.github/workflows/rack-continuous.yaml
@@ -3,13 +3,15 @@
 name: RACK continous lint
 
 on:
+  pull_request:
+    branches: [ '*' ]
   push:
     branches: [ '*' ]
     tags-ignore: [ '*' ]
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - name: Check out RACK source

--- a/.github/workflows/rack-continuous.yaml
+++ b/.github/workflows/rack-continuous.yaml
@@ -31,7 +31,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.x'
+        python-version: 3.8
 
     - name: Install development dependencies
       run: pip3 install -q -r cli/dev/requirements.txt

--- a/cli/tests/docker-compose.yml
+++ b/cli/tests/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '2'
 services:
   rack:
-    image: "interran/rack-box:v0.9"
+    image: "gehighassurance/rack-box:v3.0"
     ports:
       - "80:80"
       - "3030:3030"

--- a/rack-box/README-Docker-Hub.md
+++ b/rack-box/README-Docker-Hub.md
@@ -9,8 +9,8 @@ You will need to increase the resources given to Docker in order to run a RACK b
 Now you are ready to start your RACK box.  Type the following commands to download the Docker RACK box and run it on your computer:
 
 ```shell
-docker pull interran/rack-box:v3.0
-docker run --detach -p 80:80 -p 12050-12092:12050-12092 interran/rack-box:v3.0
+docker pull gehighassurance/rack-box:v3.0
+docker run --detach -p 80:80 -p 12050-12092:12050-12092 gehighassurance/rack-box:v3.0
 ```
 
 Type "localhost" in your web browser's address bar, hit Enter, and you should see your RACK box's welcome page appear in your browser.  The welcome page will tell you some things you can do with your RACK box.

--- a/rack-box/README-Docker-Hub.md
+++ b/rack-box/README-Docker-Hub.md
@@ -1,10 +1,12 @@
 # Install a Docker RACK Box
 
-You will need to increase the resources given to Docker in order to run a RACK box.  Click the right mouse button on Docker's whale icon in the system tray and select "Settings".  When the Settings window appears, click on Resources and make the following changes to the resource settings:
+You may need to increase the resources given to Docker in order to run a RACK box.  Click the right mouse button on Docker's whale icon in the system tray and select "Settings".  When the Settings window appears, click on Resources and if you see these resource settings, make the following changes:
 
 1. Increase the number of CPUs to 4 if you have enough CPUs (2 may be enough if you don't have many CPUs).
 2. Increase the amount of Memory to 4.00 GB (or more if you have plenty of RAM).
 3. Click the Apply & Restart button to restart Docker with the new resource settings.
+
+If you don't see these resource settings, it means Docker can use all of your computer's CPUs and 80% of your computer's RAM so you don't need to change anything.
 
 Now you are ready to start your RACK box.  Type the following commands to download the Docker RACK box and run it on your computer:
 

--- a/rack-box/README-GitHub-Release.md
+++ b/rack-box/README-GitHub-Release.md
@@ -3,8 +3,8 @@
 Here are very brief instructions how to run the Docker RACK box.  You will find more detailed [instructions](https://github.com/ge-high-assurance/RACK/wiki/Install-a-Docker-RACK-Box) in the RACK Wiki.  You will need to give your Docker Hub username to the RACK team so you can be given access to our Docker Hub repository.
 
 1. Open a terminal window where you can run `docker`.
-2. Type `docker pull interran/rack-box:v3.0`
-3. Type `docker run --detach -p 80:80 -p 12050-12092:12050-12092 interran/rack-box:v3.0`
+2. Type `docker pull gehighassurance/rack-box:v3.0`
+3. Type `docker run --detach -p 80:80 -p 12050-12092:12050-12092 gehighassurance/rack-box:v3.0`
 4. Visit <http://localhost/> in your browser to view the RACK box's welcome page.
 
 ## Run the Virtual RACK box

--- a/rack-box/README.md
+++ b/rack-box/README.md
@@ -4,7 +4,7 @@ This README is for RACK developers and RACK-in-a-Box power users who
 want to know how to build rack-box images.  Normally we let our RACK
 repository's GitHub Actions workflow build rack-box images and push or
 upload them to our [Docker
-Hub](https://hub.docker.com/repository/docker/interran/rack-box) or
+Hub](https://hub.docker.com/repository/docker/gehighassurance/rack-box) or
 [GitHub Releases](https://github.com/ge-high-assurance/RACK/releases)
 pages automatically.
 
@@ -139,7 +139,7 @@ the following places:
 
 ### Download pages
 
-- [ ] [Docker Hub](https://hub.docker.com/repository/docker/interran/rack-box)
+- [ ] [Docker Hub](https://hub.docker.com/repository/docker/gehighassurance/rack-box)
 - [ ] [GitHub Releases](https://github.com/ge-high-assurance/RACK/releases)
 
 Our GitHub Actions release workflow automates building and uploading

--- a/rack-box/rack-box-docker.json
+++ b/rack-box/rack-box-docker.json
@@ -3,7 +3,7 @@
     "http_proxy": "{{env `http_proxy`}}",
     "https_proxy": "{{env `https_proxy`}}",
     "no_proxy": "{{env `no_proxy`}}",
-    "repository": "interran/rack-box",
+    "repository": "gehighassurance/rack-box",
     "tags": "{{user `version`}}",
     "version": "dev"
   },


### PR DESCRIPTION
Make it so that tag-only pushes will not trigger either rack-box-continuous.yml or rack-continuous.yaml workflows.  Now creating a new release will trigger only rack-box-release.yml, not all threee workflows.

Make rack-continuous.yaml a little more concise and remove superfluous shell: bash lines.

Streamline CI workflows and reduce duplication of lines by eliminating some caches that probably weren't saving us much time anyway.  The workflows were getting a little too long.  Also change our Docker Hub repository from interran/rack-box to gehighassurance/rack-box now that RACK is public.

In rack-box-continuous.yml and rack-box-release.yml, stop caching rack-cli.tar.gz, rack.tar.gz, documentation.html, index.html, style.css, and systemctl3.py.  Eliminate rack-box-release.yml's setup job (which was used only to populate some caches) and do all the work in its build job which will make it easier to compare rack-box-continuous.yml and rack-box-release.yml and keep both synchronized with each other.

In rack-continuous.yaml, tweak steps and comments slightly for better readability.
