### PR TITLE
ci: Don't allow failure in ontology linting step

### DIFF
--- a/.github/workflows/rack-lint-continuous.yml
+++ b/.github/workflows/rack-lint-continuous.yml
@@ -43,13 +43,11 @@ jobs:
         mypy .
 
     - name: Lint RACK Ontology
-      continue-on-error: true
       run: |
         sudo apt-add-repository ppa:swi-prolog/stable
         sudo apt-get update -qq --yes
         sudo apt-get install -qq --yes swi-prolog
-        cd RACK-Ontology
-        ../assist/bin/check
+        ./assist/bin/check
 
     - name: Lint shell scripts
       # This action is composite on master which `act` can't yet handle.


### PR DESCRIPTION
This was previously an allowed failure because it was failing on what we had checked in, now that it's no longer failing we can enforce it's checks going forward.