### PR TITLE
Fix typo in GrammaTech overlay: when->then

### DIFF
--- a/GrammaTech-Ontology/OwlModels/GrammaTech.owl
+++ b/GrammaTech-Ontology/OwlModels/GrammaTech.owl
@@ -77,8 +77,8 @@
     <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#double"/>
     <rdfs:domain rdf:resource="http://arcos.rack/TESTING#TEST_EXECUTION"/>
   </owl:DatatypeProperty>
-  <owl:DatatypeProperty rdf:ID="whenTextConfidence">
-    <rdfs:comment xml:lang="en">confidence that this was the when-portion of the text</rdfs:comment>
+  <owl:DatatypeProperty rdf:ID="thenTextConfidence">
+    <rdfs:comment xml:lang="en">confidence that this was the then-portion of the text</rdfs:comment>
     <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#double"/>
     <rdfs:domain rdf:resource="#AcertRequirement"/>
   </owl:DatatypeProperty>

--- a/GrammaTech-Ontology/ontology/GrammaTech.sadl
+++ b/GrammaTech-Ontology/ontology/GrammaTech.sadl
@@ -11,7 +11,7 @@ AcertRequirement is a type of REQUIREMENT.
         describes AcertRequirement with values of type double.
     ifTextConfidence (note "confidence that this was the if-portion of the text")
         describes AcertRequirement with values of type double.
-    whenTextConfidence (note "confidence that this was the when-portion of the text")
+    thenTextConfidence (note "confidence that this was the then-portion of the text")
         describes AcertRequirement with values of type double.
     givenTextConfidence (note "confidence that this was the given-portion of the text")
         describes AcertRequirement with values of type double.


### PR DESCRIPTION
@lucja-kot-grammatech Does this work for you?

Now the confidence values will correctly match the text fields.

```
	givenText (note "optional part that can be used to set certain conditions apart from other conditions in the ifText part") describes REQUIREMENT with values of type string.
	ifText (note "conditions under which this requirement holds") describes REQUIREMENT with values of type string.
	thenText (note "specifies what should hold by this requirement if the requirement conditions are met") describes REQUIREMENT with values of type string.
```