### PR TITLE
Reintroduce a few components into Turnstile

### DIFF
--- a/Turnstile-Ontology/02-Software/03-Implementation/CounterApplication.sadl
+++ b/Turnstile-Ontology/02-Software/03-Implementation/CounterApplication.sadl
@@ -48,6 +48,14 @@ input_o is a ObjectFile
     has file:createBy input_o_Compiling
     has fileFormat ElfFile.
 
+input_function is a COMPONENT
+    has identifier "input_function"
+    has dataInsertedBy Mockup
+    has componentType SOURCE_FUNCTION
+    has sw:name "input"
+    has valueType "void()"
+    has definedIn input_c.
+
 // output.o
 
 output_c is a SourceCode
@@ -77,6 +85,14 @@ output_o is a ObjectFile
     has filename "output.o"
     has file:createBy output_o_Compiling
     has fileFormat ElfFile.
+
+output_function is a COMPONENT
+    has identifier "output_function"
+    has dataInsertedBy Mockup
+    has componentType SOURCE_FUNCTION
+    has sw:name "output"
+    has valueType "void()"
+    has definedIn output_c.
 
 // hw.o libhw.so
 
@@ -127,7 +143,7 @@ counter_c is a SourceCode
     has filename "counter.c"
     has file:createBy CodeSW-1
     has fileFormat CSourceFile.
-    
+
 counter_h is a SourceCode
     has identifier "counter_h"
     has filename "counter.h"
@@ -153,7 +169,17 @@ counter_exe is an ObjectFile
     has filename "counter.exe"
     has file:createBy counter_exe_Compiling
     has fileFormat ElfFile.
-    
+
+main_function is a COMPONENT
+    has identifier "main_function"
+    has componentType SOURCE_FUNCTION
+    has dataInsertedBy Mockup
+    has sw:name "main"
+    has valueType "int(int argc, char* argv[])"
+    has controlFlowsToUnconditionally input_function
+    has controlFlowsToUnconditionally output_function
+    has definedIn counter_c.
+
 // conf.json
 
 conf_json is a FILE

--- a/Turnstile-Ontology/99-Utils/Data/Model.yaml
+++ b/Turnstile-Ontology/99-Utils/Data/Model.yaml
@@ -32,3 +32,4 @@ ingestion-steps:
 - {nodegroup: "Ingest-SystemComponent", csv: "SystemComponent.csv"}
 - {nodegroup: "Ingest-SystemInterfaceDefinition", csv: "SystemInterfaceDefinition.csv"}
 - {nodegroup: "Ingest-SystemRequirement", csv: "SystemRequirement.csv"}
+- {nodegroup: "Ingest-SoftwareComponent", csv: "SoftwareComponent.csv"}

--- a/Turnstile-Ontology/99-Utils/Data/SoftwareComponent.csv
+++ b/Turnstile-Ontology/99-Utils/Data/SoftwareComponent.csv
@@ -1,0 +1,7 @@
+"identifier","componentTypeId","name","valueType","instantiateId","definedInId","mentionId","subcomponentId","requirementId","annotationId","controlFlowsToConditionallyId","controlFlowsToUnconditionallyId","dataInsertedById","generatedAtTime","invalidatedAtTime","wasAttributedToId","wasDerivedFromId","wasGeneratedById"	
+"input_function","SOURCE_FUNCTION","input","void()",null,"input_c",null,null,null,null,null,null,"ACTIVITY-Turnstile software data mockup",null,null,null,null,null	
+"main_function","SOURCE_FUNCTION","main","int(int argc, char* argv[])",null,"counter_c",null,null,null,null,"input_function","input_function","ACTIVITY-Turnstile software data mockup",null,null,null,null,null	
+"main_function","SOURCE_FUNCTION","main","int(int argc, char* argv[])",null,"counter_c",null,null,null,null,"input_function","output_function","ACTIVITY-Turnstile software data mockup",null,null,null,null,null	
+"main_function","SOURCE_FUNCTION","main","int(int argc, char* argv[])",null,"counter_c",null,null,null,null,"output_function","input_function","ACTIVITY-Turnstile software data mockup",null,null,null,null,null	
+"main_function","SOURCE_FUNCTION","main","int(int argc, char* argv[])",null,"counter_c",null,null,null,null,"output_function","output_function","ACTIVITY-Turnstile software data mockup",null,null,null,null,null	
+"output_function","SOURCE_FUNCTION","output","void()",null,"output_c",null,null,null,null,null,null,"ACTIVITY-Turnstile software data mockup",null,null,null,null,null	

--- a/Turnstile-Ontology/99-Utils/NodeGroups/Ingest-SoftwareComponent.json
+++ b/Turnstile-Ontology/99-Utils/NodeGroups/Ingest-SoftwareComponent.json
@@ -1,0 +1,966 @@
+{
+    "importSpec": {
+        "baseURI": "http://arcos.data/software",
+        "columns": [
+            {
+                "colId": "col_0",
+                "colName": "annotationId"
+            },
+            {
+                "colId": "col_1",
+                "colName": "componentTypeId"
+            },
+            {
+                "colId": "col_2",
+                "colName": "controlFlowUnconditionallyId"
+            },
+            {
+                "colId": "col_3",
+                "colName": "controlFlowsToConditionallyId"
+            },
+            {
+                "colId": "col_4",
+                "colName": "controlFlowsToUnconditionallyId"
+            },
+            {
+                "colId": "col_5",
+                "colName": "definedInId"
+            },
+            {
+                "colId": "col_6",
+                "colName": "instantiateId"
+            },
+            {
+                "colId": "col_7",
+                "colName": "mentionId"
+            },
+            {
+                "colId": "col_8",
+                "colName": "name"
+            },
+            {
+                "colId": "col_9",
+                "colName": "requirementId"
+            },
+            {
+                "colId": "col_10",
+                "colName": "subcomponentId"
+            },
+            {
+                "colId": "col_11",
+                "colName": "identifier"
+            },
+            {
+                "colId": "col_12",
+                "colName": "valueType"
+            }
+        ],
+        "dataValidator": [],
+        "nodes": [
+            {
+                "URILookupMode": "createIfMissing",
+                "mapping": [],
+                "props": [
+                    {
+                        "URIRelation": "http://arcos.rack/SOFTWARE#name",
+                        "mapping": [
+                            {
+                                "colId": "col_8",
+                                "transformList": [
+                                    "trans_0"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "URILookup": [
+                            "?COMPONENT"
+                        ],
+                        "URIRelation": "http://arcos.rack/PROV-S#identifier",
+                        "mapping": [
+                            {
+                                "colId": "col_11"
+                            }
+                        ]
+                    },
+                    {
+                        "URIRelation": "http://arcos.rack/SOFTWARE#valueType",
+                        "mapping": [
+                            {
+                                "colId": "col_12",
+                                "transformList": [
+                                    "trans_0"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "sparqlID": "?COMPONENT",
+                "type": "http://arcos.rack/SOFTWARE#COMPONENT"
+            },
+            {
+                "URILookupMode": "createIfMissing",
+                "mapping": [],
+                "props": [
+                    {
+                        "URILookup": [
+                            "?ANNOTATION"
+                        ],
+                        "URIRelation": "http://arcos.rack/PROV-S#identifier",
+                        "mapping": [
+                            {
+                                "colId": "col_0",
+                                "transformList": [
+                                    "trans_0"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "sparqlID": "?ANNOTATION",
+                "type": "http://arcos.rack/PROV-S#ENTITY"
+            },
+            {
+                "URILookupMode": "createIfMissing",
+                "mapping": [],
+                "props": [
+                    {
+                        "URILookup": [
+                            "?COMPONENT_TYPE"
+                        ],
+                        "URIRelation": "http://arcos.rack/PROV-S#identifier",
+                        "mapping": [
+                            {
+                                "colId": "col_1"
+                            }
+                        ]
+                    }
+                ],
+                "sparqlID": "?COMPONENT_TYPE",
+                "type": "http://arcos.rack/SOFTWARE#COMPONENT_TYPE"
+            },
+            {
+                "URILookupMode": "createIfMissing",
+                "mapping": [],
+                "props": [
+                    {
+                        "URILookup": [
+                            "?CONTROL_FLOW_CONDITIONAL"
+                        ],
+                        "URIRelation": "http://arcos.rack/PROV-S#identifier",
+                        "mapping": [
+                            {
+                                "colId": "col_3",
+                                "transformList": [
+                                    "trans_0"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "sparqlID": "?CONTROL_FLOW_CONDITIONAL",
+                "type": "http://arcos.rack/SOFTWARE#COMPONENT"
+            },
+            {
+                "URILookupMode": "createIfMissing",
+                "mapping": [],
+                "props": [
+                    {
+                        "URILookup": [
+                            "?CONTROL_FLOW_UNCONDITIONAL"
+                        ],
+                        "URIRelation": "http://arcos.rack/PROV-S#identifier",
+                        "mapping": [
+                            {
+                                "colId": "col_4",
+                                "transformList": [
+                                    "trans_0"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "sparqlID": "?CONTROL_FLOW_UNCONDITIONAL",
+                "type": "http://arcos.rack/SOFTWARE#COMPONENT"
+            },
+            {
+                "URILookupMode": "createIfMissing",
+                "mapping": [],
+                "props": [
+                    {
+                        "URILookup": [
+                            "?DEFINE_IN"
+                        ],
+                        "URIRelation": "http://arcos.rack/PROV-S#identifier",
+                        "mapping": [
+                            {
+                                "colId": "col_5",
+                                "transformList": [
+                                    "trans_0"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "sparqlID": "?DEFINE_IN",
+                "type": "http://arcos.rack/FILE#FILE"
+            },
+            {
+                "URILookupMode": "createIfMissing",
+                "mapping": [],
+                "props": [
+                    {
+                        "URILookup": [
+                            "?INSTANTIATE"
+                        ],
+                        "URIRelation": "http://arcos.rack/PROV-S#identifier",
+                        "mapping": [
+                            {
+                                "colId": "col_6",
+                                "transformList": [
+                                    "trans_0"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "sparqlID": "?INSTANTIATE",
+                "type": "http://arcos.rack/PROV-S#ENTITY"
+            },
+            {
+                "URILookupMode": "createIfMissing",
+                "mapping": [],
+                "props": [
+                    {
+                        "URILookup": [
+                            "?MENTION"
+                        ],
+                        "URIRelation": "http://arcos.rack/PROV-S#identifier",
+                        "mapping": [
+                            {
+                                "colId": "col_7",
+                                "transformList": [
+                                    "trans_0"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "sparqlID": "?MENTION",
+                "type": "http://arcos.rack/PROV-S#ENTITY"
+            },
+            {
+                "URILookupMode": "createIfMissing",
+                "mapping": [],
+                "props": [
+                    {
+                        "URILookup": [
+                            "?REQUIREMENT"
+                        ],
+                        "URIRelation": "http://arcos.rack/PROV-S#identifier",
+                        "mapping": [
+                            {
+                                "colId": "col_9",
+                                "transformList": [
+                                    "trans_0"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "sparqlID": "?REQUIREMENT",
+                "type": "http://arcos.rack/PROV-S#ENTITY"
+            },
+            {
+                "URILookupMode": "createIfMissing",
+                "mapping": [],
+                "props": [
+                    {
+                        "URILookup": [
+                            "?SUBCOMPONENT"
+                        ],
+                        "URIRelation": "http://arcos.rack/PROV-S#identifier",
+                        "mapping": [
+                            {
+                                "colId": "col_10",
+                                "transformList": [
+                                    "trans_0"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "sparqlID": "?SUBCOMPONENT",
+                "type": "http://arcos.rack/SOFTWARE#COMPONENT"
+            }
+        ],
+        "texts": [],
+        "transforms": [
+            {
+                "arg1": "^null$",
+                "arg2": "",
+                "name": "rm_null",
+                "transId": "trans_0",
+                "transType": "replaceAll"
+            }
+        ],
+        "version": "1"
+    },
+    "sNodeGroup": {
+        "limit": 0,
+        "offset": 0,
+        "orderBy": [],
+        "sNodeList": [
+            {
+                "NodeName": "COMPONENT",
+                "SparqlID": "?SUBCOMPONENT",
+                "deletionMode": "NO_DELETE",
+                "fullURIName": "http://arcos.rack/SOFTWARE#COMPONENT",
+                "instanceValue": null,
+                "isReturned": false,
+                "isRuntimeConstrained": false,
+                "nodeList": [],
+                "propList": [
+                    {
+                        "Constraints": "",
+                        "KeyName": "identifier",
+                        "SparqlID": "?subcomponentId",
+                        "UriRelationship": "http://arcos.rack/PROV-S#identifier",
+                        "ValueType": "string",
+                        "fullURIName": "",
+                        "instanceValues": [],
+                        "isMarkedForDeletion": false,
+                        "isReturned": true,
+                        "isRuntimeConstrained": false,
+                        "optMinus": 1,
+                        "relationship": "http://www.w3.org/2001/XMLSchema#string"
+                    }
+                ],
+                "subClassNames": [],
+                "valueConstraint": ""
+            },
+            {
+                "NodeName": "ENTITY",
+                "SparqlID": "?REQUIREMENT",
+                "deletionMode": "NO_DELETE",
+                "fullURIName": "http://arcos.rack/PROV-S#ENTITY",
+                "instanceValue": null,
+                "isReturned": false,
+                "isRuntimeConstrained": false,
+                "nodeList": [],
+                "propList": [
+                    {
+                        "Constraints": "",
+                        "KeyName": "identifier",
+                        "SparqlID": "?requirementId",
+                        "UriRelationship": "http://arcos.rack/PROV-S#identifier",
+                        "ValueType": "string",
+                        "fullURIName": "",
+                        "instanceValues": [],
+                        "isMarkedForDeletion": false,
+                        "isReturned": true,
+                        "isRuntimeConstrained": false,
+                        "optMinus": 1,
+                        "relationship": "http://www.w3.org/2001/XMLSchema#string"
+                    }
+                ],
+                "subClassNames": [
+                    "http://arcos.rack/SACM-S#ASSERTED_CONTEXT",
+                    "http://arcos.rack/SACM-S#ARGUMENT_REASONING",
+                    "http://arcos.rack/DOCUMENT#DESCRIPTION",
+                    "http://arcos.rack/SYSTEM#SYSTEM",
+                    "http://arcos.rack/DOCUMENT#SECTION",
+                    "http://arcos.rack/PROCESS#OBJECTIVE",
+                    "http://arcos.rack/SACM-S#CLAIM",
+                    "http://arcos.rack/SYSTEM#INTERFACE",
+                    "http://arcos.rack/ANALYSIS#ANALYSIS_ANNOTATION",
+                    "http://arcos.rack/REQUIREMENTS#DATA_DICTIONARY_TERM",
+                    "http://arcos.rack/HAZARD#HAZARD",
+                    "http://arcos.rack/PROV-S#COLLECTION",
+                    "http://arcos.rack/ANALYSIS#ANALYSIS_REPORT",
+                    "http://arcos.rack/DOCUMENT#SPECIFICATION",
+                    "http://arcos.rack/DOCUMENT#REPORT",
+                    "http://arcos.rack/DOCUMENT#REQUEST",
+                    "http://arcos.rack/SACM-S#ARGUMENT_PACKAGE",
+                    "http://arcos.rack/FILE#FILE",
+                    "http://arcos.rack/TESTING#TEST",
+                    "http://arcos.rack/TESTING#TEST_RESULT",
+                    "http://arcos.rack/DOCUMENT#PLAN",
+                    "http://arcos.rack/REVIEW#REVIEW_LOG",
+                    "http://arcos.rack/SACM-S#ASSERTED_INFERENCE",
+                    "http://arcos.rack/SOFTWARE#COMPONENT",
+                    "http://arcos.rack/SACM-S#ARTIFACT_REFERENCE",
+                    "http://arcos.rack/DOCUMENT#PROCEDURE",
+                    "http://arcos.rack/REQUIREMENTS#REQUIREMENT"
+                ],
+                "valueConstraint": ""
+            },
+            {
+                "NodeName": "ENTITY",
+                "SparqlID": "?MENTION",
+                "deletionMode": "NO_DELETE",
+                "fullURIName": "http://arcos.rack/PROV-S#ENTITY",
+                "instanceValue": null,
+                "isReturned": false,
+                "isRuntimeConstrained": false,
+                "nodeList": [],
+                "propList": [
+                    {
+                        "Constraints": "",
+                        "KeyName": "identifier",
+                        "SparqlID": "?mentionId",
+                        "UriRelationship": "http://arcos.rack/PROV-S#identifier",
+                        "ValueType": "string",
+                        "fullURIName": "",
+                        "instanceValues": [],
+                        "isMarkedForDeletion": false,
+                        "isReturned": true,
+                        "isRuntimeConstrained": false,
+                        "optMinus": 1,
+                        "relationship": "http://www.w3.org/2001/XMLSchema#string"
+                    }
+                ],
+                "subClassNames": [
+                    "http://arcos.rack/SACM-S#ASSERTED_CONTEXT",
+                    "http://arcos.rack/SACM-S#ARGUMENT_REASONING",
+                    "http://arcos.rack/DOCUMENT#DESCRIPTION",
+                    "http://arcos.rack/SYSTEM#SYSTEM",
+                    "http://arcos.rack/DOCUMENT#SECTION",
+                    "http://arcos.rack/PROCESS#OBJECTIVE",
+                    "http://arcos.rack/SACM-S#CLAIM",
+                    "http://arcos.rack/SYSTEM#INTERFACE",
+                    "http://arcos.rack/ANALYSIS#ANALYSIS_ANNOTATION",
+                    "http://arcos.rack/REQUIREMENTS#DATA_DICTIONARY_TERM",
+                    "http://arcos.rack/HAZARD#HAZARD",
+                    "http://arcos.rack/PROV-S#COLLECTION",
+                    "http://arcos.rack/ANALYSIS#ANALYSIS_REPORT",
+                    "http://arcos.rack/DOCUMENT#SPECIFICATION",
+                    "http://arcos.rack/DOCUMENT#REPORT",
+                    "http://arcos.rack/DOCUMENT#REQUEST",
+                    "http://arcos.rack/SACM-S#ARGUMENT_PACKAGE",
+                    "http://arcos.rack/FILE#FILE",
+                    "http://arcos.rack/TESTING#TEST",
+                    "http://arcos.rack/TESTING#TEST_RESULT",
+                    "http://arcos.rack/DOCUMENT#PLAN",
+                    "http://arcos.rack/REVIEW#REVIEW_LOG",
+                    "http://arcos.rack/SACM-S#ASSERTED_INFERENCE",
+                    "http://arcos.rack/SOFTWARE#COMPONENT",
+                    "http://arcos.rack/SACM-S#ARTIFACT_REFERENCE",
+                    "http://arcos.rack/DOCUMENT#PROCEDURE",
+                    "http://arcos.rack/REQUIREMENTS#REQUIREMENT"
+                ],
+                "valueConstraint": ""
+            },
+            {
+                "NodeName": "ENTITY",
+                "SparqlID": "?INSTANTIATE",
+                "deletionMode": "NO_DELETE",
+                "fullURIName": "http://arcos.rack/PROV-S#ENTITY",
+                "instanceValue": null,
+                "isReturned": false,
+                "isRuntimeConstrained": false,
+                "nodeList": [],
+                "propList": [
+                    {
+                        "Constraints": "",
+                        "KeyName": "identifier",
+                        "SparqlID": "?instantiateId",
+                        "UriRelationship": "http://arcos.rack/PROV-S#identifier",
+                        "ValueType": "string",
+                        "fullURIName": "",
+                        "instanceValues": [],
+                        "isMarkedForDeletion": false,
+                        "isReturned": true,
+                        "isRuntimeConstrained": false,
+                        "optMinus": 1,
+                        "relationship": "http://www.w3.org/2001/XMLSchema#string"
+                    }
+                ],
+                "subClassNames": [
+                    "http://arcos.rack/SACM-S#ASSERTED_CONTEXT",
+                    "http://arcos.rack/SACM-S#ARGUMENT_REASONING",
+                    "http://arcos.rack/DOCUMENT#DESCRIPTION",
+                    "http://arcos.rack/SYSTEM#SYSTEM",
+                    "http://arcos.rack/DOCUMENT#SECTION",
+                    "http://arcos.rack/PROCESS#OBJECTIVE",
+                    "http://arcos.rack/SACM-S#CLAIM",
+                    "http://arcos.rack/SYSTEM#INTERFACE",
+                    "http://arcos.rack/ANALYSIS#ANALYSIS_ANNOTATION",
+                    "http://arcos.rack/REQUIREMENTS#DATA_DICTIONARY_TERM",
+                    "http://arcos.rack/HAZARD#HAZARD",
+                    "http://arcos.rack/PROV-S#COLLECTION",
+                    "http://arcos.rack/ANALYSIS#ANALYSIS_REPORT",
+                    "http://arcos.rack/DOCUMENT#SPECIFICATION",
+                    "http://arcos.rack/DOCUMENT#REPORT",
+                    "http://arcos.rack/DOCUMENT#REQUEST",
+                    "http://arcos.rack/SACM-S#ARGUMENT_PACKAGE",
+                    "http://arcos.rack/FILE#FILE",
+                    "http://arcos.rack/TESTING#TEST",
+                    "http://arcos.rack/TESTING#TEST_RESULT",
+                    "http://arcos.rack/DOCUMENT#PLAN",
+                    "http://arcos.rack/REVIEW#REVIEW_LOG",
+                    "http://arcos.rack/SACM-S#ASSERTED_INFERENCE",
+                    "http://arcos.rack/SOFTWARE#COMPONENT",
+                    "http://arcos.rack/SACM-S#ARTIFACT_REFERENCE",
+                    "http://arcos.rack/DOCUMENT#PROCEDURE",
+                    "http://arcos.rack/REQUIREMENTS#REQUIREMENT"
+                ],
+                "valueConstraint": ""
+            },
+            {
+                "NodeName": "ENTITY",
+                "SparqlID": "?DEFINE_IN",
+                "deletionMode": "NO_DELETE",
+                "fullURIName": "http://arcos.rack/FILE#FILE",
+                "instanceValue": null,
+                "isReturned": false,
+                "isRuntimeConstrained": false,
+                "nodeList": [],
+                "propList": [
+                    {
+                        "Constraints": "",
+                        "KeyName": "identifier",
+                        "SparqlID": "?definedInId",
+                        "UriRelationship": "http://arcos.rack/PROV-S#identifier",
+                        "ValueType": "string",
+                        "fullURIName": "",
+                        "instanceValues": [],
+                        "isMarkedForDeletion": false,
+                        "isReturned": true,
+                        "isRuntimeConstrained": false,
+                        "optMinus": 1,
+                        "relationship": "http://www.w3.org/2001/XMLSchema#string"
+                    }
+                ],
+                "subClassNames": [
+                    "http://arcos.rack/SACM-S#ASSERTED_CONTEXT",
+                    "http://arcos.rack/SACM-S#ARGUMENT_REASONING",
+                    "http://arcos.rack/DOCUMENT#DESCRIPTION",
+                    "http://arcos.rack/SYSTEM#SYSTEM",
+                    "http://arcos.rack/DOCUMENT#SECTION",
+                    "http://arcos.rack/PROCESS#OBJECTIVE",
+                    "http://arcos.rack/SACM-S#CLAIM",
+                    "http://arcos.rack/SYSTEM#INTERFACE",
+                    "http://arcos.rack/ANALYSIS#ANALYSIS_ANNOTATION",
+                    "http://arcos.rack/REQUIREMENTS#DATA_DICTIONARY_TERM",
+                    "http://arcos.rack/HAZARD#HAZARD",
+                    "http://arcos.rack/PROV-S#COLLECTION",
+                    "http://arcos.rack/ANALYSIS#ANALYSIS_REPORT",
+                    "http://arcos.rack/DOCUMENT#SPECIFICATION",
+                    "http://arcos.rack/DOCUMENT#REPORT",
+                    "http://arcos.rack/DOCUMENT#REQUEST",
+                    "http://arcos.rack/SACM-S#ARGUMENT_PACKAGE",
+                    "http://arcos.rack/FILE#FILE",
+                    "http://arcos.rack/TESTING#TEST",
+                    "http://arcos.rack/TESTING#TEST_RESULT",
+                    "http://arcos.rack/DOCUMENT#PLAN",
+                    "http://arcos.rack/REVIEW#REVIEW_LOG",
+                    "http://arcos.rack/SACM-S#ASSERTED_INFERENCE",
+                    "http://arcos.rack/SOFTWARE#COMPONENT",
+                    "http://arcos.rack/SACM-S#ARTIFACT_REFERENCE",
+                    "http://arcos.rack/DOCUMENT#PROCEDURE",
+                    "http://arcos.rack/REQUIREMENTS#REQUIREMENT"
+                ],
+                "valueConstraint": ""
+            },
+            {
+                "NodeName": "COMPONENT",
+                "SparqlID": "?CONTROL_FLOW_UNCONDITIONAL",
+                "deletionMode": "NO_DELETE",
+                "fullURIName": "http://arcos.rack/SOFTWARE#COMPONENT",
+                "instanceValue": null,
+                "isReturned": false,
+                "isRuntimeConstrained": false,
+                "nodeList": [],
+                "propList": [
+                    {
+                        "Constraints": "",
+                        "KeyName": "identifier",
+                        "SparqlID": "?controlFlowsToUnconditionallyId",
+                        "UriRelationship": "http://arcos.rack/PROV-S#identifier",
+                        "ValueType": "string",
+                        "fullURIName": "",
+                        "instanceValues": [],
+                        "isMarkedForDeletion": false,
+                        "isReturned": true,
+                        "isRuntimeConstrained": false,
+                        "optMinus": 1,
+                        "relationship": "http://www.w3.org/2001/XMLSchema#string"
+                    }
+                ],
+                "subClassNames": [],
+                "valueConstraint": ""
+            },
+            {
+                "NodeName": "COMPONENT",
+                "SparqlID": "?CONTROL_FLOW_CONDITIONAL",
+                "deletionMode": "NO_DELETE",
+                "fullURIName": "http://arcos.rack/SOFTWARE#COMPONENT",
+                "instanceValue": null,
+                "isReturned": false,
+                "isRuntimeConstrained": false,
+                "nodeList": [],
+                "propList": [
+                    {
+                        "Constraints": "",
+                        "KeyName": "identifier",
+                        "SparqlID": "?controlFlowConditionalId",
+                        "UriRelationship": "http://arcos.rack/PROV-S#identifier",
+                        "ValueType": "string",
+                        "fullURIName": "",
+                        "instanceValues": [],
+                        "isMarkedForDeletion": false,
+                        "isReturned": true,
+                        "isRuntimeConstrained": false,
+                        "optMinus": 1,
+                        "relationship": "http://www.w3.org/2001/XMLSchema#string"
+                    }
+                ],
+                "subClassNames": [],
+                "valueConstraint": ""
+            },
+            {
+                "NodeName": "COMPONENT_TYPE",
+                "SparqlID": "?COMPONENT_TYPE",
+                "deletionMode": "NO_DELETE",
+                "fullURIName": "http://arcos.rack/SOFTWARE#COMPONENT_TYPE",
+                "instanceValue": null,
+                "isReturned": false,
+                "isRuntimeConstrained": false,
+                "nodeList": [],
+                "propList": [
+                    {
+                        "Constraints": "",
+                        "KeyName": "identifier",
+                        "SparqlID": "?componentTypeId",
+                        "UriRelationship": "http://arcos.rack/PROV-S#identifier",
+                        "ValueType": "string",
+                        "fullURIName": "",
+                        "instanceValues": [],
+                        "isMarkedForDeletion": false,
+                        "isReturned": true,
+                        "isRuntimeConstrained": false,
+                        "optMinus": 0,
+                        "relationship": "http://www.w3.org/2001/XMLSchema#string"
+                    }
+                ],
+                "subClassNames": [],
+                "valueConstraint": ""
+            },
+            {
+                "NodeName": "ENTITY",
+                "SparqlID": "?ANNOTATION",
+                "deletionMode": "NO_DELETE",
+                "fullURIName": "http://arcos.rack/PROV-S#ENTITY",
+                "instanceValue": null,
+                "isReturned": false,
+                "isRuntimeConstrained": false,
+                "nodeList": [],
+                "propList": [
+                    {
+                        "Constraints": "",
+                        "KeyName": "identifier",
+                        "SparqlID": "?annotationId",
+                        "UriRelationship": "http://arcos.rack/PROV-S#identifier",
+                        "ValueType": "string",
+                        "fullURIName": "",
+                        "instanceValues": [],
+                        "isMarkedForDeletion": false,
+                        "isReturned": true,
+                        "isRuntimeConstrained": false,
+                        "optMinus": 1,
+                        "relationship": "http://www.w3.org/2001/XMLSchema#string"
+                    }
+                ],
+                "subClassNames": [
+                    "http://arcos.rack/SACM-S#ASSERTED_CONTEXT",
+                    "http://arcos.rack/SACM-S#ARGUMENT_REASONING",
+                    "http://arcos.rack/DOCUMENT#DESCRIPTION",
+                    "http://arcos.rack/SYSTEM#SYSTEM",
+                    "http://arcos.rack/DOCUMENT#SECTION",
+                    "http://arcos.rack/PROCESS#OBJECTIVE",
+                    "http://arcos.rack/SACM-S#CLAIM",
+                    "http://arcos.rack/SYSTEM#INTERFACE",
+                    "http://arcos.rack/ANALYSIS#ANALYSIS_ANNOTATION",
+                    "http://arcos.rack/REQUIREMENTS#DATA_DICTIONARY_TERM",
+                    "http://arcos.rack/HAZARD#HAZARD",
+                    "http://arcos.rack/PROV-S#COLLECTION",
+                    "http://arcos.rack/ANALYSIS#ANALYSIS_REPORT",
+                    "http://arcos.rack/DOCUMENT#SPECIFICATION",
+                    "http://arcos.rack/DOCUMENT#REPORT",
+                    "http://arcos.rack/DOCUMENT#REQUEST",
+                    "http://arcos.rack/SACM-S#ARGUMENT_PACKAGE",
+                    "http://arcos.rack/FILE#FILE",
+                    "http://arcos.rack/TESTING#TEST",
+                    "http://arcos.rack/TESTING#TEST_RESULT",
+                    "http://arcos.rack/DOCUMENT#PLAN",
+                    "http://arcos.rack/REVIEW#REVIEW_LOG",
+                    "http://arcos.rack/SACM-S#ASSERTED_INFERENCE",
+                    "http://arcos.rack/SOFTWARE#COMPONENT",
+                    "http://arcos.rack/SACM-S#ARTIFACT_REFERENCE",
+                    "http://arcos.rack/DOCUMENT#PROCEDURE",
+                    "http://arcos.rack/REQUIREMENTS#REQUIREMENT"
+                ],
+                "valueConstraint": ""
+            },
+            {
+                "NodeName": "COMPONENT",
+                "SparqlID": "?COMPONENT",
+                "deletionMode": "NO_DELETE",
+                "fullURIName": "http://arcos.rack/SOFTWARE#COMPONENT",
+                "instanceValue": null,
+                "isReturned": false,
+                "isRuntimeConstrained": false,
+                "nodeList": [
+                    {
+                        "ConnectBy": "annotations",
+                        "Connected": true,
+                        "DeletionMarkers": [
+                            false
+                        ],
+                        "KeyName": "annotations",
+                        "OptionalMinus": [
+                            "1"
+                        ],
+                        "Qualifiers": [
+                            ""
+                        ],
+                        "SnodeSparqlIDs": [
+                            "?ANNOTATION"
+                        ],
+                        "UriConnectBy": "http://arcos.rack/SOFTWARE#annotations",
+                        "UriValueType": "http://arcos.rack/PROV-S#ENTITY",
+                        "ValueType": "ENTITY"
+                    },
+                    {
+                        "ConnectBy": "componentType",
+                        "Connected": true,
+                        "DeletionMarkers": [
+                            false
+                        ],
+                        "KeyName": "componentType",
+                        "OptionalMinus": [
+                            "0"
+                        ],
+                        "Qualifiers": [
+                            ""
+                        ],
+                        "SnodeSparqlIDs": [
+                            "?COMPONENT_TYPE"
+                        ],
+                        "UriConnectBy": "http://arcos.rack/SOFTWARE#componentType",
+                        "UriValueType": "http://arcos.rack/SOFTWARE#COMPONENT_TYPE",
+                        "ValueType": "COMPONENT_TYPE"
+                    },
+                    {
+                        "ConnectBy": "controlFlowsToConditionally",
+                        "Connected": true,
+                        "DeletionMarkers": [
+                            false
+                        ],
+                        "KeyName": "controlFlowsToConditionally",
+                        "OptionalMinus": [
+                            "1"
+                        ],
+                        "Qualifiers": [
+                            ""
+                        ],
+                        "SnodeSparqlIDs": [
+                            "?CONTROL_FLOW_CONDITIONAL"
+                        ],
+                        "UriConnectBy": "http://arcos.rack/SOFTWARE#controlFlowsToConditionally",
+                        "UriValueType": "http://arcos.rack/SOFTWARE#COMPONENT",
+                        "ValueType": "COMPONENT"
+                    },
+                    {
+                        "ConnectBy": "controlFlowsToUnconditionally",
+                        "Connected": true,
+                        "DeletionMarkers": [
+                            false
+                        ],
+                        "KeyName": "controlFlowsToUnconditionally",
+                        "OptionalMinus": [
+                            "1"
+                        ],
+                        "Qualifiers": [
+                            ""
+                        ],
+                        "SnodeSparqlIDs": [
+                            "?CONTROL_FLOW_UNCONDITIONAL"
+                        ],
+                        "UriConnectBy": "http://arcos.rack/SOFTWARE#controlFlowsToUnconditionally",
+                        "UriValueType": "http://arcos.rack/SOFTWARE#COMPONENT",
+                        "ValueType": "COMPONENT"
+                    },
+                    {
+                        "ConnectBy": "definedIn",
+                        "Connected": true,
+                        "DeletionMarkers": [
+                            false
+                        ],
+                        "KeyName": "definedIn",
+                        "OptionalMinus": [
+                            "1"
+                        ],
+                        "Qualifiers": [
+                            ""
+                        ],
+                        "SnodeSparqlIDs": [
+                            "?DEFINE_IN"
+                        ],
+                        "UriConnectBy": "http://arcos.rack/SOFTWARE#definedIn",
+                        "UriValueType": "http://arcos.rack/PROV-S#ENTITY",
+                        "ValueType": "ENTITY"
+                    },
+                    {
+                        "ConnectBy": "instantiates",
+                        "Connected": true,
+                        "DeletionMarkers": [
+                            false
+                        ],
+                        "KeyName": "instantiates",
+                        "OptionalMinus": [
+                            "1"
+                        ],
+                        "Qualifiers": [
+                            ""
+                        ],
+                        "SnodeSparqlIDs": [
+                            "?INSTANTIATE"
+                        ],
+                        "UriConnectBy": "http://arcos.rack/SOFTWARE#instantiates",
+                        "UriValueType": "http://arcos.rack/PROV-S#ENTITY",
+                        "ValueType": "ENTITY"
+                    },
+                    {
+                        "ConnectBy": "mentions",
+                        "Connected": true,
+                        "DeletionMarkers": [
+                            false
+                        ],
+                        "KeyName": "mentions",
+                        "OptionalMinus": [
+                            "1"
+                        ],
+                        "Qualifiers": [
+                            ""
+                        ],
+                        "SnodeSparqlIDs": [
+                            "?MENTION"
+                        ],
+                        "UriConnectBy": "http://arcos.rack/SOFTWARE#mentions",
+                        "UriValueType": "http://arcos.rack/PROV-S#ENTITY",
+                        "ValueType": "ENTITY"
+                    },
+                    {
+                        "ConnectBy": "requirements",
+                        "Connected": true,
+                        "DeletionMarkers": [
+                            false
+                        ],
+                        "KeyName": "requirements",
+                        "OptionalMinus": [
+                            "1"
+                        ],
+                        "Qualifiers": [
+                            ""
+                        ],
+                        "SnodeSparqlIDs": [
+                            "?REQUIREMENT"
+                        ],
+                        "UriConnectBy": "http://arcos.rack/SOFTWARE#requirements",
+                        "UriValueType": "http://arcos.rack/PROV-S#ENTITY",
+                        "ValueType": "ENTITY"
+                    },
+                    {
+                        "ConnectBy": "subcomponentOf",
+                        "Connected": true,
+                        "DeletionMarkers": [
+                            false
+                        ],
+                        "KeyName": "subcomponentOf",
+                        "OptionalMinus": [
+                            "1"
+                        ],
+                        "Qualifiers": [
+                            ""
+                        ],
+                        "SnodeSparqlIDs": [
+                            "?SUBCOMPONENT"
+                        ],
+                        "UriConnectBy": "http://arcos.rack/SOFTWARE#subcomponentOf",
+                        "UriValueType": "http://arcos.rack/PROV-S#ENTITY",
+                        "ValueType": "ENTITY"
+                    }
+                ],
+                "propList": [
+                    {
+                        "Constraints": "",
+                        "KeyName": "name",
+                        "SparqlID": "?name",
+                        "UriRelationship": "http://arcos.rack/SOFTWARE#name",
+                        "ValueType": "string",
+                        "fullURIName": "",
+                        "instanceValues": [],
+                        "isMarkedForDeletion": false,
+                        "isReturned": true,
+                        "isRuntimeConstrained": false,
+                        "optMinus": 1,
+                        "relationship": "http://www.w3.org/2001/XMLSchema#string"
+                    },
+                    {
+                        "Constraints": "",
+                        "KeyName": "identifier",
+                        "SparqlID": "?identifier",
+                        "UriRelationship": "http://arcos.rack/PROV-S#identifier",
+                        "ValueType": "string",
+                        "fullURIName": "",
+                        "instanceValues": [],
+                        "isMarkedForDeletion": false,
+                        "isReturned": true,
+                        "isRuntimeConstrained": false,
+                        "optMinus": 0,
+                        "relationship": "http://www.w3.org/2001/XMLSchema#string"
+                    },
+                    {
+                        "Constraints": "",
+                        "KeyName": "valueType",
+                        "SparqlID": "?valueType",
+                        "UriRelationship": "http://arcos.rack/SOFTWARE#valueType",
+                        "ValueType": "string",
+                        "fullURIName": "",
+                        "instanceValues": [],
+                        "isMarkedForDeletion": false,
+                        "isReturned": true,
+                        "isRuntimeConstrained": false,
+                        "optMinus": 1,
+                        "relationship": "http://www.w3.org/2001/XMLSchema#string"
+                    }
+                ],
+                "subClassNames": [],
+                "valueConstraint": ""
+            }
+        ],
+        "version": 11
+    },
+    "sparqlConn": {
+        "data": [
+            {
+                "graph": "http://rack001/data",
+                "type": "fuseki",
+                "url": "http://localhost:3030/RACK"
+            }
+        ],
+        "domain": "",
+        "enableOwlImports": true,
+        "model": [
+            {
+                "graph": "http://rack001/model",
+                "type": "fuseki",
+                "url": "http://localhost:3030/RACK"
+            }
+        ],
+        "name": "MyDB"
+    },
+    "version": 2
+}

--- a/Turnstile-Ontology/99-Utils/NodeGroups/store_data.csv
+++ b/Turnstile-Ontology/99-Utils/NodeGroups/store_data.csv
@@ -1,4 +1,5 @@
 ID,comments,creator,jsonFile
+Ingest-SoftwareComponent,Node group to ingest COMPONENT data for the RACK-in-a-Box Turnstile example.,Turnstile,Ingest-SoftwareComponent.json
 Ingest-SoftwareComponentTestResult,Node group to ingest SoftwareComponentTestResult data for the RACK-in-a-Box Turnstile example.,Turnstile,Ingest-SoftwareComponentTestResult.json
 Ingest-SoftwareUnitTest,Node group to ingest SoftwareUnitTest data for the RACK-in-a-Box Turnstile example.,Turnstile,Ingest-SoftwareUnitTest.json
 Ingest-SoftwareThread,Node group to ingest SoftwareThread data for the RACK-in-a-Box Turnstile example.,Turnstile,Ingest-SoftwareThread.json

--- a/Turnstile-Ontology/OwlModels/CounterApplication.owl
+++ b/Turnstile-Ontology/OwlModels/CounterApplication.owl
@@ -192,6 +192,34 @@
     <j.3:filename>dist.tar</j.3:filename>
     <j.2:identifier>dist_tar</j.2:identifier>
   </j.3:FILE>
+  <j.1:COMPONENT rdf:ID="main_function">
+    <j.1:definedIn rdf:resource="#counter_c"/>
+    <j.1:controlFlowsToUnconditionally>
+      <j.1:COMPONENT rdf:ID="output_function">
+        <j.1:definedIn rdf:resource="#output_c"/>
+        <j.1:valueType>void()</j.1:valueType>
+        <j.1:name>output</j.1:name>
+        <j.1:componentType rdf:resource="http://arcos.rack/SOFTWARE#SOURCE_FUNCTION"/>
+        <j.2:dataInsertedBy rdf:resource="#Mockup"/>
+        <j.2:identifier>output_function</j.2:identifier>
+      </j.1:COMPONENT>
+    </j.1:controlFlowsToUnconditionally>
+    <j.1:controlFlowsToUnconditionally>
+      <j.1:COMPONENT rdf:ID="input_function">
+        <j.1:definedIn rdf:resource="#input_c"/>
+        <j.1:valueType>void()</j.1:valueType>
+        <j.1:name>input</j.1:name>
+        <j.1:componentType rdf:resource="http://arcos.rack/SOFTWARE#SOURCE_FUNCTION"/>
+        <j.2:dataInsertedBy rdf:resource="#Mockup"/>
+        <j.2:identifier>input_function</j.2:identifier>
+      </j.1:COMPONENT>
+    </j.1:controlFlowsToUnconditionally>
+    <j.1:valueType>int(int argc, char* argv[])</j.1:valueType>
+    <j.1:name>main</j.1:name>
+    <j.2:dataInsertedBy rdf:resource="#Mockup"/>
+    <j.1:componentType rdf:resource="http://arcos.rack/SOFTWARE#SOURCE_FUNCTION"/>
+    <j.2:identifier>main_function</j.2:identifier>
+  </j.1:COMPONENT>
   <j.0:SoftwareIntegration rdf:ID="test_exe_Compiling">
     <j.1:compileInput>
       <j.0:SourceCode rdf:ID="test_h">


### PR DESCRIPTION
Fixes #240 

@russell-d-e @AbhaMoitra This commit reintroduces a small number of components back into turnstile so that the *Control Flow From Function* query has something to do. I didn't know how to use Dan's python code to generate the CSV or nodegroups and so I've just copied what we used to have to get things working quickly for the imminent release.