### PR TITLE
Assist file updates

### DIFF
--- a/Turnstile-Ontology/02-Software/03-Implementation/Makefile
+++ b/Turnstile-Ontology/02-Software/03-Implementation/Makefile
@@ -21,7 +21,7 @@ lib%.so: %.o
 	$(CC) $(CFLAGS) -shared -o $@ $<
 
 $(EXE): $(APP).c $(APP).h $(OBJECTS) $(LIBS)
-	$(CC) $(CFLAGS) -L$(PWD) -lhw -o $@ $< $(OBJECTS)
+	$(CC) $(CFLAGS) -L../$$(basename $$(pwd)) -lhw -o $@ $< $(OBJECTS)
 
 $(DIST): conf.json $(LIBS) $(EXE)
 	$(TAR) cf $@ $^

--- a/Turnstile-Ontology/02-Software/03-Implementation/Makefile
+++ b/Turnstile-Ontology/02-Software/03-Implementation/Makefile
@@ -35,4 +35,4 @@ test: $(TESTEXE)
 
 .PHONY: clean
 clean:
-	rm -f $(OBJECTS) $(LIBS) $(EXE) $(DIST) $(TESTEXE)
+	rm -f $(OBJECTS) $(LIBS) $(EXE) $(DIST) $(TESTEXE) .*.d .*.rack

--- a/assist/bin/ingest_data
+++ b/assist/bin/ingest_data
@@ -12,6 +12,9 @@ usage_exit() {
     echo "  If the -a option is specified, the data is not uploaded or"
     echo "  written to a file, but an analysis of the data is written to stdout."
     echo ""
+    echo "  The -r option can be used to specify additional data recognizer"
+    echo "  files to use (usually project-specific)."
+    echo ""
     echo "  Example:"
     # shellcheck disable=2086
     echo "    $ $(basename $0) http://TurnstileSystem Turnstile-Ontology"
@@ -25,10 +28,11 @@ loads=(
 
 mode="upload"
 
-while getopts "ao:" opt ; do
+while getopts "ao:r:" opt ; do
     case $opt in
         a) mode="analyze";;
         o) mode="$OPTARG";;
+        r) loads+=(-f $OPTARG);;
         ?) echo "Unrecognized option argument: $opt" >&2
            usage_exit >&2;;
     esac

--- a/assist/bin/ingest_data
+++ b/assist/bin/ingest_data
@@ -3,6 +3,7 @@
 # Copyright (c) 2020, General Electric Company and Galois, Inc.
 
 usage_exit() {
+    # shellcheck disable=SC2046
     echo Usage: $(basename "$0") '[-o OwlFile]' '[-a]' '[-r RecognizerFile]' DATA_NAMESPACE DATA_DIR
     echo ""
     echo "  Reads RACK ontology and creates instances from DATA_DIR data"

--- a/assist/bin/ingest_data
+++ b/assist/bin/ingest_data
@@ -32,7 +32,7 @@ while getopts "ao:r:" opt ; do
     case $opt in
         a) mode="analyze";;
         o) mode="$OPTARG";;
-        r) loads+=(-f $OPTARG);;
+        r) loads+=(-g "load_recognizer(${OPTARG@Q})");;
         ?) echo "Unrecognized option argument: $opt" >&2
            usage_exit >&2;;
     esac
@@ -44,13 +44,11 @@ if [ $# -ne 2 ] ; then
 fi
 
 case $mode in
-    upload) target="upload_model_to_rack"
-            ;;
+    upload) target="upload_model_to_rack";;
     analyze) target="report(${1@Q}, [])"
              loads+=(-f $(dirname "$0")/rack/analyze.pl)
              ;;
-    *) target="save_model_to_file(${mode@Q},${1@Q})"
-       ;;
+    *) target="save_model_to_file(${mode@Q},${1@Q})";;
 esac
 
 # add -q to suppress informational messages

--- a/assist/bin/ingest_data
+++ b/assist/bin/ingest_data
@@ -2,32 +2,51 @@
 # shellcheck disable=SC2207
 # Copyright (c) 2020, General Electric Company and Galois, Inc.
 
+usage_exit() {
+    echo Usage: $(basename "$0") '[-o OwlFile]' '[-a]' '[-r RecognizerFile]' DATA_NAMESPACE DATA_DIR
+    echo ""
+    echo "  Reads RACK ontology and creates instances from DATA_DIR data"
+    echo "  under the specified namespace.  The created instances are then"
+    echo "  uploaded to RACK (by default) or written to the specified OWL file."
+    echo ""
+    echo "  If the -a option is specified, the data is not uploaded or"
+    echo "  written to a file, but an analysis of the data is written to stdout."
+    echo ""
+    echo "  Example:"
+    # shellcheck disable=2086
+    echo "    $ $(basename $0) http://TurnstileSystem Turnstile-Ontology"
+    exit 1
+}
+
+
 loads=(
     -f $(dirname "$0")/rack/model.pl
 )
 
-# shellcheck disable=SC2046
-case $# in
-    2) target="upload_model_to_rack" ;;
-    3) if [ "$3" == "analysis" ]
-       then target="report(${1@Q}, [])"; loads+=(-f $(dirname "$0")/rack/analyze.pl)
-       else target="save_model_to_file(${3@Q},${1@Q})"
-       fi;;
-    *) echo Usage: $(basename "$0") DATA_NAMESPACE DATA_DIR '[OwlFile|"analysis"]'
-       echo ""
-       echo "  Reads RACK ontology and creates instances from DATA_DIR data"
-       echo "  under the specified namespace.  The created instances are then"
-       echo "  uploaded to RACK or written to the specified OWL file."
-       echo ""
-       echo "  If the third term is the word analysis, the data is not"
-       echo "  uploaded or written to a file, but an analysis of the data"
-       echo "  is written to stdout."
-       echo ""
-       echo "  Example:"
-       # shellcheck disable=2086
-       echo "    $ $(basename $0) http://TurnstileSystem/CounterApplication \ "
-       echo "           models/TurnstileSystem/src"
-       exit 1
+mode="upload"
+
+while getopts "ao:" opt ; do
+    case $opt in
+        a) mode="analyze";;
+        o) mode="$OPTARG";;
+        ?) echo "Unrecognized option argument: $opt" >&2
+           usage_exit >&2;;
+    esac
+done
+shift $((OPTIND-1))
+if [ $# -ne 2 ] ; then
+    echo "Invalid number of positional parameters" >&2
+    usage_exit >&2;
+fi
+
+case $mode in
+    upload) target="upload_model_to_rack"
+            ;;
+    analyze) target="report(${1@Q}, [])"
+             loads+=(-f $(dirname "$0")/rack/analyze.pl)
+             ;;
+    *) target="save_model_to_file(${mode@Q},${1@Q})"
+       ;;
 esac
 
 # add -q to suppress informational messages

--- a/assist/bin/rack/check.pl
+++ b/assist/bin/rack/check.pl
@@ -206,4 +206,4 @@ prolog:message(property_value_wrong_type(Instance, Property, DefType, Val, ValTy
       prefix_shorten(Val, SV)
     },
     [ 'Instance property ~w . ~w of ~w should be a ~w but is a ~w'-[
-          SI, SP, SV, SDTy, SVTy] ].
+          SI, SP, SV, SVTy, SDTy] ].

--- a/assist/bin/rack/model.pl
+++ b/assist/bin/rack/model.pl
@@ -627,7 +627,14 @@ add_rdfdata(RDFClass, Class, DataRef, Data) :-
 add_rdfproperty(ShortC, ShortP, _RDFClass, Property, DataRef, Data) :-
     data_get(ShortC, ShortP, Data, Value),
     (
-        % If this is an atom, treat it as a shorthand reference to an
+        % If this is an atom, it might be existing or might need to be created.
+
+        % Is it already full qualified and should be left untouched?
+        atom(Value),
+        atom_concat('http', _, Value), !,
+        TargetRef = Value;
+
+        % Check if it is a shorthand reference to an
         % object in the current namespace or the RACK ontology namespace
         atom(Value),
         rack_ref(_ShortVal, Value), !,

--- a/assist/bin/rack/model.pl
+++ b/assist/bin/rack/model.pl
@@ -602,6 +602,7 @@ rdf_dataref(RDFClass, Data, Instance) :-
     rack_namespace(NS),
     ns_ref(NS, InstanceSuffix, Instance),
     add_triple(Instance, rdf:type, RDFClass),
+    % Use InstanceData to drive data_get property relation definitions
     (is_list(InstanceData),
      add_each_rdfdata(RDFClass, RDFClass, Instance, InstanceData);
      \+ is_list(InstanceData),

--- a/assist/bin/rack/model.pl
+++ b/assist/bin/rack/model.pl
@@ -734,6 +734,6 @@ data_get(_, 'PROV-S#identifier', uid(UID,_,_), UIDStr) :- atom_string(UID, UIDSt
 data_get(_, 'PROV-S#title', uid(_,Title,_), Title).
 data_get(_, 'PROV-S#description', uid(_,_,Description), Description).
 
-data_get('SOFTWARE#FILE', 'SOFTWARE#filename', sw_file_data(_, Dir, NameOrPath), Value) :-
+data_get('FILE#FILE', 'FILE#filename', sw_file_data(_, Dir, NameOrPath), Value) :-
     file_to_fpath(NameOrPath, Dir, Path),
     atom_string(Path, Value).

--- a/assist/bin/rack/model.pl
+++ b/assist/bin/rack/model.pl
@@ -709,8 +709,10 @@ load_recognizer(FPath) :-
 
 :- multifile data_instance/4, data_get/4.
 
-data_instance('PROV-S#ACTIVITY', load_data_start, ModelName, [uid(ModelName),
-                                                              model_start(ModelName, StartTime)]) :-
+data_instance('PROV-S#ACTIVITY', load_data_start, ModelName,
+              [uid(ModelName, "assist model",
+                   "The RACK ASSIST model for automated ingestion"),
+               model_start(ModelName, StartTime)]) :-
     rack_model_name(ModelName),
     % n.b. get_time/1 is impure and unstable, so call it in the
     % data_instance which is only called once as opposed to the
@@ -727,7 +729,9 @@ data_get('PROV-S#ACTIVITY', 'PROV-S#startedAtTime', model_start(ModelName, Start
 data_get('PROV-S#ACTIVITY', 'PROV-S#endedAtTime', model_end(ModelName, EndTime), EndTime) :-
     rack_model_name(ModelName).
 
-data_get(_, 'PROV-S#identifier', uid(UID), UIDStr) :- atom_string(UID, UIDStr).
+data_get(_, 'PROV-S#identifier', uid(UID,_,_), UIDStr) :- atom_string(UID, UIDStr).
+data_get(_, 'PROV-S#title', uid(_,Title,_), Title).
+data_get(_, 'PROV-S#description', uid(_,_,Description), Description).
 
 data_get('SOFTWARE#FILE', 'SOFTWARE#filename', sw_file_data(_, Dir, NameOrPath), Value) :-
     file_to_fpath(NameOrPath, Dir, Path),

--- a/assist/bin/rack/model.pl
+++ b/assist/bin/rack/model.pl
@@ -608,9 +608,10 @@ add_each_rdfdata(RDFClass, Class, DataRef, DataList) :-
     add_rdfdata(RDFClass, Class, DataRef, Data).
 
 add_rdfdata(RDFClass, Class, DataRef, Data) :-
-    (rdf(Class, rdfs:subClassOf, Parent), !,
-     (add_rdfdata(RDFClass, Parent, DataRef, Data);true) ;
-     true),
+    rdf(Class, rdfs:subClassOf, Parent),
+    add_rdfdata(RDFClass, Parent, DataRef, Data).
+
+add_rdfdata(RDFClass, Class, DataRef, Data) :-
     property(Class, Property, _),
     rack_ref(ShortC, RDFClass),
     rack_ref(ShortP, Property),

--- a/assist/bin/rack/model.pl
+++ b/assist/bin/rack/model.pl
@@ -341,6 +341,7 @@ ontology_leaf_class(C) :-
       findall(OtherPCRef,
               (rdf(OtherPCRef, rdf:type, owl:'Class'),
                rdf(OtherPCRef, rdfs:subClassOf, PCRef),
+               OtherPCRef \= C,  % because C is reachable from C below
                % OtherPCRef \= 'http://arcos.rack/PROV-S#THING',
                rdf_reachable(C, rdfs:subClassOf, OtherPCRef)),
               OtherRefs),

--- a/assist/bin/rack/model.pl
+++ b/assist/bin/rack/model.pl
@@ -518,7 +518,12 @@ realize_loaded_data :-
     findall(Instance, rdf_dataref(_RDFClass2, load_data, Instance), LdInstances),
     findall(Instance, rdf_dataref(_RDFClass3, load_data_finish, Instance), FiInstances),
     append(StInstances, LdInstances, StLdInstances),
-    append(StLdInstances, FiInstances, Instances),
+    append(StLdInstances, FiInstances, PrimaryInstances),
+    rack_namespace(NS),
+    findall(Instance, (member(PIRef, PrimaryInstances),
+                       ns_ref(NS, PI, PIRef),
+                       rdf_dataref(_RDFClass4, generated_from(PI), Instance)), GenInstances),
+    append(PrimaryInstances, GenInstances, Instances),
     length(Instances, Count),
     rack_namespace(Namespace),
     print_message(informational, loaded_data_instances(Namespace, Count)).

--- a/assist/bin/rack/model.pl
+++ b/assist/bin/rack/model.pl
@@ -620,8 +620,11 @@ add_rdfproperty(ShortC, ShortP, _RDFClass, Property, DataRef, Data) :-
     data_get(ShortC, ShortP, Data, Value),
     (
         % If this is an atom, treat it as a shorthand reference to an
-        % object in the current namespace.
-        %
+        % object in the current namespace or the RACK ontology namespace
+        atom(Value),
+        rack_ref(_ShortVal, Value), !,
+        TargetRef = Value ;
+
         % Note that the reference might not have been explicitly
         % defined.  From an RDF-triple perspective, this is fine:
         % simply creating this property causes it to *exist* because

--- a/assist/databin/databin.rack
+++ b/assist/databin/databin.rack
@@ -17,7 +17,8 @@ databin_name(MyName) :-
                  build_start/2,
                  build_finished/3,
                  build_user/2,
-                 file_sha1/3.
+                 file_sha1/3,
+                 file_committer/2.
 
 %% Recognizers for matching tool output data
 
@@ -182,6 +183,10 @@ data_get('FILE#FILE', 'FILE#fileFormat',
     % (e.g. a .o object file)
     build_from(Nonce, Dir),
     \+ output_of(compile, Dir, F, _).
+
+data_get('FILE#FILE', 'PROV-S#wasAttributedTo', sw_file_data(_, _, F), Committer) :-
+    file_committer(F, C),
+    atom_string(C, Committer).
 
 output_of(Tool, Dir, F, BuildNonce) :-
     % File F in dir Dir might be the output of a previous build (if

--- a/assist/databin/databin.rack
+++ b/assist/databin/databin.rack
@@ -204,6 +204,12 @@ data_get('FILE#FILE', 'FILE#createBy', sw_file_data(Nonce, _, F), V) :-
     member(F, FS),
     build_with(Nonce, ToolType, _ToolName, _ToolPath, _ToolArgs),
     append_fld(Nonce, ToolType, V).
+data_get('FILE#FILE', 'FILE#wasGeneratedBy', sw_file_data(Nonce, _, F), V) :-
+    build_outputs(Nonce, FS),
+    member(F, FS),
+    build_with(Nonce, ToolType, _ToolName, _ToolPath, _ToolArgs),
+    append_fld(Nonce, ToolType, V).
+
 
 data_get('FILE#FILE', 'FILE#fileHash', uid(FileInstance, _, _), FileHashRef) :-
     file_sha1(FName, _SHA1, Nonce),

--- a/assist/databin/databin.rack
+++ b/assist/databin/databin.rack
@@ -225,6 +225,10 @@ data_get('FILE#FILE', 'PROV-S#wasDerivedFrom', sw_file_data(Nonce, Dir, File), I
     member(InpFile, InpFiles),
     file_instance(Nonce, Dir, InpFile, InputInstance).
 
+data_get('FILE#FILE', 'PROV-S#generatedAtTime', sw_file_data(Nonce, _, File), GenTime) :-
+    build_outputs(Nonce, OutFiles),
+    member(File, OutFiles),
+    build_finished(Nonce, GenTime, _).
 
 data_get('FILE#FILE', 'FILE#fileHash', uid(FileInstance, _, _), FileHashRef) :-
     file_sha1(FName, _SHA1, Nonce),

--- a/assist/databin/databin.rack
+++ b/assist/databin/databin.rack
@@ -120,7 +120,7 @@ data_instance('FILE#FILE', load_data, ToolPath,
     build_with(Nonce, _ToolType, _ToolName, ToolPath, _ToolArgs),
     UID = ToolPath.
 
-data_get('SOFTWARE#FILE', 'SOFTWARE#fileFormat',
+data_get('FILE#FILE', 'FILE#fileFormat',
          sw_file_data(Nonce, _, F), 'CSourceFile') :-
     build_inputs(Nonce, FS),
     member(F, FS),

--- a/assist/databin/databin.rack
+++ b/assist/databin/databin.rack
@@ -96,6 +96,26 @@ data_get('SOFTWARE#PACKAGE', 'SOFTWARE#packageInput', package_tar(Nonce), V) :-
     build_from(Nonce, Dir),
     file_instance(Nonce, Dir, File, V).
 
+data_get('SOFTWARE#PACKAGE', 'SOFTWARE#packagedBy', package_tar(Nonce), TarPath) :-
+    tar_start(Nonce, _, TarPath).
+
+data_get('SOFTWARE#PACKAGE', 'PROV-S#wasAssociatedWith',
+         package_tar(N),
+         UserInstance) :-
+    build_user(N, UserName),
+    user_instance_name(UserName, UserInstance).
+data_get('SOFTWARE#PACKAGE', 'SOFTWARE#performedBy',
+         package_tar(N),
+         UserInstance) :-
+    build_user(N, UserName),
+    user_instance_name(UserName, UserInstance).
+
+
+data_get('FILE#FILE', 'FILE#fileParent', sw_file_data(Nonce, Dir, File), ParentInstance) :-
+    tar_access(Nonce, File, open),
+    tar_access(Nonce, ParentFile, create),
+    file_instance(Nonce, Dir, ParentFile, ParentInstance).
+
 data_get(_, 'PROV-S#startedAtTime', package_tar(N), T) :- tar_start(N, T, _).
 data_get(_, 'PROV-S#endedAtTime', package_tar(N), T) :- tar_finished(N, T, _).
 

--- a/assist/databin/databin.rack
+++ b/assist/databin/databin.rack
@@ -26,7 +26,8 @@ databin_name(MyName) :-
 data_instance('PROV-S#ACTIVITY', % create an instance of this
               load_data_start,   % on this event (starting ingestion)
               MyName,            % output name
-              [uid(MyName),ingesting_data(StartTime)]   % output attributes ot match data_get operations
+              [uid(MyName, "assist ingestion", "The RACK ASSIST ingestion process"),
+               ingesting_data(StartTime)]   % output attributes ot match data_get operations
              ) :-
     databin_name(MyName),
     get_time(TS), stamp_date_time(TS, date(_Y,Mo,D,H,Min,S,UTCOff,_TZName,_DST), local),
@@ -79,8 +80,11 @@ data_get(_, 'PROV-S#startedAtTime', package_tar(N), T) :- tar_start(N, T, _).
 data_get(_, 'PROV-S#endedAtTime', package_tar(N), T) :- tar_finished(N, T, _).
 
 data_instance('FILE#FILE', load_data, TarPath,
-              [uid(TarPath), sw_file_data(Nonce, '/tmp', TarPath)]) :-
-    tar_start(Nonce, _, TarPath).
+              [uid(TarPath, Title, Descr),
+               sw_file_data(Nonce, '/tmp', TarPath)]) :-
+    tar_start(Nonce, _, TarPath),
+    atom_string(TarPath, Title),
+    string_concat(Title, " file", Descr).
 
 data_get('FILE#FILE', 'FILE#createBy', sw_file_data(Nonce, Dir, File), V) :-
     tar_access(Nonce, File, create),
@@ -106,19 +110,28 @@ data_instance('FILE#FILE', load_data, Instance, InstanceData) :-
     build_from(Nonce, Dir),
     member(Input, Inputs),
     file_instance(Nonce, Dir, Input, Instance),
-    InstanceData = [uid(Instance), sw_file_data(Nonce, Dir, Input)].
+    atom_string(Input, Title),
+    string_concat(Title, " file", Descr),
+    InstanceData = [uid(Instance, Title, Descr),
+                    sw_file_data(Nonce, Dir, Input)].
 
 data_instance('FILE#FILE', load_data, Instance, InstanceData) :-
     build_outputs(Nonce, Outputs),
     build_from(Nonce, Dir),
     member(Output, Outputs),
     file_instance(Nonce, Dir, Output, Instance),
-    InstanceData = [uid(Instance), sw_file_data(Nonce, Dir, Output)].
+    atom_string(Output, Title),
+    string_concat(Title, " file", Descr),
+    InstanceData = [uid(Instance, Title, Descr),
+                    sw_file_data(Nonce, Dir, Output)].
 
 data_instance('FILE#FILE', load_data, ToolPath,
-              [uid(UID), sw_file_data(Nonce, '/tmp', ToolPath)]) :-
+              [uid(UID, Title, Descr),
+               sw_file_data(Nonce, '/tmp', ToolPath)]) :-
     build_with(Nonce, _ToolType, _ToolName, ToolPath, _ToolArgs),
-    UID = ToolPath.
+    UID = ToolPath,
+    Title = ToolPath,
+    string_concat(Title, " file", Descr).
 
 data_get('FILE#FILE', 'FILE#fileFormat',
          sw_file_data(Nonce, _, F), 'CSourceFile') :-
@@ -152,46 +165,34 @@ data_get('FILE#FILE', 'FILE#createBy', sw_file_data(Nonce, _, F), V) :-
     build_with(Nonce, ToolType, _ToolName, _ToolPath, _ToolArgs),
     append_fld(Nonce, ToolType, V).
 
-data_get('FILE#FILE', 'FILE#fileHash', uid(FileInstance), FileHashRef) :-
+data_get('FILE#FILE', 'FILE#fileHash', uid(FileInstance, _, _), FileHashRef) :-
     file_sha1(FName, _SHA1, Nonce),
     file_instance(Nonce, _, FName, FileInstance),
     append_fld(FileInstance, 'hash', FileHashRef).
 
 data_instance('FILE#FILE_HASH', generated_from(FileInstance), Instance,
-              [uid(Instance), file_hash(FName, SHA1)]) :-
+              [uid(Instance, Title, Descr),
+               file_hash(FName, SHA1)]) :-
     file_sha1(FName, SHA1, Nonce),
     build_from(Nonce, Dir),
     file_instance(Nonce, Dir, FName, FileInstance),
-    append_fld(FileInstance, 'hash', Instance).
+    append_fld(FileInstance, 'hash', Instance),
+    atom_string(FName, FNameStr),
+    string_concat(FNameStr, " hash", Title),
+    string_concat(FNameStr, " SHA1 hash value of file contents", Descr).
 data_get('FILE#FILE_HASH', 'FILE#hashType', file_hash(_, Hash), HashRef) :-
     file_sha1(_, Hash, _),
     rack_ref('FILE#SHA1', HashRef).
 data_get('FILE#FILE_HASH', 'FILE#hashValue', file_hash(_, Hash), HashStr) :-
     atom_string(Hash, HashStr).
-data_get('FILE#FILE_HASH', 'PROV-S#title', file_hash(FName, _), Title) :-
-    atom_string(FName, FNameStr),
-    string_concat(FNameStr, " hash", Title).
-data_get('FILE#FILE_HASH', 'PROV-S#description', file_hash(FName, Hash), Description) :-
-    atom_string(FName, FNameStr),
-    file_sha1(FName, Hash, _),
-    string_concat(FNameStr, " SHA1 hash value of file contents", Description).
 
 %% -- Formats ------------------------------
 
-data_instance('FILE#FORMAT', load_data, F, [uid(F), fmt(F)]) :-
-    member(F, [ 'CSourceFile', 'ElfFile', 'TarFile', 'ArchiveFile' ]).
+data_instance('FILE#FORMAT', load_data, F, [uid(F, Title, Descr), fmt(F)]) :-
+    member(F, [ 'CSourceFile', 'ElfFile', 'TarFile', 'ArchiveFile' ]),
+    Title = F,
+    string_concat(Title, " file format", Descr).
 
-data_get('FILE#FORMAT', 'PROV-S#title', fmt('CSourceFile'), "C-source").
-data_get('FILE#FORMAT', 'PROV-S#description', fmt('CSourceFile'), "Compileable source written in the C language").
-
-data_get('FILE#FORMAT', 'PROV-S#title', fmt('ElfFile'), "object/executable").
-data_get('FILE#FORMAT', 'PROV-S#description', fmt('ElfFile'), "Binary object or executable").
-
-data_get('FILE#FORMAT', 'PROV-S#title', fmt('TarFile'), "archive:tar").
-data_get('FILE#FORMAT', 'PROV-S#description', fmt('TarFile'), "Multi-file archive format (TAR)").
-
-data_get('FILE#FORMAT', 'PROV-S#title', fmt('ArchiveFile'), "archive:library").
-data_get('FILE#FORMAT', 'PROV-S#description', fmt('ArchiveFile'), "Multi-file library archive format (AR)").
 
 %% -- Activities ------------------------------
 
@@ -201,12 +202,15 @@ activity_instance(Nonce, ToolType, InstanceName) :-
 %% -------------------- COMPILE
 
 data_instance('SOFTWARE#COMPILE', load_data, Instance,
-              [ uid(Instance), activity_data(BW,BS,BF) ]) :-
+              [ uid(Instance, Title, Descr),
+                activity_data(BW,BS,BF) ]) :-
     BW = build_with(Nonce, compile, _ToolName, _ToolPath, _ToolArgs),  % compile tool
     BS = build_start(Nonce, _StartTime),
     BF = build_finished(Nonce, _FinishTime, _ExitVal),
     BW, BS, BF,
-    activity_instance(Nonce, compile, Instance).
+    activity_instance(Nonce, compile, Instance),
+    Title = "compilation",
+    Descr = "Execution of the compiler".
 
 data_get('SOFTWARE#COMPILE', 'SOFTWARE#compiledBy',
          activity_data(build_with(_, compile, _, ToolPath, _),_,_),
@@ -225,12 +229,15 @@ data_get('SOFTWARE#COMPILE', 'SOFTWARE#performedBy',
 %% -------------------- MAKE
 
 data_instance('SOFTWARE#BUILD', load_data, Instance,
-              [ uid(Instance), activity_data(BW,BS,BF) ]) :-
+              [ uid(Instance, Title, Descr),
+                activity_data(BW,BS,BF) ]) :-
     BW = build_with(Nonce, make, _ToolName, _ToolPath, _ToolArgs),   % make tool
     BS = build_start(Nonce, _StartTime),
     BF = build_finished(Nonce, _FinishTime, _ExitVal),
     BW, BS, BF,
-    activity_instance(Nonce, make, Instance).
+    activity_instance(Nonce, make, Instance),
+    Title = "build",
+    Descr = "Build tool invocation".
 
 data_get('SOFTWARE#BUILD', 'SOFTWARE#step',
          activity_data(build_with(BuildNonce, _, _, _, _),_,_), V) :-
@@ -246,14 +253,16 @@ data_get(_, 'PROV-S#wasInformedBy', activity_data(build_with(ToolNonce, ToolType
     activity_instance(MakeNonce, make, MakeInstance).
 
 data_instance('PROV-S#ACTIVITY', load_data, Instance,
-              [ uid(Instance), activity_data(BW,BS,BF) ]) :-
+              [ uid(Instance, Title, Descr), activity_data(BW,BS,BF) ]) :-
     BW = build_with(Nonce, ToolType, _ToolName, _ToolPath, _ToolArgs),
     BS = build_start(Nonce, _StartTime),
     BF = build_finished(Nonce, _FinishTime, _ExitVal),
     BW, BS, BF,
     ToolType \= compile,
     ToolType \= make,
-    activity_instance(Nonce, ToolType, Instance).
+    activity_instance(Nonce, ToolType, Instance),
+    atom_string(ToolType, Title),
+    string_concat(Title, " tool invocation", Descr).
 
 data_instance('PROV-S#AGENT', load_data, Instance, [ activity_data(user_instance(BU, Instance)) ]) :-
     BU = build_user(_Nonce, UserName),

--- a/assist/databin/databin.rack
+++ b/assist/databin/databin.rack
@@ -160,6 +160,18 @@ data_instance('FILE#FORMAT', load_data, F, [uid(F), fmt(F)]) :-
 data_get('FILE#FORMAT', 'PROV-S#identifier', fmt(Fmt), FmtS) :-
     atom_string(Fmt, FmtS).
 
+data_get('FILE#FORMAT', 'PROV-S#title', fmt('CSourceFile'), "C-source").
+data_get('FILE#FORMAT', 'PROV-S#description', fmt('CSourceFile'), "Compileable source written in the C language").
+
+data_get('FILE#FORMAT', 'PROV-S#title', fmt('ElfFile'), "object/executable").
+data_get('FILE#FORMAT', 'PROV-S#description', fmt('ElfFile'), "Binary object or executable").
+
+data_get('FILE#FORMAT', 'PROV-S#title', fmt('TarFile'), "archive:tar").
+data_get('FILE#FORMAT', 'PROV-S#description', fmt('TarFile'), "Multi-file archive format (TAR)").
+
+data_get('FILE#FORMAT', 'PROV-S#title', fmt('ArchiveFile'), "archive:library").
+data_get('FILE#FORMAT', 'PROV-S#description', fmt('ArchiveFile'), "Multi-file library archive format (AR)").
+
 %% -- Activities ------------------------------
 
 activity_instance(Nonce, ToolType, InstanceName) :-

--- a/assist/databin/databin.rack
+++ b/assist/databin/databin.rack
@@ -157,7 +157,8 @@ data_get('FILE#FILE', 'FILE#fileHash', uid(FileInstance), FileHashRef) :-
     file_instance(Nonce, _, FName, FileInstance),
     append_fld(FileInstance, 'hash', FileHashRef).
 
-data_instance('FILE#FILE_HASH', generated_from(FileInstance), Instance, file_hash(FileInstance, SHA1)) :-
+data_instance('FILE#FILE_HASH', generated_from(FileInstance), Instance,
+              [uid(Instance), file_hash(FName, SHA1)]) :-
     file_sha1(FName, SHA1, Nonce),
     build_from(Nonce, Dir),
     file_instance(Nonce, Dir, FName, FileInstance),
@@ -167,13 +168,18 @@ data_get('FILE#FILE_HASH', 'FILE#hashType', file_hash(_, Hash), HashRef) :-
     rack_ref('FILE#SHA1', HashRef).
 data_get('FILE#FILE_HASH', 'FILE#hashValue', file_hash(_, Hash), HashStr) :-
     atom_string(Hash, HashStr).
+data_get('FILE#FILE_HASH', 'PROV-S#title', file_hash(FName, _), Title) :-
+    atom_string(FName, FNameStr),
+    string_concat(FNameStr, " hash", Title).
+data_get('FILE#FILE_HASH', 'PROV-S#description', file_hash(FName, Hash), Description) :-
+    atom_string(FName, FNameStr),
+    file_sha1(FName, Hash, _),
+    string_concat(FNameStr, " SHA1 hash value of file contents", Description).
 
 %% -- Formats ------------------------------
 
 data_instance('FILE#FORMAT', load_data, F, [uid(F), fmt(F)]) :-
     member(F, [ 'CSourceFile', 'ElfFile', 'TarFile', 'ArchiveFile' ]).
-data_get('FILE#FORMAT', 'PROV-S#identifier', fmt(Fmt), FmtS) :-
-    atom_string(Fmt, FmtS).
 
 data_get('FILE#FORMAT', 'PROV-S#title', fmt('CSourceFile'), "C-source").
 data_get('FILE#FORMAT', 'PROV-S#description', fmt('CSourceFile'), "Compileable source written in the C language").

--- a/assist/databin/databin.rack
+++ b/assist/databin/databin.rack
@@ -132,6 +132,11 @@ data_get('FILE#FILE', 'FILE#createBy', sw_file_data(Nonce, Dir, File), V) :-
     build_from(Nonce, Dir),
     activity_instance(Nonce, tar, V).
 
+data_get('FILE#FILE', 'PROV-S#wasGeneratedBy', sw_file_data(Nonce, Dir, File), V) :-
+    tar_access(Nonce, File, create),
+    build_from(Nonce, Dir),
+    activity_instance(Nonce, tar, V).
+
 data_get('SOFTWARE#BUILD', 'SOFTWARE#step',
          activity_data(build_with(BuildNonce, _, _, _, _),_,_), V) :-
     build_step(BuildNonce, N),

--- a/assist/databin/databin.rack
+++ b/assist/databin/databin.rack
@@ -206,6 +206,11 @@ data_get('SOFTWARE#BUILD', 'SOFTWARE#step',
     build_step(BuildNonce, ToolNonce),
     activity_instance(ToolNonce, ToolType, V).
 
+data_get(_, 'PROV-S#wasInformedBy', activity_data(build_with(ToolNonce, ToolType,_,_,_),_,_), MakeInstance) :-
+    build_with(MakeNonce, make, _, _, _),
+    build_with(ToolNonce, ToolType, _, _, _),
+    build_step(MakeNonce, ToolNonce),
+    activity_instance(MakeNonce, make, MakeInstance).
 
 data_instance('PROV-S#ACTIVITY', load_data, Instance,
               [ uid(Instance), activity_data(BW,BS,BF) ]) :-

--- a/assist/databin/databin.rack
+++ b/assist/databin/databin.rack
@@ -152,6 +152,21 @@ data_get('FILE#FILE', 'FILE#createBy', sw_file_data(Nonce, _, F), V) :-
     build_with(Nonce, ToolType, _ToolName, _ToolPath, _ToolArgs),
     append_fld(Nonce, ToolType, V).
 
+data_get('FILE#FILE', 'FILE#fileHash', uid(FileInstance), FileHashRef) :-
+    file_sha1(FName, _SHA1, Nonce),
+    file_instance(Nonce, _, FName, FileInstance),
+    append_fld(FileInstance, 'hash', FileHashRef).
+
+data_instance('FILE#FILE_HASH', generated_from(FileInstance), Instance, file_hash(FileInstance, SHA1)) :-
+    file_sha1(FName, SHA1, Nonce),
+    build_from(Nonce, Dir),
+    file_instance(Nonce, Dir, FName, FileInstance),
+    append_fld(FileInstance, 'hash', Instance).
+data_get('FILE#FILE_HASH', 'FILE#hashType', file_hash(_, Hash), HashRef) :-
+    file_sha1(_, Hash, _),
+    rack_ref('FILE#SHA1', HashRef).
+data_get('FILE#FILE_HASH', 'FILE#hashValue', file_hash(_, Hash), HashStr) :-
+    atom_string(Hash, HashStr).
 
 %% -- Formats ------------------------------
 

--- a/assist/databin/databin.rack
+++ b/assist/databin/databin.rack
@@ -218,6 +218,13 @@ data_get('FILE#FILE', 'PROV-S#wasAttributedTo',
     member(File, OutFiles),
     user_instance_name(UserName, UserInstance).
 
+data_get('FILE#FILE', 'PROV-S#wasDerivedFrom', sw_file_data(Nonce, Dir, File), InputInstance) :-
+    build_outputs(Nonce, OutFiles),
+    member(File, OutFiles),
+    build_inputs(Nonce, InpFiles),
+    member(InpFile, InpFiles),
+    file_instance(Nonce, Dir, InpFile, InputInstance).
+
 
 data_get('FILE#FILE', 'FILE#fileHash', uid(FileInstance, _, _), FileHashRef) :-
     file_sha1(FName, _SHA1, Nonce),

--- a/assist/databin/databin.rack
+++ b/assist/databin/databin.rack
@@ -59,25 +59,34 @@ data_instance('PROV-S#AGENT', ingesting_data(_), Instance,
 %% -------------------- TAR FILES
 
 data_instance('FILE#FILE', load_data, Instance,
-              [ uid(Instance), sw_file_data(Nonce, Dir, File) ]) :-
+              [ uid(Instance, Title, Descr),
+                sw_file_data(Nonce, Dir, File) ]) :-
     tar_access(Nonce, File, create),
     build_from(Nonce, Dir),
-    file_instance(Nonce, Dir, File, Instance).
+    file_instance(Nonce, Dir, File, Instance),
+    atom_string(File, Title),
+    string_concat(Title, " file", Descr).
 
 data_instance('FILE#FILE', load_data, Instance,
-              [ uid(Instance), sw_file_data(Nonce, Dir, File) ]) :-
+              [ uid(Instance, Title, Descr),
+                sw_file_data(Nonce, Dir, File) ]) :-
     tar_access(Nonce, File, open),
     build_from(Nonce, Dir),
-    file_instance(Nonce, Dir, File, Instance).
+    file_instance(Nonce, Dir, File, Instance),
+    atom_string(File, Title),
+    string_concat(Title, " file", Descr).
 
 data_get('FILE#FILE', 'FILE#fileFormat',
          sw_file_data(Nonce, _, File), 'TarFile') :-
     tar_access(Nonce, File, create).
 
 data_instance('SOFTWARE#PACKAGE', load_data, Instance,
-              [ uid(Instance), package_tar(Nonce) ]) :-
+              [ uid(Instance, Title, Descr),
+                package_tar(Nonce) ]) :-
     tar_access(Nonce, _, create),
-    activity_instance(Nonce, tar, Instance).
+    activity_instance(Nonce, tar, Instance),
+    Title = "package:tar",
+    Descr = "Software package file in TAR format".
 
 data_get('SOFTWARE#PACKAGE', 'SOFTWARE#packagedBy', package_tar(N), ToolPath) :-
     tar_start(N, _, ToolPath).

--- a/assist/databin/databin.rack
+++ b/assist/databin/databin.rack
@@ -210,6 +210,14 @@ data_get('FILE#FILE', 'FILE#wasGeneratedBy', sw_file_data(Nonce, _, F), V) :-
     build_with(Nonce, ToolType, _ToolName, _ToolPath, _ToolArgs),
     append_fld(Nonce, ToolType, V).
 
+data_get('FILE#FILE', 'PROV-S#wasAttributedTo',
+         sw_file_data(Nonce, _, File),
+         UserInstance) :-
+    build_user(Nonce, UserName),
+    build_outputs(Nonce, OutFiles),
+    member(File, OutFiles),
+    user_instance_name(UserName, UserInstance).
+
 
 data_get('FILE#FILE', 'FILE#fileHash', uid(FileInstance, _, _), FileHashRef) :-
     file_sha1(FName, _SHA1, Nonce),

--- a/assist/databin/databin.rack
+++ b/assist/databin/databin.rack
@@ -214,6 +214,11 @@ data_get('FILE#FILE', 'FILE#wasGeneratedBy', sw_file_data(Nonce, _, F), V) :-
     member(F, FS),
     build_with(Nonce, ToolType, _ToolName, _ToolPath, _ToolArgs),
     append_fld(Nonce, ToolType, V).
+data_get('FILE#FILE', 'FILE#createBy', sw_file_data(Nonce, _, File), V) :-
+    sw_dev_for_file(_FileInstance, Nonce, V, File, _Committer).
+data_get('FILE#FILE', 'PROV-S#wasGeneratedBy', sw_file_data(Nonce, _, File), V) :-
+    sw_dev_for_file(_FileInstance, Nonce, V, File, _Committer).
+
 
 data_get('FILE#FILE', 'PROV-S#wasAttributedTo',
          sw_file_data(Nonce, _, File),
@@ -268,6 +273,32 @@ data_instance('FILE#FORMAT', load_data, F, [uid(F, Title, Descr), fmt(F)]) :-
 
 activity_instance(Nonce, ToolType, InstanceName) :-
     append_fld(Nonce, ToolType, InstanceName).
+
+
+%% -------------------- CODE_DEVELOPMENT
+
+data_instance('SOFTWARE#CODE_DEVELOPMENT', generated_from(FileInstance), Instance,
+              [ uid(Instance, "sw-development", "User development of software"),
+                sw_devel(FileInstance, File, Committer)
+              ]) :-
+    sw_dev_for_file(FileInstance, _, Instance, File, Committer).
+
+% given FileInstance or Nonce+File, can generate the rest (if applicable)
+sw_dev_for_file(FileInstance, Nonce, Instance, File, Committer) :-
+    build_inputs(Nonce, Inputs),
+    build_from(Nonce, Dir),
+    member(File, Inputs),
+    file_instance(Nonce, Dir, File, FileInstance),
+    file_committer(File, Committer),
+    atom_concat('sw-dev-', FileInstance, Instance).
+
+data_get('SOFTWARE#CODE_DEVELOPMENT', 'SOFTWARE#author', sw_devel(_, _, C), Committer) :-
+    atom_string(C, Committer).
+
+data_get('SOFTWARE#CODE_DEVELOPMENT', 'PROV-S#wasAssociatedWith', sw_devel(_, _, C), Committer) :-
+    atom_string(C, Committer).
+
+data_get('SOFTWARE#CODE_DEVELOPMENT', 'PROV-S#used', sw_devel(I,_,_), I).
 
 %% -------------------- COMPILE
 

--- a/assist/databin/databin.rack
+++ b/assist/databin/databin.rack
@@ -44,6 +44,17 @@ data_get('PROV-S#ACTIVITY',         % for an instance of this
 data_get('PROV-S#ACTIVITY', 'PROV-S#wasInformedBy', ingesting_data(_), ModelName) :-
     rack_model_name(ModelName).
 data_get('PROV-S#ACTIVITY', 'PROV-S#endedAtTime', ingested_data(EndTime), EndTime).
+data_get('PROV-S#ACTIVITY', 'PROV-S#wasAssociatedWith', ingesting_data(_), UserInstance) :-
+    geteuid(UID),
+    user_info(UID, UserData),
+    user_data(name, UserData, UserName),
+    user_instance_name(UserName, UserInstance).
+data_instance('PROV-S#AGENT', ingesting_data(_), Instance,
+              activity_data(user_instance(UserName, Instance))) :-
+    geteuid(UID),
+    user_info(UID, UserData),
+    user_data(name, UserData, UserName),
+    user_instance_name(UserName, Instance).
 
 %% -------------------- TAR FILES
 

--- a/assist/databin/databin.rack
+++ b/assist/databin/databin.rack
@@ -176,7 +176,7 @@ data_instance('FILE#FILE', load_data, ToolPath,
                sw_file_data(Nonce, '/tmp', ToolPath)]) :-
     build_with(Nonce, _ToolType, _ToolName, ToolPath, _ToolArgs),
     UID = ToolPath,
-    Title = ToolPath,
+    atom_string(ToolPath, Title),
     string_concat(Title, " file", Descr).
 
 data_get('FILE#FILE', 'FILE#fileFormat',
@@ -270,7 +270,7 @@ data_get('FILE#FILE_HASH', 'FILE#hashValue', file_hash(_, Hash), HashStr) :-
 
 data_instance('FILE#FORMAT', load_data, F, [uid(F, Title, Descr), fmt(F)]) :-
     member(F, [ 'CSourceFile', 'ElfFile', 'TarFile', 'ArchiveFile' ]),
-    Title = F,
+    atom_string(F, Title),
     string_concat(Title, " file format", Descr).
 
 

--- a/assist/databin/databin.rack
+++ b/assist/databin/databin.rack
@@ -16,6 +16,7 @@ databin_name(MyName) :-
                  build_from/2,
                  build_start/2,
                  build_finished/3,
+                 build_user/2,
                  file_sha1/3.
 
 %% Recognizers for matching tool output data
@@ -169,6 +170,17 @@ data_instance('SOFTWARE#COMPILE', load_data, Instance,
 data_get('SOFTWARE#COMPILE', 'SOFTWARE#compiledBy',
          activity_data(build_with(_, compile, _, ToolPath, _),_,_),
          ToolPath).
+data_get('SOFTWARE#COMPILE', 'PROV-S#wasAssociatedWith',
+         activity_data(_,build_start(N,_),_),
+         UserInstance) :-
+    build_user(N, UserName),
+    user_instance_name(UserName, UserInstance).
+data_get('SOFTWARE#COMPILE', 'SOFTWARE#performedBy',
+         activity_data(_,build_start(N,_),_),
+         UserInstance) :-
+    build_user(N, UserName),
+    user_instance_name(UserName, UserInstance).
+
 
 data_instance('SOFTWARE#BUILD', load_data, Instance,
               [ uid(Instance), activity_data(BW,BS,BF) ]) :-
@@ -195,6 +207,20 @@ data_instance('PROV-S#ACTIVITY', load_data, Instance,
     ToolType \= compile,
     ToolType \= make,
     activity_instance(Nonce, ToolType, Instance).
+
+data_instance('PROV-S#AGENT', load_data, Instance, [ activity_data(user_instance(BU, Instance)) ]) :-
+    BU = build_user(_Nonce, UserName),
+    BU,
+    user_instance_name(UserName, Instance).
+user_instance_name(UserName, Instance) :- append_fld('User', UserName, Instance).
+data_get(_, 'PROV-S#identifier', activity_data(user_instance(build_user(_,User),_)), UserStr) :-
+    atom_string(User, UserStr).
+data_get(_, 'PROV-S#title', activity_data(user_instance(_,_)), "Username").
+data_get(_, 'PROV-S#description', activity_data(user_instance(_,_)), "The username of the user agent").
+data_get(_, 'PROV-S#wasAssociatedWith', activity_data(_,build_start(N,_),_), UserInstance) :-
+    build_user(N, UserName),
+    user_instance_name(UserName, UserInstance).
+
 
 data_get(_, 'PROV-S#startedAtTime', activity_data(_,build_start(_,T),_), T).
 data_get(_, 'PROV-S#endedAtTime', activity_data(_,_,build_finished(_,T,_)), T).

--- a/assist/databin/databin.rack
+++ b/assist/databin/databin.rack
@@ -2,7 +2,7 @@
 :- multifile data_instance/4, data_get/4.
 
 databin_name(MyName) :-
-    append_fld('v0.8', ingest_databin, MyName).
+    append_fld('v0.9', ingest_databin, MyName).
 
 % These are the various facts that might be emitted by the databin
 % wrappers that will be recognized here.
@@ -353,4 +353,3 @@ data_get(_, 'PROV-S#wasAssociatedWith', activity_data(_,build_start(N,_),_),
 data_get(_, 'PROV-S#startedAtTime', activity_data(_,build_start(_,T),_), T).
 data_get(_, 'PROV-S#endedAtTime', activity_data(_,_,build_finished(_,T,_)), T).
 data_get(_, 'PROV-S#dataInsertedBy', _, MyName) :- databin_name(MyName).
-

--- a/assist/databin/databin.rack
+++ b/assist/databin/databin.rack
@@ -35,21 +35,21 @@ data_get('PROV-S#ACTIVITY', 'PROV-S#wasInformedBy', ingesting_data(_), ModelName
     rack_model_name(ModelName).
 data_get('PROV-S#ACTIVITY', 'PROV-S#endedAtTime', ingested_data(EndTime), EndTime).
 
-%% -- tar ------------------------------
+%% -------------------- TAR FILES
 
-data_instance('SOFTWARE#FILE', load_data, Instance,
+data_instance('FILE#FILE', load_data, Instance,
               [ uid(Instance), sw_file_data(Nonce, Dir, File) ]) :-
     tar_access(Nonce, File, create),
     build_from(Nonce, Dir),
     file_instance(Nonce, Dir, File, Instance).
 
-data_instance('SOFTWARE#FILE', load_data, Instance,
+data_instance('FILE#FILE', load_data, Instance,
               [ uid(Instance), sw_file_data(Nonce, Dir, File) ]) :-
     tar_access(Nonce, File, open),
     build_from(Nonce, Dir),
     file_instance(Nonce, Dir, File, Instance).
 
-data_get('SOFTWARE#FILE', 'SOFTWARE#fileFormat',
+data_get('FILE#FILE', 'FILE#fileFormat',
          sw_file_data(Nonce, _, File), 'TarFile') :-
     tar_access(Nonce, File, create).
 
@@ -69,11 +69,11 @@ data_get('SOFTWARE#PACKAGE', 'SOFTWARE#packageInput', package_tar(Nonce), V) :-
 data_get(_, 'PROV-S#startedAtTime', package_tar(N), T) :- tar_start(N, T, _).
 data_get(_, 'PROV-S#endedAtTime', package_tar(N), T) :- tar_finished(N, T, _).
 
-data_instance('SOFTWARE#FILE', load_data, TarPath,
+data_instance('FILE#FILE', load_data, TarPath,
               [uid(TarPath), sw_file_data(Nonce, '/tmp', TarPath)]) :-
     tar_start(Nonce, _, TarPath).
 
-data_get('SOFTWARE#FILE', 'SOFTWARE#createBy', sw_file_data(Nonce, Dir, File), V) :-
+data_get('FILE#FILE', 'FILE#createBy', sw_file_data(Nonce, Dir, File), V) :-
     tar_access(Nonce, File, create),
     build_from(Nonce, Dir),
     activity_instance(Nonce, tar, V).
@@ -85,7 +85,7 @@ data_get('SOFTWARE#BUILD', 'SOFTWARE#step',
     activity_instance(N, tar, V).
 
 
-%% -- files ------------------------------
+%% -------------------- MISC FILES
 
 file_instance(Nonce, _, Input, InstanceRef) :-
     % The above failed so file was not an output of a previous build.
@@ -94,21 +94,21 @@ file_instance(Nonce, _, Input, InstanceRef) :-
      atom_string(IA, Input), file_sha1(IA, SHA1, Nonce), !, append_fld(SHA1, IA, InstanceRef);
      append_fld(Nonce, Input, InstanceRef)).
 
-data_instance('SOFTWARE#FILE', load_data, Instance, InstanceData) :-
+data_instance('FILE#FILE', load_data, Instance, InstanceData) :-
     build_inputs(Nonce, Inputs),
     build_from(Nonce, Dir),
     member(Input, Inputs),
     file_instance(Nonce, Dir, Input, Instance),
     InstanceData = [uid(Instance), sw_file_data(Nonce, Dir, Input)].
 
-data_instance('SOFTWARE#FILE', load_data, Instance, InstanceData) :-
+data_instance('FILE#FILE', load_data, Instance, InstanceData) :-
     build_outputs(Nonce, Outputs),
     build_from(Nonce, Dir),
     member(Output, Outputs),
     file_instance(Nonce, Dir, Output, Instance),
     InstanceData = [uid(Instance), sw_file_data(Nonce, Dir, Output)].
 
-data_instance('SOFTWARE#FILE', load_data, ToolPath,
+data_instance('FILE#FILE', load_data, ToolPath,
               [uid(UID), sw_file_data(Nonce, '/tmp', ToolPath)]) :-
     build_with(Nonce, _ToolType, _ToolName, ToolPath, _ToolArgs),
     UID = ToolPath.
@@ -133,13 +133,13 @@ output_of(Tool, Dir, F, BuildNonce) :-
     member(F, FS), !.  % red cut
 output_of(_, _, _, _) :- false.  % base case for checkout output_of
 
-data_get('SOFTWARE#FILE', 'SOFTWARE#fileFormat',
+data_get('FILE#FILE', 'FILE#fileFormat',
          sw_file_data(Nonce, _, F), 'ElfFile') :-
     build_outputs(Nonce, FS),
     member(F, FS),
     build_with(Nonce, compile, _, _, _).
 
-data_get('SOFTWARE#FILE', 'SOFTWARE#createBy', sw_file_data(Nonce, _, F), V) :-
+data_get('FILE#FILE', 'FILE#createBy', sw_file_data(Nonce, _, F), V) :-
     build_outputs(Nonce, FS),
     member(F, FS),
     build_with(Nonce, ToolType, _ToolName, _ToolPath, _ToolArgs),
@@ -148,9 +148,9 @@ data_get('SOFTWARE#FILE', 'SOFTWARE#createBy', sw_file_data(Nonce, _, F), V) :-
 
 %% -- Formats ------------------------------
 
-data_instance('SOFTWARE#FORMAT', load_data, F, [uid(F), fmt(F)]) :-
+data_instance('FILE#FORMAT', load_data, F, [uid(F), fmt(F)]) :-
     member(F, [ 'CSourceFile', 'ElfFile', 'TarFile', 'ArchiveFile' ]).
-data_get('SOFTWARE#FORMAT', 'PROV-S#identifier', fmt(Fmt), FmtS) :-
+data_get('FILE#FORMAT', 'PROV-S#identifier', fmt(Fmt), FmtS) :-
     atom_string(Fmt, FmtS).
 
 %% -- Activities ------------------------------

--- a/assist/databin/databin.rack
+++ b/assist/databin/databin.rack
@@ -318,7 +318,15 @@ data_instance('SOFTWARE#COMPILE', load_data, Instance,
     Title = "compilation",
     Descr = "Execution of the compiler".
 
-data_get('SOFTWARE#COMPILE', 'SOFTWARE#compiledBy',
+data_get(_, 'SOFTWARE#compileInput',
+         activity_data(build_with(Nonce, compile, _, _, _),_,_),
+         InputInstance) :-
+    build_inputs(Nonce, Inputs),
+    member(Input, Inputs),
+    build_from(Nonce, Dir),
+    file_instance(Nonce, Dir, Input, InputInstance).
+
+data_get(_, 'SOFTWARE#compiledBy',
          activity_data(build_with(_, compile, _, ToolPath, _),_,_),
          ToolPath).
 data_get('SOFTWARE#COMPILE', 'PROV-S#wasAssociatedWith',

--- a/assist/databin/databin.rack
+++ b/assist/databin/databin.rack
@@ -23,7 +23,11 @@ databin_name(MyName) :-
 
 % -- This ingestion activity
 
-data_instance('PROV-S#ACTIVITY', load_data_start, MyName, [uid(MyName),ingesting_data(StartTime)]) :-
+data_instance('PROV-S#ACTIVITY', % create an instance of this
+              load_data_start,   % on this event (starting ingestion)
+              MyName,            % output name
+              [uid(MyName),ingesting_data(StartTime)]   % output attributes ot match data_get operations
+             ) :-
     databin_name(MyName),
     get_time(TS), stamp_date_time(TS, date(_Y,Mo,D,H,Min,S,UTCOff,_TZName,_DST), local),
     StartTime = date_time(1999,Mo,D,H,Min,S,UTCOff).
@@ -31,7 +35,11 @@ data_instance('PROV-S#ACTIVITY', load_data_finish, MyName, ingested_data(EndTime
     databin_name(MyName),
     get_time(TS), stamp_date_time(TS, date(Y,Mo,D,H,Min,S,UTCOff,_TZName,_DST), local),
     EndTime = date_time(Y,Mo,D,H,Min,S,UTCOff).
-data_get('PROV-S#ACTIVITY', 'PROV-S#startedAtTime', ingesting_data(StartTime), StartTime).
+data_get('PROV-S#ACTIVITY',         % for an instance of this
+         'PROV-S#startedAtTime',    % if this relation exists
+         ingesting_data(StartTime), % and this attribute is available from a data_instance
+         StartTime                  % then generate this value (here, an owl date_time atom)
+        ).
 data_get('PROV-S#ACTIVITY', 'PROV-S#wasInformedBy', ingesting_data(_), ModelName) :-
     rack_model_name(ModelName).
 data_get('PROV-S#ACTIVITY', 'PROV-S#endedAtTime', ingested_data(EndTime), EndTime).
@@ -89,8 +97,6 @@ data_get('SOFTWARE#BUILD', 'SOFTWARE#step',
 %% -------------------- MISC FILES
 
 file_instance(Nonce, _, Input, InstanceRef) :-
-    % The above failed so file was not an output of a previous build.
-    % It was probably created by a user, so it's a new, distinct file.
     (file_sha1(Input, SHA1, Nonce), !, append_fld(SHA1, Input, InstanceRef);
      atom_string(IA, Input), file_sha1(IA, SHA1, Nonce), !, append_fld(SHA1, IA, InstanceRef);
      append_fld(Nonce, Input, InstanceRef)).
@@ -159,9 +165,11 @@ data_get('FILE#FORMAT', 'PROV-S#identifier', fmt(Fmt), FmtS) :-
 activity_instance(Nonce, ToolType, InstanceName) :-
     append_fld(Nonce, ToolType, InstanceName).
 
+%% -------------------- COMPILE
+
 data_instance('SOFTWARE#COMPILE', load_data, Instance,
               [ uid(Instance), activity_data(BW,BS,BF) ]) :-
-    BW = build_with(Nonce, compile, _ToolName, _ToolPath, _ToolArgs),
+    BW = build_with(Nonce, compile, _ToolName, _ToolPath, _ToolArgs),  % compile tool
     BS = build_start(Nonce, _StartTime),
     BF = build_finished(Nonce, _FinishTime, _ExitVal),
     BW, BS, BF,
@@ -181,10 +189,11 @@ data_get('SOFTWARE#COMPILE', 'SOFTWARE#performedBy',
     build_user(N, UserName),
     user_instance_name(UserName, UserInstance).
 
+%% -------------------- MAKE
 
 data_instance('SOFTWARE#BUILD', load_data, Instance,
               [ uid(Instance), activity_data(BW,BS,BF) ]) :-
-    BW = build_with(Nonce, make, _ToolName, _ToolPath, _ToolArgs),
+    BW = build_with(Nonce, make, _ToolName, _ToolPath, _ToolArgs),   % make tool
     BS = build_start(Nonce, _StartTime),
     BF = build_finished(Nonce, _FinishTime, _ExitVal),
     BW, BS, BF,

--- a/assist/databin/databin.rack
+++ b/assist/databin/databin.rack
@@ -329,16 +329,18 @@ data_instance('PROV-S#ACTIVITY', load_data, Instance,
     atom_string(ToolType, Title),
     string_concat(Title, " tool invocation", Descr).
 
-data_instance('PROV-S#AGENT', load_data, Instance, [ activity_data(user_instance(BU, Instance)) ]) :-
-    BU = build_user(_Nonce, UserName),
-    BU,
+data_instance('PROV-S#AGENT', load_data, Instance,
+              activity_data(user_instance(UserName, Instance))) :-
+    build_user(_Nonce, UserName),
     user_instance_name(UserName, Instance).
 user_instance_name(UserName, Instance) :- append_fld('User', UserName, Instance).
-data_get(_, 'PROV-S#identifier', activity_data(user_instance(build_user(_,User),_)), UserStr) :-
+data_get(_, 'PROV-S#identifier', activity_data(user_instance(User,_)), UserStr) :-
     atom_string(User, UserStr).
 data_get(_, 'PROV-S#title', activity_data(user_instance(_,_)), "Username").
-data_get(_, 'PROV-S#description', activity_data(user_instance(_,_)), "The username of the user agent").
-data_get(_, 'PROV-S#wasAssociatedWith', activity_data(_,build_start(N,_),_), UserInstance) :-
+data_get(_, 'PROV-S#description', activity_data(user_instance(_,_)),
+         "The username of the user agent").
+data_get(_, 'PROV-S#wasAssociatedWith', activity_data(_,build_start(N,_),_),
+         UserInstance) :-
     build_user(N, UserName),
     user_instance_name(UserName, UserInstance).
 

--- a/assist/databin/gcc
+++ b/assist/databin/gcc
@@ -5,7 +5,6 @@
 
 
 # TODO: use -M for internal assist of include files
-# TODO: get -L paths and -l libraries
 
 # shellcheck disable=SC2046
 . $(dirname "$0")/rackfuncs.sh
@@ -14,6 +13,8 @@ inf=()
 outf=''
 inclf=''
 opts=()
+libdirs=()
+libs=()
 
 outnxt=0
 inclnxt=0
@@ -25,6 +26,8 @@ for ARG ; do
         -o) outnxt=1 ;;
         -MF) inclnxt=1 ;;
         -MT) ignnxt=1 ;;
+        -L*) libdirs+=("${ARG:2}") ;;
+        -l*) libs+=("lib${ARG:2}") ;;
         *) if (( outnxt )) ; then
                outf="${ARG}"
                outnxt=0
@@ -80,6 +83,20 @@ nonce="n$(date +%s)-$$"
     echo "build_user(${nonce@Q}, '"$(whoami)"')."
     for inp in ${inf[*]} ; do
         git log -n 1 --pretty=format:"file_committer(${inp@Q}, '%al').%n" $inp 2>/dev/null
+    done
+    for lf in ${libs[*]} ; do
+        for ld in ${libdirs[*]} ; do
+            for ext in .so .a ; do
+                ldr=$(cd "${ld}"; echo $(top_rel_curdir))
+                if [ "$ldr" == "." ] ; then lp=${lf}${ext}; else lp=${ldr}/${lf}${ext}; fi
+                if [ -f ${lp} ] ; then
+                    echo "build_inputs(${nonce@Q}, [ ${lp@Q} ])."
+                    IFS=' ' read sum f < <(sha1sum "$lp")
+                    echo "file_sha1(${lp@Q}, ${sum@Q}, ${nonce@Q})."
+                    break 2
+                fi
+            done
+        done
     done
 ) > "${rackf}"
 

--- a/assist/databin/gcc
+++ b/assist/databin/gcc
@@ -97,6 +97,7 @@ when_done() {
             for F in "${fl[@]}"; do
                 read sum f < <(sha1sum "$F")
                 echo "file_sha1(${f@Q}, ${sum@Q}, ${nonce@Q})." >> "${rackf}"
+                git log -n 1 --pretty=format:"file_committer(${F@Q}, '%al').%n" $F 2>/dev/null >> "${rackf}"
             done
         fi
     fi

--- a/assist/databin/gcc
+++ b/assist/databin/gcc
@@ -68,7 +68,8 @@ nonce="n$(date +%s)-$$"
 (
     export IFS=","
     echo ":- multifile build_with/5, build_from/2, build_inputs/2, build_outputs/2,
-                       build_start/2, build_finished/3, build_user/2, file_sha1/3."
+                       build_start/2, build_finished/3, build_user/2, file_sha1/3,
+                       file_committer/2."
     # shellcheck disable=SC2086
     echo "build_with(${nonce@Q}, compile," ${tool@Q}, ${realtool@Q}, [ "${opts[*]@Q}" ] ")."
     # shellcheck disable=SC2086,SC2027,SC2046
@@ -77,6 +78,9 @@ nonce="n$(date +%s)-$$"
     echo "build_outputs(${nonce@Q}, [ ${outf@Q} ])."
     echo "build_start(${nonce@Q}, $(date +'date_time(%Y,%m,%d,%H,%M,%S,%z)'))."
     echo "build_user(${nonce@Q}, '"$(whoami)"')."
+    for inp in ${inf[*]} ; do
+        git log -n 1 --pretty=format:"file_committer(${inp@Q}, '%al').%n" $inp 2>/dev/null
+    done
 ) > "${rackf}"
 
 update_make_steps

--- a/assist/databin/gcc
+++ b/assist/databin/gcc
@@ -80,16 +80,17 @@ nonce="n$(date +%s)-$$"
     echo "build_inputs(${nonce@Q}, [ ${inf[*]@Q} ])."
     echo "build_outputs(${nonce@Q}, [ ${outf@Q} ])."
     echo "build_start(${nonce@Q}, $(date +'date_time(%Y,%m,%d,%H,%M,%S,%z)'))."
-    echo "build_user(${nonce@Q}, '"$(whoami)"')."
+    echo "build_user(${nonce@Q}, '$(whoami)')."
     for inp in ${inf[*]} ; do
-        git log -n 1 --pretty=format:"file_committer(${inp@Q}, '%al').%n" $inp 2>/dev/null
+        git log -n 1 --pretty=format:"file_committer(${inp@Q}, '%al').%n" "$inp" 2>/dev/null
     done
     for lf in ${libs[*]} ; do
         for ld in ${libdirs[*]} ; do
             for ext in .so .a ; do
+                # shellcheck disable=SC2005,SC2164
                 ldr=$(cd "${ld}"; echo $(top_rel_curdir))
                 if [ "$ldr" == "." ] ; then lp=${lf}${ext}; else lp=${ldr}/${lf}${ext}; fi
-                if [ -f ${lp} ] ; then
+                if [ -f "${lp}" ] ; then
                     echo "build_inputs(${nonce@Q}, [ ${lp@Q} ])."
                     IFS=' ' read sum f < <(sha1sum "$lp")
                     echo "file_sha1(${lp@Q}, ${sum@Q}, ${nonce@Q})."
@@ -114,7 +115,7 @@ when_done() {
             for F in "${fl[@]}"; do
                 read sum f < <(sha1sum "$F")
                 echo "file_sha1(${f@Q}, ${sum@Q}, ${nonce@Q})." >> "${rackf}"
-                git log -n 1 --pretty=format:"file_committer(${F@Q}, '%al').%n" $F 2>/dev/null >> "${rackf}"
+                git log -n 1 --pretty=format:"file_committer(${F@Q}, '%al').%n" "$F" 2>/dev/null >> "${rackf}"
             done
         fi
     fi

--- a/assist/databin/gcc
+++ b/assist/databin/gcc
@@ -68,7 +68,7 @@ nonce="n$(date +%s)-$$"
 (
     export IFS=","
     echo ":- multifile build_with/5, build_from/2, build_inputs/2, build_outputs/2,
-                       build_start/2, build_finished/3, file_sha1/3."
+                       build_start/2, build_finished/3, build_user/2, file_sha1/3."
     # shellcheck disable=SC2086
     echo "build_with(${nonce@Q}, compile," ${tool@Q}, ${realtool@Q}, [ "${opts[*]@Q}" ] ")."
     # shellcheck disable=SC2086,SC2027,SC2046
@@ -76,6 +76,7 @@ nonce="n$(date +%s)-$$"
     echo "build_inputs(${nonce@Q}, [ ${inf[*]@Q} ])."
     echo "build_outputs(${nonce@Q}, [ ${outf@Q} ])."
     echo "build_start(${nonce@Q}, $(date +'date_time(%Y,%m,%d,%H,%M,%S,%z)'))."
+    echo "build_user(${nonce@Q}, '"$(whoami)"')."
 ) > "${rackf}"
 
 update_make_steps

--- a/assist/databin/make
+++ b/assist/databin/make
@@ -21,7 +21,7 @@ export MAKE_DATABIN="${outf}@${nonce}:${MAKE_DATABIN}"
     # shellcheck disable=SC2027,SC2046
     echo "build_from(${nonce@Q}, '"$(top_rel_curdir)"')."
     echo "build_start(${nonce@Q}, $(date +'date_time(%Y,%m,%d,%H,%M,%S,%z)'))."
-    echo "build_user(${nonce@Q}, '"$(whoami)"')."
+    echo "build_user(${nonce@Q}, '$(whoami)')."
 ) > "${outf}"
 
 when_done() {

--- a/assist/databin/make
+++ b/assist/databin/make
@@ -15,12 +15,13 @@ nonce="n$(date +%s)-$$"
 export MAKE_DATABIN="${outf}@${nonce}:${MAKE_DATABIN}"
 
 (
-    echo ":- multifile build_with/5, build_from/2, build_inputs/2, build_outputs/2, build_start/2, build_finished/3, build_step/2."
+    echo ":- multifile build_with/5, build_from/2, build_inputs/2, build_outputs/2, build_start/2, build_finished/3, build_step/2, build_user/2."
     # shellcheck disable=SC2086
     echo "build_with(${nonce@Q}, make," ${tool@Q}, ${realtool@Q}, [ "${*@Q}" ] ")."
     # shellcheck disable=SC2027,SC2046
     echo "build_from(${nonce@Q}, '"$(top_rel_curdir)"')."
     echo "build_start(${nonce@Q}, $(date +'date_time(%Y,%m,%d,%H,%M,%S,%z)'))."
+    echo "build_user(${nonce@Q}, '"$(whoami)"')."
 ) > "${outf}"
 
 when_done() {

--- a/assist/databin/tar
+++ b/assist/databin/tar
@@ -17,7 +17,7 @@ on_finish() {
 trap on_finish EXIT ERR
 
 echo ":- multifile tar_start/3, tar_finished/3, tar_access/3,
-                   build_from/2, file_sha1/3." > ${tmpfile}.out
+                   build_from/2, build_user/2, file_sha1/3, file_committer/2." > ${tmpfile}.out
 echo "tar_start(${nonce@Q}, $(date +'date_time(%Y,%m,%d,%H,%M,%S,%z)'), ${realtool@Q})." >> ${tmpfile}.out
 echo "build_user(${nonce@Q}, '"$(whoami)"')." >> ${tmpfile}.out
 
@@ -57,6 +57,8 @@ BEGIN { show=0;
              print "tar_access('${nonce}', '" unquoted_name "', open)."
              "sha1sum " name | getline shafilesum
              split(shafilesum, sha)
+             gitauth = "git log -n 1 --pretty=format:\"file_committer('" unquoted_name "', '%al').\" " name " 2>/dev/null" | getline
+             if (gitauth != 0) print
              print "file_sha1('" sha[2] "', '" sha[1] "', '${nonce}')."
            }
          }

--- a/assist/databin/tar
+++ b/assist/databin/tar
@@ -19,6 +19,7 @@ trap on_finish EXIT ERR
 echo ":- multifile tar_start/3, tar_finished/3, tar_access/3,
                    build_from/2, file_sha1/3." > ${tmpfile}.out
 echo "tar_start(${nonce@Q}, $(date +'date_time(%Y,%m,%d,%H,%M,%S,%z)'), ${realtool@Q})." >> ${tmpfile}.out
+echo "build_user(${nonce@Q}, '"$(whoami)"')." >> ${tmpfile}.out
 
 strace -f -e trace=file -e status=successful -o "$tmpfile" "$realtool" "${@}"
 

--- a/assist/databin/tar
+++ b/assist/databin/tar
@@ -42,15 +42,19 @@ BEGIN { show=0;
       # Initialization command
     }
     show=1;
-    print "tar_access('${nonce}', ", p[2], "create)."
+    unquoted_fname = substr(p[2], 0, length(p[2])-1)
+    gsub("\"", "", unquoted_fname)
+    print "tar_access('${nonce}', '" unquoted_fname "', create)."
     "sha1sum " name | getline shafilesum
     split(shafilesum, sha)
     print "file_sha1('" sha[2] "', '" sha[1] "', '${nonce}')."
   }
 /openat/ { if (show==1) {
-             print "tar_access('${nonce}', ", \$3, "open)."
              name = \$3
              gsub(",$", "", name)
+             unquoted_name = name
+             gsub("\"", "", unquoted_name)
+             print "tar_access('${nonce}', '" unquoted_name "', open)."
              "sha1sum " name | getline shafilesum
              split(shafilesum, sha)
              print "file_sha1('" sha[2] "', '" sha[1] "', '${nonce}')."

--- a/assist/databin/tar
+++ b/assist/databin/tar
@@ -46,7 +46,7 @@ BEGIN { show=0;
     unquoted_fname = substr(p[2], 0, length(p[2])-1)
     gsub("\"", "", unquoted_fname)
     print "tar_access('${nonce}', '" unquoted_fname "', create)."
-    "sha1sum " name | getline shafilesum
+    ("sha1sum " name) | getline shafilesum
     split(shafilesum, sha)
     print "file_sha1('" sha[2] "', '" sha[1] "', '${nonce}')."
   }
@@ -56,9 +56,9 @@ BEGIN { show=0;
              unquoted_name = name
              gsub("\"", "", unquoted_name)
              print "tar_access('${nonce}', '" unquoted_name "', open)."
-             "sha1sum " name | getline shafilesum
+             ("sha1sum " name) | getline shafilesum
              split(shafilesum, sha)
-             gitauth = "git log -n 1 --pretty=format:\"file_committer('" unquoted_name "', '%al').\" " name " 2>/dev/null" | getline
+             gitauth = ("git log -n 1 --pretty=format:\"file_committer('" unquoted_name "', '%al').\" " name " 2>/dev/null") | getline
              if (gitauth != 0) print
              print "file_sha1('" sha[2] "', '" sha[1] "', '${nonce}')."
            }

--- a/assist/databin/tar
+++ b/assist/databin/tar
@@ -21,7 +21,7 @@ echo ":- multifile tar_start/3, tar_finished/3, tar_access/3,
 echo "tar_start(${nonce@Q}, $(date +'date_time(%Y,%m,%d,%H,%M,%S,%z)'), ${realtool@Q})." >> ${tmpfile}.out
 echo "build_user(${nonce@Q}, '$(whoami)')." >> ${tmpfile}.out
 
-strace -f -e trace=file -e status=successful -o "$tmpfile" "$realtool" "${@}"
+strace -f -e trace=file -o "$tmpfile" "$realtool" "${@}"
 
 rval=$?
 echo "tar_finished(${nonce@Q}, $(date +'date_time(%Y,%m,%d,%H,%M,%S,%z)'), $rval)." >> ${tmpfile}.out
@@ -31,6 +31,7 @@ awk -f <(
 BEGIN { show=0;
         print "build_from(${nonce@Q}, '$(top_rel_curdir)').";
       }
+/ = -1/ { next }
 /creat/ {
     split(\$2, p, "(");
     if (show==0) {

--- a/assist/databin/tar
+++ b/assist/databin/tar
@@ -19,7 +19,7 @@ trap on_finish EXIT ERR
 echo ":- multifile tar_start/3, tar_finished/3, tar_access/3,
                    build_from/2, build_user/2, file_sha1/3, file_committer/2." > ${tmpfile}.out
 echo "tar_start(${nonce@Q}, $(date +'date_time(%Y,%m,%d,%H,%M,%S,%z)'), ${realtool@Q})." >> ${tmpfile}.out
-echo "build_user(${nonce@Q}, '"$(whoami)"')." >> ${tmpfile}.out
+echo "build_user(${nonce@Q}, '$(whoami)')." >> ${tmpfile}.out
 
 strace -f -e trace=file -e status=successful -o "$tmpfile" "$realtool" "${@}"
 


### PR DESCRIPTION
This PR updates the ASSIST tooling:
* Accommodations for changes in RACK ontology (esp. new FILE module)
* Additional recognizers for various fields
* Some bug-fixes in the tooling itself
* Ability to generate instances based on other instances (e.g. FILE_HASH instances for a FILE instance)
* Support for user-provided recognizers