### PR TITLE
Incorporate ontology review for REVIEW

### DIFF
--- a/RACK-Ontology/OwlModels/REVIEW.owl
+++ b/RACK-Ontology/OwlModels/REVIEW.owl
@@ -38,15 +38,6 @@
     <rdfs:subClassOf rdf:resource="PROV-S#THING"/>
   </owl:Class>
   <owl:Class rdf:ID="REVIEW">
-    <rdfs:subClassOf>
-      <owl:Restriction>
-        <owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >1</owl:cardinality>
-        <owl:onProperty>
-          <owl:ObjectProperty rdf:ID="author"/>
-        </owl:onProperty>
-      </owl:Restriction>
-    </rdfs:subClassOf>
     <rdfs:comment xml:lang="en">Artifact review ACTIVITY</rdfs:comment>
     <rdfs:subClassOf rdf:resource="PROV-S#ACTIVITY"/>
   </owl:Class>
@@ -89,7 +80,7 @@
     <rdfs:range rdf:resource="PROV-S#ENTITY"/>
     <rdfs:domain rdf:resource="#REVIEW_LOG"/>
   </owl:ObjectProperty>
-  <owl:ObjectProperty rdf:about="#author">
+  <owl:ObjectProperty rdf:ID="author">
     <rdfs:subPropertyOf rdf:resource="PROV-S#wasAssociatedWith"/>
     <rdfs:comment xml:lang="en">AGENT(s) putting items up for review</rdfs:comment>
     <rdfs:range rdf:resource="PROV-S#AGENT"/>

--- a/RACK-Ontology/OwlModels/REVIEW.owl
+++ b/RACK-Ontology/OwlModels/REVIEW.owl
@@ -6,10 +6,12 @@
     xmlns:sadlimplicitmodel="http://sadl.org/sadlimplicitmodel#"
     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
     xmlns:Rv="http://arcos.rack/REVIEW#"
+    xmlns:D="http://arcos.rack/DOCUMENT#"
     xmlns:sadlbasemodel="http://sadl.org/sadlbasemodel#"
     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
   xml:base="http://arcos.rack/REVIEW">
   <owl:Ontology rdf:about="">
+    <owl:imports rdf:resource="DOCUMENT"/>
     <owl:imports rdf:resource="PROV-S"/>
     <owl:imports rdf:resource="http://sadl.org/builtinfunctions"/>
     <owl:imports rdf:resource="http://sadl.org/sadlimplicitmodel"/>
@@ -24,7 +26,7 @@
             <provs:identifier>Passed</provs:identifier>
           </Rv:REVIEW_STATE>
           <Rv:REVIEW_STATE rdf:ID="ReviseWithoutReview">
-            <provs:identifier>Review Without Review</provs:identifier>
+            <provs:identifier>Revise Without Review</provs:identifier>
           </Rv:REVIEW_STATE>
           <Rv:REVIEW_STATE rdf:ID="ReviseWithReview">
             <provs:identifier>Revise With Review</provs:identifier>
@@ -36,12 +38,21 @@
     <rdfs:subClassOf rdf:resource="PROV-S#THING"/>
   </owl:Class>
   <owl:Class rdf:ID="REVIEW">
-    <rdfs:comment xml:lang="en">Code review ACTIVITY</rdfs:comment>
+    <rdfs:subClassOf>
+      <owl:Restriction>
+        <owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >1</owl:cardinality>
+        <owl:onProperty>
+          <owl:ObjectProperty rdf:ID="author"/>
+        </owl:onProperty>
+      </owl:Restriction>
+    </rdfs:subClassOf>
+    <rdfs:comment xml:lang="en">Artifact review ACTIVITY</rdfs:comment>
     <rdfs:subClassOf rdf:resource="PROV-S#ACTIVITY"/>
   </owl:Class>
   <owl:Class rdf:ID="REVIEW_LOG">
     <rdfs:comment xml:lang="en">Outcome of a REVIEW ACTIVITY</rdfs:comment>
-    <rdfs:subClassOf rdf:resource="PROV-S#ENTITY"/>
+    <rdfs:subClassOf rdf:resource="DOCUMENT#REPORT"/>
   </owl:Class>
   <owl:ObjectProperty rdf:ID="reviewer">
     <rdfs:subPropertyOf rdf:resource="PROV-S#wasAssociatedWith"/>
@@ -57,7 +68,7 @@
   </owl:ObjectProperty>
   <owl:ObjectProperty rdf:ID="governedBy">
     <rdfs:subPropertyOf rdf:resource="PROV-S#used"/>
-    <rdfs:comment xml:lang="en">ENTITY(s) (e.g. REQUIREMENT) used for performing the review</rdfs:comment>
+    <rdfs:comment xml:lang="en">ENTITY(s) (e.g. REQUIREMENT or SPECIFICATION) used for performing the review</rdfs:comment>
     <rdfs:range rdf:resource="PROV-S#ENTITY"/>
     <rdfs:domain rdf:resource="#REVIEW"/>
   </owl:ObjectProperty>
@@ -73,12 +84,12 @@
     <rdfs:domain rdf:resource="#REVIEW_LOG"/>
   </owl:ObjectProperty>
   <owl:ObjectProperty rdf:ID="reviews">
-    <rdfs:subPropertyOf rdf:resource="PROV-S#wasDerivedFrom"/>
-    <rdfs:comment xml:lang="en">ENTITY(s) that the review was performed on</rdfs:comment>
+    <rdfs:subPropertyOf rdf:resource="PROV-S#wasImpactedBy"/>
+    <rdfs:comment xml:lang="en">The subject being reviewed</rdfs:comment>
     <rdfs:range rdf:resource="PROV-S#ENTITY"/>
     <rdfs:domain rdf:resource="#REVIEW_LOG"/>
   </owl:ObjectProperty>
-  <owl:ObjectProperty rdf:ID="author">
+  <owl:ObjectProperty rdf:about="#author">
     <rdfs:subPropertyOf rdf:resource="PROV-S#wasAssociatedWith"/>
     <rdfs:comment xml:lang="en">AGENT(s) putting items up for review</rdfs:comment>
     <rdfs:range rdf:resource="PROV-S#AGENT"/>

--- a/RACK-Ontology/OwlModels/REVIEW.owl
+++ b/RACK-Ontology/OwlModels/REVIEW.owl
@@ -52,7 +52,7 @@
   </owl:Class>
   <owl:Class rdf:ID="REVIEW_LOG">
     <rdfs:comment xml:lang="en">Outcome of a REVIEW ACTIVITY</rdfs:comment>
-    <rdfs:subClassOf rdf:resource="DOCUMENT#REPORT"/>
+    <rdfs:subClassOf rdf:resource="PROV-S#ENTITY"/>
   </owl:Class>
   <owl:ObjectProperty rdf:ID="reviewer">
     <rdfs:subPropertyOf rdf:resource="PROV-S#wasAssociatedWith"/>

--- a/RACK-Ontology/ontology/REVIEW.sadl
+++ b/RACK-Ontology/ontology/REVIEW.sadl
@@ -10,15 +10,24 @@
  * of the Defense Advanced Research Projects Agency (DARPA).
  */
 
+/************** edit history *****************
+  *
+  * dwa - 11 Nov 2020 - reduced cardinality of several
+  * dwa - 11 Nov 2020 - removed incorrect associations
+  * dwa - 11 Nov 2020 - removed unnecessary subclassing
+  *
+  *********************************************/
+
 uri "http://arcos.rack/REVIEW" alias Rv.
 import "http://arcos.rack/PROV-S".
+import "http://arcos.rack/DOCUMENT".
 
 REVIEW_LOG
 	(note "Outcome of a REVIEW ACTIVITY")
-	is a type of ENTITY.
+	is a type of REPORT.
 
-	reviews (note "ENTITY(s) that the review was performed on") describes REVIEW_LOG with values of type ENTITY.
-	reviews is a type of wasDerivedFrom.
+	reviews (note "The subject being reviewed") describes REVIEW_LOG with values of type ENTITY.
+	reviews is a type of wasImpactedBy.
 
 	reviewResult (note "Review status descriptor") describes REVIEW_LOG with values of type REVIEW_STATE.
 
@@ -29,14 +38,14 @@ REVIEW_STATE (note "Life-cycle status of a review log")
     is a type of THING,
     must be one of {Passed, ReviseWithoutReview, ReviseWithReview}.
 Passed              is a REVIEW_STATE with identifier "Passed".
-ReviseWithoutReview is a REVIEW_STATE with identifier "Review Without Review".
+ReviseWithoutReview is a REVIEW_STATE with identifier "Revise Without Review".
 ReviseWithReview    is a REVIEW_STATE with identifier "Revise With Review".
 
 REVIEW
-	(note "Code review ACTIVITY")
+	(note "Artifact review ACTIVITY")
 	is a type of ACTIVITY.
 
-	author (note "AGENT(s) putting items up for review") describes REVIEW with values of type AGENT.
+	author (note "AGENT(s) putting items up for review") describes REVIEW with a single value of type AGENT.
 	author is a type of wasAssociatedWith.
 
 	reviewer (note "AGENT(s) performing the review") describes REVIEW with values of type AGENT.
@@ -45,5 +54,5 @@ REVIEW
 	reviewed (note "ENTITY(s) being reviewed") describes REVIEW with values of type ENTITY.
 	reviewed is a type of used.
 
-	governedBy (note "ENTITY(s) (e.g. REQUIREMENT) used for performing the review") describes REVIEW with values of type ENTITY.
+	governedBy (note "ENTITY(s) (e.g. REQUIREMENT or SPECIFICATION) used for performing the review") describes REVIEW with values of type ENTITY.
 	governedBy is a type of used.

--- a/RACK-Ontology/ontology/REVIEW.sadl
+++ b/RACK-Ontology/ontology/REVIEW.sadl
@@ -45,7 +45,7 @@ REVIEW
 	(note "Artifact review ACTIVITY")
 	is a type of ACTIVITY.
 
-	author (note "AGENT(s) putting items up for review") describes REVIEW with a single value of type AGENT.
+	author (note "AGENT(s) putting items up for review") describes REVIEW with values of type AGENT.
 	author is a type of wasAssociatedWith.
 
 	reviewer (note "AGENT(s) performing the review") describes REVIEW with values of type AGENT.

--- a/RACK-Ontology/ontology/REVIEW.sadl
+++ b/RACK-Ontology/ontology/REVIEW.sadl
@@ -24,7 +24,7 @@ import "http://arcos.rack/DOCUMENT".
 
 REVIEW_LOG
 	(note "Outcome of a REVIEW ACTIVITY")
-	is a type of REPORT.
+	is a type of ENTITY.
 
 	reviews (note "The subject being reviewed") describes REVIEW_LOG with values of type ENTITY.
 	reviews is a type of wasImpactedBy.


### PR DESCRIPTION
Note that while Dave proposed removing `governedBy` because it was already covered by properties of REQUIREMENT that in Turnstile governedBy was used to point to a `SPECIFICATION`. We'll need to either leave it in or figure out some other way to express what Turnstile says.