### PR TITLE
cli: emit a warning guessing command to correct mistake

### DIFF
--- a/cli/bin/rack
+++ b/cli/bin/rack
@@ -24,6 +24,7 @@ import yaml
 from jsonschema import ValidationError
 
 from rack import CustomFormatter, get_argument_parser
+from rack import cliMethod, CLIMethod, INGEST_CSV_CONFIG_SCHEMA, INGEST_OWL_CONFIG_SCHEMA
 
 __author__ = "Eric Mertens"
 __email__ = "emertens@galois.com"
@@ -79,6 +80,11 @@ if __name__ == "__main__":
         logger.error('Failed to load YAML configuration file: %s\n%s', args.config, exc)
         sys.exit(1)
     except ValidationError as exc:
+        instance_keys = set(exc.instance.keys())
+        if instance_keys == set(INGEST_CSV_CONFIG_SCHEMA['properties']) and not cliMethod == CLIMethod.DATA_IMPORT:
+            logger.warning('This looks like a data ingestion schema. Did you want "rack data import"?')
+        if instance_keys == set(INGEST_OWL_CONFIG_SCHEMA['properties']) and not cliMethod == CLIMethod.MODEL_IMPORT:
+            logger.warning('This looks like an OWL ingestion schema. Did you want "rack model import"?')
         logger.error('Bad configuration file: %s\n%s', args.config, exc)
         sys.exit(1)
     except re.error as exc:

--- a/cli/rack/__init__.py
+++ b/cli/rack/__init__.py
@@ -53,6 +53,15 @@ class Graph(Enum):
     DATA = "data"
     MODEL = "model"
 
+class CLIMethod(Enum):
+    """Enumeration of the CLI methods (for context in error reporting)"""
+    DATA_IMPORT = "data import"
+    MODEL_IMPORT = "model import"
+    OTHER_CLI_METHOD = "..."
+
+# In the absence of overwrite, this will be the default
+cliMethod = CLIMethod.OTHER_CLI_METHOD
+
 @unique
 class ExportFormat(Enum):
     """Enumeration of data export formats"""
@@ -377,10 +386,12 @@ def dispatch_data_count(args: SimpleNamespace) -> None:
 
 def dispatch_data_import(args: SimpleNamespace) -> None:
     """Implementation of the data import subcommand"""
+    cliMethod = CLIMethod.DATA_IMPORT
     ingest_data_driver(Path(args.config), args.base_url, args.data_graph, args.triple_store, args.clear)
 
 def dispatch_model_import(args: SimpleNamespace) -> None:
     """Implementation of the plumbing model subcommand"""
+    cliMethod = CLIMethod.MODEL_IMPORT
     ingest_owl_driver(Path(args.config), args.base_url, args.triple_store, args.clear)
 
 def dispatch_nodegroups_import(args: SimpleNamespace) -> None:


### PR DESCRIPTION
When one passes the wrong file to the command-line argument, we get a pretty
elaborate error message.  This adds a one-line warning suggesting a command
that would likely work given the fields in the input file.

That is, if the fields in the input file correspond to fields we expect in some
known command, this suggests the user to try that command instead.

<img width="750" alt="image" src="https://user-images.githubusercontent.com/478606/104208263-8e5a1900-53fe-11eb-8b88-f5d1b351f1f5.png">
