### PR TITLE
ada: use ScrapingToolKit as output

### DIFF
--- a/ada/ontology.py
+++ b/ada/ontology.py
@@ -4,18 +4,42 @@ from __future__ import annotations
 
 __copyright__ = "Copyright (c) 2020, Galois, Inc."
 
-from enum import Enum
-from typing import List, Optional
+from typing import NewType, Optional, Set
+# from typing_extensions import TypedDict
 from rdflib import Graph, Literal, Namespace, URIRef
 
-FILE = Namespace("http://arcos.rack/FILE#")
-PROV_S = Namespace("http://arcos.rack/PROV-S#")
-SOFTWARE = Namespace("http://arcos.rack/SOFTWARE#")
-RDF = Namespace("http://www.w3.org/1999/02/22-rdf-syntax-ns#")
+ComponentTypeIdentifier = NewType("ComponentTypeIdentifier", str)
+FileIdentifier = NewType("FileIdentifier", str)
+FormatIdentifier = NewType("FormatIdentifier", str)
+SoftwareComponentIdentifier = NewType("SoftwareComponentIdentifier", str)
+
+MODULE = ComponentTypeIdentifier("MODULE")
+SOURCE_FUNCTION = ComponentTypeIdentifier("SOURCE_FUNCTION")
+
+# SoftwareComponent = TypedDict("SoftwareComponent", {
+#     "mentions": Set[SoftwareComponentIdentifier],
+#     "title": str,
+#     "type": ComponentTypeIdentifier,
+# })
+
+# File = TypedDict("File", {
+#     "format": FormatIdentifier,
+#     "name": str,
+# })
+
+FILE_NS = Namespace("http://arcos.rack/FILE#")
+PROV_S_NS = Namespace("http://arcos.rack/PROV-S#")
+SOFTWARE_NS = Namespace("http://arcos.rack/SOFTWARE#")
+RDF_NS = Namespace("http://www.w3.org/1999/02/22-rdf-syntax-ns#")
 
 class Thing:
     """RACK-Ontology PROV-S#Thing"""
-    def __init__(self, identifier: str, uri: str, rdf_type: URIRef) -> None:
+    def __init__(
+        self,
+        identifier: str,
+        uri: str,
+        rdf_type: URIRef
+    ) -> None:
         # PROV-S#identifier
         self.identifier = identifier
         self.node: URIRef = URIRef(uri)
@@ -23,31 +47,41 @@ class Thing:
 
     def add_to_graph(self, graph: Graph) -> None:
         """Adds this class to the graph received in argument."""
-        graph.bind("ontology:file", FILE)
-        graph.bind("ontology:prov-s", PROV_S)
-        graph.bind("ontology:sw", SOFTWARE)
-        graph.add((self.node, PROV_S.identifier, Literal(self.identifier)))
-        graph.add((self.node, RDF.type, self.rdf_type))
+        graph.bind("ontology:file", FILE_NS)
+        graph.bind("ontology:prov-s", PROV_S_NS)
+        graph.bind("ontology:sw", SOFTWARE_NS)
+        graph.add((self.node, PROV_S_NS.identifier, Literal(self.identifier)))
+        graph.add((self.node, RDF_NS.type, self.rdf_type))
 
-class FileFormat(Thing):
+class Format(Thing):
     """RACK-Ontology File#FORMAT"""
-    def __init__(self, identifier: str, uri: str) -> None:
-        super().__init__(identifier, uri, FILE.FORMAT)
+    def __init__(self, identifier: FormatIdentifier, uri: str) -> None:
+        super().__init__(identifier, uri, FILE_NS.FORMAT)
+
+    def get_identifier(self) -> FormatIdentifier:
+        """Accessor to the identifier field with type FormatIdentifier."""
+        return FormatIdentifier(self.identifier)
 
 class File(Thing):
     """File entity"""
 
-    def __init__(self, identifier: str, uri: str, filename: str, file_format: FileFormat) -> None:
-        super().__init__(identifier, uri, FILE.FILE)
+    def __init__(
+        self,
+        identifier: str,
+        uri: str,
+        name: str,
+        format_: Format,
+    ) -> None:
+        super().__init__(identifier, uri, FILE_NS.FILE)
         # FILE#filename
-        self.filename: str = filename
+        self.name: str = name
         # FILE#fileFormat
-        self.file_format: FileFormat = file_format
+        self.format: Format = format_
 
     def add_to_graph(self, graph: Graph) -> None:
         super().add_to_graph(graph)
-        graph.add((self.node, FILE.filename, Literal(self.filename)))
-        graph.add((self.node, FILE.fileFormat, Literal(self.file_format.node)))
+        graph.add((self.node, FILE_NS.filename, Literal(self.name)))
+        graph.add((self.node, FILE_NS.fileFormat, Literal(self.format.identifier)))
 
 class Entity(Thing):
     """PROV-S#ENTITY"""
@@ -60,32 +94,39 @@ class Entity(Thing):
         super().add_to_graph(graph)
 
         if self.defined_in is not None:
-            graph.add((self.node, FILE.definedIn, self.defined_in.node))
-
-class ComponentType(Enum):
-    """Software component types"""
-    SOURCE_FUNCTION = "SOURCE_FUNCTION"
-    MODULE = "MODULE"
+            graph.add((self.node, FILE_NS.definedIn, self.defined_in.node))
 
 class SoftwareComponent(Entity):
     """Software components (SOFTWARE#SWCOMPONENT)"""
 
-    def __init__(self, identifier: str, uri: str, title: str, ty: ComponentType) -> None:
-        super().__init__(identifier, uri, SOFTWARE.SWCOMPONENT)
+    def __init__(
+        self,
+        component_type: ComponentTypeIdentifier,
+        identifier: SoftwareComponentIdentifier,
+        title: str,
+        uri: str,
+    ) -> None:
+        super().__init__(identifier, uri, SOFTWARE_NS.SWCOMPONENT)
+        self.component_type = component_type
+        self.mentions: Set[SoftwareComponent] = set()
         self.title = title
-        self.component_type = ty
-        self.mentions: List[SoftwareComponent] = []
+        self.uri = uri
 
     def add_mention(self, component: SoftwareComponent) -> None:
         """Registers a component that this component mentions."""
-        self.mentions.append(component)
+        self.mentions.add(component)
 
     def add_to_graph(self, graph: Graph) -> None:
-        """Serialize the component into an RDF graph"""
+        """Serialize the component into an RDF graph."""
+
         super().add_to_graph(graph)
 
-        graph.add((self.node, SOFTWARE.componentType, SOFTWARE[self.component_type.value]))
-        graph.add((self.node, PROV_S.title, Literal(self.title)))
+        graph.add((self.node, SOFTWARE_NS.componentType, SOFTWARE_NS[self.component_type]))
+        graph.add((self.node, PROV_S_NS.title, Literal(self.title)))
 
-        for component in self.mentions:
-            graph.add((self.node, SOFTWARE.mentions, component.node))
+        for callee in self.mentions:
+            graph.add((self.node, SOFTWARE_NS.mentions, callee.uri))
+
+    def get_identifier(self) -> SoftwareComponentIdentifier:
+        """Accessor to the identifier field with type SoftwareComponentIdentifier."""
+        return SoftwareComponentIdentifier(self.identifier)

--- a/ada/rack_rdf.py
+++ b/ada/rack_rdf.py
@@ -14,23 +14,28 @@ DATA = Namespace("http://data/")
 g.bind("dat", DATA)
 g.bind("format", FORMAT)
 
-txt_format = ontology.FileFormat("txt", FORMAT.TEXT_FILE)
+txt_format = ontology.Format(ontology.FormatIdentifier("txt"), FORMAT.TEXT_FILE)
 
-my_file = ontology.File("src.txt", DATA["src.txt"], "src.txt", txt_format)
+my_file = ontology.File(
+    identifier="src.txt",
+    uri=DATA["src.txt"],
+    name="src.txt",
+    format_=txt_format,
+)
 
 c1 = ontology.SoftwareComponent(
-    "fun1",
-    DATA["fun1"],
-    "fun1",
-    ontology.ComponentType.SOURCE_FUNCTION
+    component_type=ontology.SOURCE_FUNCTION,
+    identifier=ontology.SoftwareComponentIdentifier("fun1"),
+    title="fun1",
+    uri=DATA["fun1"],
 )
 c1.defined_in = my_file
 
 c2 = ontology.SoftwareComponent(
-    "fun2",
-    DATA["fun2"],
-    "fun2",
-    ontology.ComponentType.SOURCE_FUNCTION
+    component_type=ontology.SOURCE_FUNCTION,
+    identifier=ontology.SoftwareComponentIdentifier("fun2"),
+    title="fun2",
+    uri=DATA["fun2"],
 )
 c2.defined_in = my_file
 c2.add_mention(c1)

--- a/ada/requirements.txt
+++ b/ada/requirements.txt
@@ -1,3 +1,5 @@
 colorama~=0.4.4
+lxml
 rdflib==5.0.0
 rope~=0.18.0
+git+https://github.com/ge-high-assurance/RACK.git@vr/ScrapingToolKit-master#egg=ScrapingToolKit&subdirectory=ScrapingToolKit

--- a/ada/run_analysis.py
+++ b/ada/run_analysis.py
@@ -11,11 +11,13 @@ __copyright__ = "Copyright (c) 2020, Galois, Inc."
 import argparse
 import logging
 import os
-from typing import Dict, List, Optional
 import sys
+from typing import Dict, List, Optional, Set
+from typing_extensions import TypedDict
 
+import Evidence
+import Evidence.Add
 from colorama import Fore, Style
-
 import libadalang as lal
 from rdflib import Graph, Namespace
 
@@ -97,49 +99,162 @@ provider = (
 
 context = lal.AnalysisContext(unit_provider=provider)
 
+# This structure captures the output of the analysis in a structured way that
+# can be passed to different backends to output in different formats.
+AnalysisOutput = TypedDict(
+    "AnalysisOutput",
+    {
+        "component_types": Set[ontology.ComponentTypeIdentifier],
+        "components": Dict[
+            ontology.SoftwareComponentIdentifier,
+            ontology.SoftwareComponent
+        ],
+        "files": Dict[ontology.FileIdentifier, ontology.File],
+        "formats": Set[ontology.Format],
+    }
+)
+
+FILE_NS = Namespace("http://data/file#")
+FORMAT_NS = Namespace("http://data/format#")
+SOFTWARE_COMPONENT_NS = Namespace("http://data/software-component#")
+
 DEBUG = False
 
-FILE = Namespace("http://data/file#")
-FORMAT = Namespace("http://data/format#")
-SOFTWARE_COMPONENT = Namespace("http://data/software-component#")
+DEBUG_TURTLE = False
 
-ada_format = ontology.FileFormat("Ada", FORMAT.ADA_FILE)
+ADA_FORMAT = ontology.Format(
+    identifier=ontology.FormatIdentifier("Ada"),
+    uri=FORMAT_NS["ADA_FILE"],
+)
 
-def register_component(components, component: SCG.GraphNode) -> None:
+def register_component(
+    analysis_output: AnalysisOutput,
+    component: SCG.GraphNode
+) -> ontology.SoftwareComponent:
     """
     Makes sure that the component is already present in the components
     dictionary.  Adds it if necessary.
     """
-    key = SCG.node_key(component)
-    uri = SCG.get_uri(component)
-    name = SCG.get_name(component)
-    components[key] = ontology.SoftwareComponent(
-        identifier=uri,
-        uri=SOFTWARE_COMPONENT[uri],
-        title=name,
-        ty=ontology.ComponentType.SOURCE_FUNCTION
-    )
+    components = analysis_output["components"]
+    component_identifier = ontology.SoftwareComponentIdentifier(SCG.get_node_identifier(component))
+    if component_identifier not in components:
+        components[component_identifier] = ontology.SoftwareComponent(
+            identifier=component_identifier,
+            # does not work because display names may contain special characters
+            # title=SCG.get_node_display_name(component),
+            # using this instead even though less ideal:
+            title=SCG.get_node_uri(component),
+            component_type=ontology.SOURCE_FUNCTION,
+            uri=SOFTWARE_COMPONENT_NS[component_identifier],
+        )
+    return components[component_identifier]
 
 def register_ada_file(
-    files: Dict[str, ontology.File],
-    file_key: Optional[str]
+    analysis_output: AnalysisOutput,
+    file_identifier: Optional[ontology.FileIdentifier],
 ) -> Optional[ontology.File]:
     """
-    Creates an ontology node corresponding to 'file_key', unless it already
-    exists, and stores it in 'files'.
-
-    Returns the existing or newly-created node.
+    Creates an entry corresponding to 'file_key', unless it already exists,
+    and stores it in "files".
     """
-    if file_key is None:
+    if file_identifier is None:
         return None
-    if file_key not in files:
-        files[file_key] = ontology.File(
-            identifier=file_key,
-            uri=FILE[file_key],
-            filename=file_key,
-            file_format=ada_format
+    files = analysis_output["files"]
+    if file_identifier not in files:
+        files[file_identifier] = ontology.File(
+            format_=ADA_FORMAT,
+            identifier=file_identifier,
+            name=file_identifier,
+            uri=FILE_NS[file_identifier],
         )
-    return files[file_key]
+    return files[file_identifier]
+
+def as_optional_file_identifier(
+    filename: Optional[str]
+) -> Optional[ontology.FileIdentifier]:
+    """Applies the FileIdentifier newtype within an Optional."""
+    if filename is None:
+        return None
+    return ontology.FileIdentifier(filename)
+
+def make_empty_analysis_output() -> AnalysisOutput:
+    """Creates an empty output, to be populated by mutation."""
+    return AnalysisOutput({
+        "component_types": set(),
+        "components": dict(),
+        "files": dict(),
+        "formats": set(),
+    })
+
+def output_as_turtle(
+    analysis_output: AnalysisOutput,
+) -> None:
+    """
+    Outputs the analysis results as Turtle, currently to stdout but could be
+    made to output in a file.
+    """
+
+    graph = Graph()
+
+    graph.bind("data:file", FILE_NS)
+    graph.bind("data:format", FORMAT_NS)
+    graph.bind("data:software-component", SOFTWARE_COMPONENT_NS)
+
+    for format_ in analysis_output["formats"]:
+        format_.add_to_graph(graph)
+
+    for file_key in analysis_output["files"]:
+        file = analysis_output["files"][file_key]
+        file.add_to_graph(graph)
+
+    for component_key in analysis_output["components"]:
+        component = analysis_output["components"][component_key]
+        component.add_to_graph(graph)
+
+    sys.stdout.buffer.write(graph.serialize(format="turtle"))
+
+def output_using_scrapingtoolkit(
+    analysis_output: AnalysisOutput,
+) -> None:
+    """Outputs the analysis output using ScrapingToolKit."""
+
+    # NOTE: overwrites pre-existing evidence file
+    Evidence.createEvidenceFile()
+
+    for component_type in analysis_output["component_types"]:
+        Evidence.Add.COMPONENT_TYPE(
+            identifier=component_type,
+        )
+
+    for format_ in analysis_output["formats"]:
+        Evidence.Add.FORMAT(
+            identifier=format_.identifier,
+        )
+
+    files = analysis_output["files"]
+    for file_identifier in files:
+        file: ontology.File = files[file_identifier]
+        Evidence.Add.FILE(
+            fileFormat_identifier=file.identifier,
+            filename=file.name,
+            identifier=file_identifier,
+        )
+
+    components = analysis_output["components"]
+    for component_identifier in components:
+        component: ontology.SoftwareComponent = components[component_identifier]
+        Evidence.Add.SWCOMPONENT(
+            identifier=component_identifier,
+            componentType_identifier=component.component_type,
+            title=component.title,
+        )
+        for callee in component.mentions:
+            Evidence.Add.SWCOMPONENT(
+                identifier=component_identifier,
+                mentions_identifier=callee.identifier,
+            )
+
+    Evidence.createCDR()
 
 def analyze_unit(unit: lal.AnalysisUnit) -> None:
     """Computes and displays the static call graph of some unit."""
@@ -147,6 +262,7 @@ def analyze_unit(unit: lal.AnalysisUnit) -> None:
         if DEBUG:
             ada_visitor = AdaPrintVisitor(max_depth=20)
             ada_visitor.visit(unit.root)
+
         static_call_graph_visitor = SCG.StaticCallGraphVisitor(
             context=context,
             caller_being_defined=None,
@@ -156,35 +272,41 @@ def analyze_unit(unit: lal.AnalysisUnit) -> None:
 
         static_call_graph_visitor.visit(unit.root)
 
-        components: Dict[str, ontology.SoftwareComponent] = dict()
-        files: Dict[str, ontology.File] = dict()
+        analysis_output = make_empty_analysis_output()
 
-        # register all files and components (so as to have one unique instance
-        # for each)
+        component_types = analysis_output["component_types"]
+        component_types.add(ontology.SOURCE_FUNCTION)
+
+        formats = analysis_output["formats"]
+        formats.add(ADA_FORMAT)
+
+        components = analysis_output["components"]
+
+        # register all components and the files they live in
         for component_key in static_call_graph_visitor.nodes:
-            component = static_call_graph_visitor.nodes[component_key]
-            register_component(components, component)
-            file = register_ada_file(files, SCG.get_definition_file(component))
-            components[component_key].defined_in = file
+            component_node = static_call_graph_visitor.nodes[component_key]
+            component = register_component(analysis_output, component_node)
+            file_ = register_ada_file(
+                analysis_output,
+                as_optional_file_identifier(SCG.get_node_file(component_node))
+            )
+            component.defined_in = file_
 
-        # add "mentions" to all components that mention other components
-        for caller in static_call_graph_visitor.edges:
-            for callee_key in static_call_graph_visitor.edges[caller]:
-                components[caller].add_mention(components[callee_key])
+        # add "mentions"
+        for caller_key in static_call_graph_visitor.edges:
+            caller_node = static_call_graph_visitor.nodes[caller_key]
+            caller_identifier = ontology.SoftwareComponentIdentifier(SCG.get_node_identifier(caller_node))
+            for callee_key in static_call_graph_visitor.edges[caller_key]:
+                callee_node = static_call_graph_visitor.nodes[callee_key]
+                callee_identifier = ontology.SoftwareComponentIdentifier(SCG.get_node_identifier(callee_node))
+                callee = components[callee_identifier]
+                caller = components[caller_identifier]
+                caller.add_mention(callee)
 
-        graph = Graph()
-        graph.bind("data:file", FILE)
-        graph.bind("data:format", FORMAT)
-        graph.bind("data:software-component", SOFTWARE_COMPONENT)
-        ada_format.add_to_graph(graph)
-
-        for component_key in components:
-            components[component_key].add_to_graph(graph)
-
-        for file_key in files:
-            files[file_key].add_to_graph(graph)
-
-        sys.stdout.buffer.write(graph.serialize(format="turtle"))
+        if DEBUG_TURTLE:
+            output_as_turtle(analysis_output)
+        else:
+            output_using_scrapingtoolkit(analysis_output)
 
     else:
         print("No root found, diagnostics:")

--- a/ada/static_call_graph.py
+++ b/ada/static_call_graph.py
@@ -9,8 +9,8 @@ its result call graph in the 'nodes' and 'edges' member variables.
 __copyright__ = "Copyright (c) 2020, Galois, Inc."
 
 import logging
-from typing import Callable, Dict, Optional, Set
-import urllib
+from typing import Callable, Dict, NewType, Optional, Set
+import urllib.parse
 
 import libadalang as lal
 
@@ -42,16 +42,17 @@ def safe_xref(node: lal.AdaNode) -> Optional[lal.DefiningName]:
         warn_about_node(node)
         return None
 
-def node_key(node: GraphNode) -> str:
-    """
-    Computes a key we can use for identifying this node uniquely.
-    """
-    xref = safe_xref(node)
-    if xref is None:
-        return str(node)
-    return str(xref)
+NodeDisplayName = NewType("NodeDisplayName", str)
+NodeFile = NewType("NodeFile", str)
+NodeIdentifier = NewType("NodeIdentifier", str)
+NodeKey = NewType("NodeKey", str)
+NodeURI = NewType("NodeURI", str)
 
-def get_definition_file(node: GraphNode) -> Optional[str]:
+def get_node_display_name(node: GraphNode) -> NodeDisplayName:
+    """Computes the name to display for a node."""
+    return NodeDisplayName(node.text)
+
+def get_node_file(node: GraphNode) -> Optional[NodeFile]:
     """"
     Returns the name of the file within which this node was defined, assuming
     we succeed to resolve the reference.
@@ -63,13 +64,24 @@ def get_definition_file(node: GraphNode) -> Optional[str]:
     # want the filename
     if xref is None:
         return None
-    return xref.p_basic_decl.full_sloc_image.split(":")[0]
+    return NodeFile(xref.p_basic_decl.full_sloc_image.split(":")[0])
 
-def get_name(node: GraphNode) -> str:
-    """Computes the name to display for a node."""
-    return node.text
+def get_node_key(node: GraphNode) -> NodeKey:
+    """
+    Computes a key we can use for identifying this node uniquely.
+    """
+    xref = safe_xref(node)
+    if xref is None:
+        return NodeKey(str(node))
+    return NodeKey(str(xref))
 
-def get_uri(node: GraphNode) -> str:
+def get_node_identifier(node: GraphNode) -> NodeIdentifier:
+    """
+    Computes the identifier to use in the database.
+    """
+    return NodeIdentifier(get_node_uri(node))
+
+def get_node_uri(node: GraphNode) -> NodeURI:
     """Computes the URI to use for a node."""
     # NOTE: we need some encoding scheme, because Ada allows operator
     # overloading, so the functions may be called "&" for instance.
@@ -77,9 +89,9 @@ def get_uri(node: GraphNode) -> str:
     xref = node.p_gnat_xref()
     if not xref:
         urlencoded = encode(node.p_relative_name.p_canonical_text)
-        return f"__RACK__UNRESOLVED__{urlencoded}"
+        return NodeURI(f"__RACK__UNRESOLVED__{urlencoded}")
         # raise Exception(f"The reference to node {node} could not be resolved.")
-    return encode(xref.p_basic_decl.p_canonical_fully_qualified_name)
+    return NodeURI(encode(xref.p_basic_decl.p_canonical_fully_qualified_name))
 
 class StaticCallGraphVisitor(AdaVisitor):
 
@@ -92,8 +104,8 @@ class StaticCallGraphVisitor(AdaVisitor):
         self,
         context: lal.AnalysisContext,
         caller_being_defined: Optional[GraphNode],
-        nodes: Dict[str, GraphNode],
-        edges: Dict[str, Set[str]]
+        nodes: Dict[NodeKey, GraphNode],
+        edges: Dict[NodeKey, Set[NodeKey]]
     ) -> None:
         """
         Initialize the visitor.  Because it is not very practical to locally
@@ -103,9 +115,9 @@ class StaticCallGraphVisitor(AdaVisitor):
         creating a bunch of short-lived instances.
         """
 
-        self.context = context
+        self.context: lal.AnalysisContext = context
 
-        self.caller_being_defined = caller_being_defined
+        self.caller_being_defined: Optional[GraphNode] = caller_being_defined
         """
         Name of the caller currently being defined, that will be deemed the
         caller of whatever call expression we encounter. This can either be a
@@ -119,16 +131,16 @@ class StaticCallGraphVisitor(AdaVisitor):
 
         # We store nodes by key so that we can retrieve node instances by their
         # key and avoid creating duplicates.
-        self.nodes = nodes
+        self.nodes: Dict[NodeKey, GraphNode] = nodes
         """All nodes in the graph, unsorted."""
 
         if caller_being_defined:
             # Register the caller as a node
-            caller_key = node_key(caller_being_defined)
+            caller_key = get_node_key(caller_being_defined)
             if caller_key is not None and caller_key not in nodes:
                 nodes[caller_key] = caller_being_defined
 
-        self.edges: Dict[str, Set[str]] = edges
+        self.edges: Dict[NodeKey, Set[NodeKey]] = edges
         """
         Edges of the graph, keyed by their origin, valued by the set of
         destinations for that origin.
@@ -136,7 +148,7 @@ class StaticCallGraphVisitor(AdaVisitor):
 
     def get_graph_node_for_name(self, node: lal.Name) -> Optional[GraphNode]:
         """Returns the graph node for a name, creating it if none exists yet."""
-        key = node_key(node)
+        key = get_node_key(node)
         if key is None:
             return None
         if key not in self.nodes:
@@ -146,13 +158,13 @@ class StaticCallGraphVisitor(AdaVisitor):
     def record_call(self, callee: lal.Name) -> None:
         """Records a witnessed static function/procedure call to callee."""
         if self.caller_being_defined is not None:
-            caller_key = node_key(self.caller_being_defined)
+            caller_key = get_node_key(self.caller_being_defined)
             if caller_key is None:
                 return
             callee_node = self.get_graph_node_for_name(callee)
             if callee_node is None:
                 return
-            callee_key = node_key(callee_node)
+            callee_key = get_node_key(callee_node)
             if callee_key is None:
                 return
             if caller_key not in self.edges:

--- a/ada/stubs/.gitignore
+++ b/ada/stubs/.gitignore
@@ -1,3 +1,5 @@
+/Evidence/
+/Logging/
 /colorama/
 /libadalang/
 /rdflib/

--- a/ada/stubs/Makefile
+++ b/ada/stubs/Makefile
@@ -1,6 +1,8 @@
 OUT=.
 
 all:
+	stubgen -p Evidence -o ${OUT}
+	stubgen -p Logging -o ${OUT}
 	stubgen -p colorama -o ${OUT}
 	stubgen -p libadalang -o ${OUT}
 	stubgen -p rdflib -o ${OUT}


### PR DESCRIPTION
This large refactoring allows us to use the ScrapingToolKit to output
information from the analysis.

In order to not completely scrape away the Turtle output, and allow us
to later make different decisions, I tried to have a layer between the
analysis computing the output and the backend outputting it.

Because we were manipulating a lot of strings, including strings to be
used as keys in Python, strings to be used as keys in the ontology data,
strings to be used as names, ..., I also added 'NewType's that prevent
us from getting these mixed up, at the price of a bit of wrapping or
casting in some places.

Currently the output to Turtle is preserved behind a 'DEBUG_TURTLE'
flag, but it may make sense to either drop it entirely, or put it behind
a command-line argument later.