### PR TITLE
Assist tool updates

### DIFF
--- a/RACK-Ontology/OwlModels/FILE.owl
+++ b/RACK-Ontology/OwlModels/FILE.owl
@@ -96,9 +96,9 @@
     <rdfs:range rdf:resource="#HASH_TYPE"/>
   </owl:ObjectProperty>
   <owl:ObjectProperty rdf:ID="definedIn">
-    <rdfs:comment xml:lang="en">The file an ENTITY is defined or contained in</rdfs:comment>
+    <rdfs:comment xml:lang="en">The file a THING is defined or contained in</rdfs:comment>
     <rdfs:range rdf:resource="#FILE"/>
-    <rdfs:domain rdf:resource="PROV-S#ENTITY"/>
+    <rdfs:domain rdf:resource="PROV-S#THING"/>
   </owl:ObjectProperty>
   <owl:ObjectProperty rdf:about="#createBy">
     <rdfs:subPropertyOf rdf:resource="PROV-S#wasGeneratedBy"/>

--- a/RACK-Ontology/ontology/FILE.sadl
+++ b/RACK-Ontology/ontology/FILE.sadl
@@ -23,7 +23,7 @@
 uri "http://arcos.rack/FILE" alias file.
 import "http://arcos.rack/PROV-S".
 
-definedIn (note "The file an ENTITY is defined or contained in") describes ENTITY with values of type FILE.
+definedIn (note "The file a THING is defined or contained in") describes THING with values of type FILE.
 
 FILE
 	(note "A file in a filesystem")

--- a/Turnstile-Ontology/02-Software/turnstile-ingest.rack
+++ b/Turnstile-Ontology/02-Software/turnstile-ingest.rack
@@ -23,7 +23,9 @@ data_get('SOFTWARE#COMPILE', 'PROV-S#identifier', uid(Instance,_,_), Instance) :
     rack_namespace(NS),
     ns_ref(NS, Instance, RDFInstance),
     add_triple(RDFInstance, rdf:type,
-               'http://Turnstile/DevelopmentPlan#SoftwareIntegration').
+               'http://Turnstile/DevelopmentPlan#SoftwareIntegration'),
+    rack_ref('SOFTWARE#COMPILE', RACK_Compile),
+    rdf_retractall(RDFInstance, rdf:type, RACK_Compile, NS).
 
 % Explicit links between software files and documented requirements.
 % These cannot be automatically discovered and are project specific.

--- a/Turnstile-Ontology/02-Software/turnstile-ingest.rack
+++ b/Turnstile-Ontology/02-Software/turnstile-ingest.rack
@@ -86,5 +86,5 @@ data_instance('SOFTWARE#SWCOMPONENT', load_data, 'main_function',
 data_get('FILE#FILE', 'FILE#fileFormat', sw_file_data(_,_,'conf.json'),
          'JSONFile').
 data_instance('FILE#FORMAT', load_data, 'JSONFile',
-              [ uid('JSONFile', 'JSONFile', 'JSON file format'),
+              [ uid('JSONFile', 'JSONFile', 'JSONFileFormat'),
                 fmt('JSONFile')]).

--- a/Turnstile-Ontology/02-Software/turnstile-ingest.rack
+++ b/Turnstile-Ontology/02-Software/turnstile-ingest.rack
@@ -83,6 +83,8 @@ data_instance('SOFTWARE#SWCOMPONENT', load_data, 'main_function',
                    "C Function: 'main'"),
                func_decl('main_function', 'counter.c')]).
 
+data_get('SOFTWARE#SWCOMPONENT', 'SOFTWARE#componentType', func_decl(_, _), 'SourceFunction').
+
 % conf.json is not part of a build, so the format is indeterminate
 
 data_get('FILE#FILE', 'FILE#fileFormat', sw_file_data(_,_,'conf.json'),

--- a/assist/bin/README.md
+++ b/assist/bin/README.md
@@ -38,6 +38,16 @@ Prolog modules in this directory:
   extensible.  Adding new checks for ontology invariants is
   encouraged by both RACK developers and users.
 
+  By default, check loads the ontology (model) from the RACK-Ontology
+  directory, recognizers from the databin directory, and instance data
+  from the Turnstile software implementation directory.  The -m flag
+  can be used to select a different ontology, and the -d flag can
+  specify a different data location.
+
+  By default, check will ingest all .owl files in the directories
+  identified.  It can alternatively read from a live RDF database
+  (e.g. Fuseki) if given a URL instead.
+
 * `ingest_data` Loads the ontology model (from disk or RACK/Fuseki),
   a set of data recognizers, and then the data to be recognized,
   instantiating that data against the ontology model.  Writes the
@@ -95,6 +105,115 @@ Prolog modules in this directory:
 
   * Does not support the SADL active operators (e.g. `Ask`,
     `Rule`, or `Test`).
+
+
+# Usage Examples
+
+## Local OWL files, no RDF server
+
+  1. Initial setup
+
+    ```shell
+    $ cd assist
+    $ export PATH=$(pwd)/bin:$(pwd)/databin:$PATH
+    ```
+
+  2. Generate data for the build process of the Turnstile
+
+    ```shell
+    $ cd ../Trunstile-Onotology/02-Software/03-Implementation
+    $ make clean
+    $ make test
+    # ... note that the test results include a failure; this is expected.
+    $ make dist
+    ```
+
+  3. Create an OWL file for the build process data.  This will use a
+     turnstile-specific recognizer that makes the additional
+     associations between elements based on the PLAN for the
+     Turnstile that are not part of the base RACK ontology.
+
+     ```shell
+     $ ingest_data -r ../turnstile-ingest.rack -o BUILD_DESC.OWL \
+         http://Turnstile/CounterApplication \
+         ../../../Turnstile-Ontology
+     $ ls BUILD_DESC.OWL
+     ```
+
+  4. Run a verification that the BUILD_DESC.OWL data doesn't violate
+     any of the constraints or other restrictions associated with the
+     RACK ontology:
+
+     ```shell
+     $ check -v -d ../../../Turnstile-Ontology
+     ```
+
+     Additionally, a summary of the information generated can be seen
+     using the analyze tool:
+
+     ```shell
+     $ analyze -i http://testdata.org
+     ```
+
+## Interacting with an RDF server
+
+  Assuming an RDF server (e.g. Fuseki) is running at localhost port
+  3030, the scenario is the same as the local OWL file scenario for
+  the first 2 steps, but beginning with step 3:
+
+  3. Upload the data to the RDF service.
+
+     ```shell
+     $ ingest_data -r ../turnstile-ingest.rack \
+         http://Turnstile/CounterApplication \
+         ../../../Turnstile-Ontology
+     $ ls BUILD_DESC.OWL
+     ```
+
+     This is the same command, but without the specification to output
+     to an OWL file; when no output OWL file is specified the
+     automatic operation is to upload to the RDF server at localhost
+     port 3030.
+
+     Note that if the server is running but not setup yet, this will
+     typically result in an error:
+
+     ```
+     url `'http://localhost:3030/RACK/upload'' does not exist (status(404,Not Found))
+     ```
+
+     To resolve this error, the server must be setup to define the
+     RACK dataset.  For Fuseki, this is easily done by opening a
+     browser window to http://localhost:3030 and clicking on the
+     "manage datasets" tab and "add a new dataset", then specifying
+     the "Dataset name" to be "RACK".
+
+     Once the RACK dataset is defined, the above `ingest_data`
+     operation should run successfully.
+
+  4. Run a verification that the data in the RDB database doesn't
+     violate any of the constraints or other restrictions associated
+     with the RACK ontology.  To read from the server, use the `-m`
+     argument to specify the URL instead of a directory.
+
+     ```shell
+     $ check -v -m http://localhost:3030/
+     ```
+
+     Or similarly the analyze command can access the live RDB database:
+
+     ```shell
+     $ analyze -m http://localhost:3030/ -i http://testdata.org
+     ```
+
+     Note that when reading OWL files from the local filesystem, the
+     ontology model exists in a different location than the instance
+     data (e.g. Turnstile), so the `check` and `analyze` commands
+     allow the `-m` and `-d` flags to specify both locations,
+     respectively.  When reading from an RDF database (e.g. Fuseki),
+     all of the information is available in a single place, so only
+     the `-m` specification is needed.
+
 
 # Prolog API Usage
 

--- a/assist/bin/common_opts.pl
+++ b/assist/bin/common_opts.pl
@@ -73,7 +73,9 @@ parse_args(ExtraArgs, Opts, PosArgs) :-
     set_declaration_level(Opts),
     get_ontology_dir(Opts, ODir),
     print_message(informational, loading_ontology_dir(ODir)),
-    load_local_model(ODir),
+    catch( (exists_directory(ODir), load_local_model(ODir)),
+           error(existence_error(iri_scheme,http),_),
+           load_model_from_url(ODir)),
     load_recognizers(Opts),
     load_data_from_dir(Opts).
 

--- a/assist/bin/common_opts.pl
+++ b/assist/bin/common_opts.pl
@@ -33,7 +33,7 @@ opts_spec(Spec) :-
        help('Declare generated RDF triples to stdout')],
 
       [opt(ontology_dir), meta('DIR_OR_URL'), type(atom),
-       shortflags([o]), longflags(['ontology', 'model']),
+       shortflags([m]), longflags(['ontology', 'model']),
        default(OwlDir),
        help('Where to load ontology .Owl files from')],
 

--- a/assist/bin/rack/analyze.pl
+++ b/assist/bin/rack/analyze.pl
@@ -151,9 +151,9 @@ parent_path(E, []) :-
     % nodes (although there can be blank nodes, e.g. a link from the
     % base class to the _::file in which it was defined).
     rdf_subject(E),
-    findall(P, (rdf(E, rdfs:subClassOf, P), \+ rdf_bnode(P)), PS),
-    length(PS, PSL),
-    PSL == 0.
+    has_no_regular_parent(E).
+has_no_regular_parent(E) :- rdf(E, rdfs:subClassOf, P), \+ rdf_bnode(P), !, fail.
+has_no_regular_parent(_E).
 
 % ----------------------------------------------------------------------
 

--- a/assist/bin/rack/check.pl
+++ b/assist/bin/rack/check.pl
@@ -195,7 +195,7 @@ prolog:message(value_outside_range(Instance, Property, Ty, V, MinV, MaxV)) -->
           SI, SP, Val, T, Min, Max ] ].
 prolog:message(multiple_types_for_instance(Instance, Types)) -->
     { prefix_shorten(Instance, SI),
-      maplist(prefix_shorten(Types, STys))
+      maplist(prefix_shorten, Types, STys)
     },
     [ 'Instance ~w has multiple types: ~w~n'-[SI, STys] ].
 prolog:message(property_value_wrong_type(Instance, Property, DefType, Val, ValType)) -->

--- a/assist/bin/rack/model.pl
+++ b/assist/bin/rack/model.pl
@@ -502,10 +502,12 @@ load_data(Namespace, Dir) :-
     % Globally asserts current namespace so that this doesn't need to
     % be threaded as an argument through all the rules.
     assert(rack_namespace(Namespace), SetNS),
-    % Find all files admitted by 'rack_datafile' recursively starting at 'Dir'
-    load_data_dir(Dir),
-    % Instantiate all the loaded data
-    realize_loaded_data,
+    catch(
+        ( % Find all files admitted by 'rack_datafile' recursively starting at 'Dir'
+            load_data_dir(Dir),
+            % Instantiate all the loaded data
+            realize_loaded_data
+        ), _, writeln('Warning: data directory not accessible.')),
     % Remove the global namespace assertion
     erase(SetNS).
 

--- a/assist/databin/databin.rack
+++ b/assist/databin/databin.rack
@@ -11,6 +11,8 @@ databin_name(MyName) :-
                  tar_start/3,
                  tar_finished/3,
                  tool/3,
+                 user_instance_name/2,
+                 sw_dev_for_file/5,
                  build_with/5,
                  build_inputs/2,
                  build_outputs/2,
@@ -283,16 +285,22 @@ toolName(Nonce, ToolName, _ToolPath, Name) :-
     string_concat(N1, Nonce, StrName),
     atom_string(Name, StrName).
 
-data_instance('AGENTS#TOOL', load_data, Name, [toolSpec(Name, ToolPath)]) :-
+data_instance('AGENTS#TOOL', load_data, Name, [toolSpec(Name, ToolPath, UserInstance)]) :-
     tar_start(Nonce, _, ToolPath),
+    userForToolUsage(Nonce, UserInstance),
     toolName(Nonce, "tar", ToolPath, Name).
 
-data_instance('AGENTS#TOOL', load_data, Name, [toolSpec(Name, ToolPath)]) :-
+data_instance('AGENTS#TOOL', load_data, Name, [toolSpec(Name, ToolPath, UserInstance)]) :-
     build_with(Nonce, _ToolType, ToolName, ToolPath, _ToolArgs),
+    userForToolUsage(Nonce, UserInstance),
     toolName(Nonce, ToolName, ToolPath, Name).
 
-data_get('AGENTS#TOOL', 'FILE#definedIn', toolSpec(_Name, ToolPath), ToolPath).
+data_get('AGENTS#TOOL', 'FILE#definedIn', toolSpec(_Name, ToolPath, _User), ToolPath).
+data_get('AGENTS#TOOL', 'PROV-S#actedOnBehalfOf', toolSpec(_Name, _ToolPath, User), User).
 
+userForToolUsage(Nonce, UserInstance) :-
+    build_user(Nonce, UserName), !, user_instance_name(UserName, UserInstance).
+userForToolUsage(_, 'userUnknown').
 
 %% -------------------- CODE_DEVELOPMENT
 

--- a/assist/databin/databin.rack
+++ b/assist/databin/databin.rack
@@ -2,7 +2,7 @@
 :- multifile data_instance/4, data_get/4.
 
 databin_name(MyName) :-
-    append_fld('v0.9', ingest_databin, MyName).
+    append_fld('v5.1', ingest_databin, MyName).
 
 % These are the various facts that might be emitted by the databin
 % wrappers that will be recognized here.

--- a/assist/databin/databin.rack
+++ b/assist/databin/databin.rack
@@ -10,6 +10,7 @@ databin_name(MyName) :-
 :- discontiguous tar_access/3,
                  tar_start/3,
                  tar_finished/3,
+                 tool/3,
                  build_with/5,
                  build_inputs/2,
                  build_outputs/2,
@@ -89,16 +90,14 @@ data_instance('SOFTWARE#PACKAGE', load_data, Instance,
     Title = "package:tar",
     Descr = "Software package file in TAR format".
 
-data_get('SOFTWARE#PACKAGE', 'SOFTWARE#packagedBy', package_tar(N), ToolPath) :-
-    tar_start(N, _, ToolPath).
+data_get('SOFTWARE#PACKAGE', 'SOFTWARE#packagedBy', package_tar(N), Name) :-
+    tar_start(N, _, ToolPath),
+    toolName(N, "tar", ToolPath, Name).
 
 data_get('SOFTWARE#PACKAGE', 'SOFTWARE#packageInput', package_tar(Nonce), V) :-
     tar_access(Nonce, File, open),
     build_from(Nonce, Dir),
     file_instance(Nonce, Dir, File, V).
-
-data_get('SOFTWARE#PACKAGE', 'SOFTWARE#packagedBy', package_tar(Nonce), TarPath) :-
-    tar_start(Nonce, _, TarPath).
 
 data_get('SOFTWARE#PACKAGE', 'PROV-S#wasAssociatedWith',
          package_tar(N),
@@ -279,6 +278,21 @@ data_instance('FILE#FORMAT', load_data, F, [uid(F, Title, Descr), fmt(F)]) :-
 activity_instance(Nonce, ToolType, InstanceName) :-
     append_fld(Nonce, ToolType, InstanceName).
 
+toolName(Nonce, ToolName, _ToolPath, Name) :-
+    string_concat(ToolName, "--:", N1),
+    string_concat(N1, Nonce, StrName),
+    atom_string(Name, StrName).
+
+data_instance('AGENTS#TOOL', load_data, Name, [toolSpec(Name, ToolPath)]) :-
+    tar_start(Nonce, _, ToolPath),
+    toolName(Nonce, "tar", ToolPath, Name).
+
+data_instance('AGENTS#TOOL', load_data, Name, [toolSpec(Name, ToolPath)]) :-
+    build_with(Nonce, _ToolType, ToolName, ToolPath, _ToolArgs),
+    toolName(Nonce, ToolName, ToolPath, Name).
+
+data_get('AGENTS#TOOL', 'FILE#definedIn', toolSpec(_Name, ToolPath), ToolPath).
+
 
 %% -------------------- CODE_DEVELOPMENT
 
@@ -327,8 +341,8 @@ data_get(_, 'SOFTWARE#compileInput',
     file_instance(Nonce, Dir, Input, InputInstance).
 
 data_get(_, 'SOFTWARE#compiledBy',
-         activity_data(build_with(_, compile, _, ToolPath, _),_,_),
-         ToolPath).
+         activity_data(build_with(Nonce, compile, ToolName, ToolPath, _ToolArgs),_,_), Name) :-
+    toolName(Nonce, ToolName, ToolPath, Name).
 data_get('SOFTWARE#COMPILE', 'PROV-S#wasAssociatedWith',
          activity_data(_,build_start(N,_),_),
          UserInstance) :-


### PR DESCRIPTION
* With change of `COMPILE` `compiledBy` to a `wasAssociatedWith`, the range became a TOOL (subclass of AGENT) and needed a way to link back to the `FILE`.  This was done via the `definedIn`, broadening the domain of the latter a bit.
* Update ASSIST analyze and check to read from a  live database (e.g. Fuseki) as well as local OWL files.
* Fix a couple of small issues in the Turnstile ASSIST definitions
* Better documentation for ASSIST tools.
* Fixed ASSIST for the recent SADL change which links defined classes to the file in which they are defined (via an RDF blank node).