### PR TITLE
some single values should be at most 1 values

### DIFF
--- a/RACK-Ontology/OwlModels/HAZARD.owl
+++ b/RACK-Ontology/OwlModels/HAZARD.owl
@@ -21,8 +21,8 @@
   <owl:Class rdf:ID="HAZARD">
     <rdfs:subClassOf>
       <owl:Restriction>
-        <owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >1</owl:cardinality>
+        <owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >1</owl:maxCardinality>
         <owl:onProperty>
           <owl:DatatypeProperty rdf:ID="likelihood"/>
         </owl:onProperty>
@@ -30,8 +30,8 @@
     </rdfs:subClassOf>
     <rdfs:subClassOf>
       <owl:Restriction>
-        <owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >1</owl:cardinality>
+        <owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >1</owl:maxCardinality>
         <owl:onProperty>
           <owl:DatatypeProperty rdf:ID="severity"/>
         </owl:onProperty>
@@ -39,8 +39,8 @@
     </rdfs:subClassOf>
     <rdfs:subClassOf>
       <owl:Restriction>
-        <owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >1</owl:cardinality>
+        <owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >1</owl:maxCardinality>
         <owl:onProperty>
           <owl:DatatypeProperty rdf:ID="effect"/>
         </owl:onProperty>

--- a/RACK-Ontology/OwlModels/SYSTEM.owl
+++ b/RACK-Ontology/OwlModels/SYSTEM.owl
@@ -21,8 +21,8 @@
   <owl:Class rdf:ID="FUNCTION">
     <rdfs:subClassOf>
       <owl:Restriction>
-        <owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >1</owl:cardinality>
+        <owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >1</owl:maxCardinality>
         <owl:onProperty>
           <owl:ObjectProperty rdf:ID="parentFunction"/>
         </owl:onProperty>

--- a/RACK-Ontology/ontology/HAZARD.sadl
+++ b/RACK-Ontology/ontology/HAZARD.sadl
@@ -38,11 +38,14 @@ HAZARD
 
 	identified (note "how this HAZARD was identified") describes HAZARD with values of type HAZARD_IDENTIFICATION.
 
-	effect (note "consequence(s) of the HAZARD") describes HAZARD with a single value of type string.
-   
-	severity (note "the severity of the HAZARD") describes HAZARD with a single value of type float [0,1].
+	effect (note "consequence(s) of the HAZARD") describes HAZARD with values of type string.
+   	effect describes HAZARD with at most 1 value.
+   	
+	severity (note "the severity of the HAZARD") describes HAZARD with values of type float [0,1].
+	severity describes HAZARD with at most 1 value.
 
-	likelihood (note "probability value between 0 and 1") describes HAZARD with a single value of type float [0,1].
+	likelihood (note "probability value between 0 and 1") describes HAZARD with values of type float [0,1].
+	likelihood describes HAZARD with at most 1 value.
 
 	// A Hazard can be mitigated by a requirement, operating procedure etc., mitigation by REQUIREMENT is defined in REQUIREMENTS.sadl.
 	H:mitigates (note "a HAZARD may be mitigated by a OP_PROCEDURE") describes OP_PROCEDURE with values of type HAZARD.

--- a/RACK-Ontology/ontology/SYSTEM.sadl
+++ b/RACK-Ontology/ontology/SYSTEM.sadl
@@ -66,9 +66,10 @@ FUNCTION
 	(note "defines functionality / capability")
 	is a type of ENTITY.
 
-   parentFunction (note "allows for decomposition of functionality") describes FUNCTION with a single value of type FUNCTION.
-
-OP_ENV   
+    parentFunction (note "allows for decomposition of functionality") describes FUNCTION with values of type FUNCTION.
+    parentFunction describes FUNCTION with at most 1 value.
+    
+OP_ENV
 	(note "defines the operating environment assumptions and constraints")
 	is a type of THING. // should this be an ENTITY?
 		


### PR DESCRIPTION
While the standalone statement `prop has a single value.` on its own means a
property is functional (has 0 or 1 values), the statement
`described with a single value of type` means exactly 1.

This commit adapts some of the instances where 0 or 1 was intended
rather than a strict exactly one. This is a generalization. All previously
valid data will stay valid.