### PR TITLE
check all shell scripts together

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Lint shell scripts
       uses: ludeeus/action-shellcheck@1.0.0
       env:
-        SHELLCHECK_OPTS: -P assist/databin -e SC1008
+        SHELLCHECK_OPTS: -x -P assist/databin -e SC1008
 
 # Cache job:
 #  - Downloads rack-box files

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Lint shell scripts
       uses: ludeeus/action-shellcheck@1.0.0
       env:
-        SHELLCHECK_OPTS: -e SC1008
+        SHELLCHECK_OPTS: -P assist/databin -e SC1008
 
 # Cache job:
 #  - Downloads rack-box files


### PR DESCRIPTION
This allows the scripts to include each other despite the shellcheck sandbox