### PR TITLE
Allow CI jobs from forks

### DIFF
--- a/.github/workflows/actions/download/action.yml
+++ b/.github/workflows/actions/download/action.yml
@@ -45,6 +45,7 @@ runs:
         tar cfz RACK/rack-box/files/rack-cli.tar.gz RACK/cli/{setup-rack.sh,wheels}
 
     - name: Package RACK documentation
+      if: github.repository == 'ge-high-assurance/RACK'
       shell: bash
       run: |
         sudo npm install -g github-wikito-converter markdown-to-html
@@ -53,6 +54,12 @@ runs:
         markdown -t RACK-in-a-box -s style.css RACK.wiki/_Welcome.md > index.html
         sed -i -e 's/>NodeGroupService/ onclick="javascript:event.target.port=12058">NodeGroupService/' index.html
         mv documentation.html index.html RACK/rack-box/files
+
+    - name: Package RACK documentation (fallback)
+      if: github.repository != 'ge-high-assurance/RACK'
+      shell: bash
+      run: |
+        touch RACK/rack-box/files/{documentation.html,index.html}
 
     - name: Package RACK ontology and data
       shell: bash

--- a/.github/workflows/actions/download/action.yml
+++ b/.github/workflows/actions/download/action.yml
@@ -45,21 +45,18 @@ runs:
         tar cfz RACK/rack-box/files/rack-cli.tar.gz RACK/cli/{setup-rack.sh,wheels}
 
     - name: Package RACK documentation
-      if: github.repository == 'ge-high-assurance/RACK'
       shell: bash
       run: |
         sudo npm install -g github-wikito-converter markdown-to-html
+        # In case job couldn't check out RACK.wiki
+        mkdir -p RACK.wiki/
+        touch -a RACK.wiki/_Footer.md
         cp RACK.wiki/_Footer.md RACK.wiki/Copyright.md
         gwtc -t RACK-in-a-Box RACK.wiki
+        touch -a RACK.wiki/_Welcome.md
         markdown -t RACK-in-a-box -s style.css RACK.wiki/_Welcome.md > index.html
         sed -i -e 's/>NodeGroupService/ onclick="javascript:event.target.port=12058">NodeGroupService/' index.html
         mv documentation.html index.html RACK/rack-box/files
-
-    - name: Package RACK documentation (fallback)
-      if: github.repository != 'ge-high-assurance/RACK'
-      shell: bash
-      run: |
-        touch RACK/rack-box/files/{documentation.html,index.html}
 
     - name: Package RACK ontology and data
       shell: bash

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -88,11 +88,10 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: ge-high-assurance/RACK
-        token: ${{ secrets.RACK_CI_PAT }}
         path: RACK
 
     - name: Check out RACK wiki
-      if: steps.cache-files.outputs.cache-hit != 'true'
+      if: steps.cache-files.outputs.cache-hit != 'true' && github.repository == 'ge-high-assurance/RACK'
       uses: actions/checkout@v2
       with:
         repository: ge-high-assurance/RACK.wiki
@@ -138,7 +137,6 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: ge-high-assurance/RACK
-        token: ${{ secrets.RACK_CI_PAT }}
         path: RACK
 
     - name: Set up Python
@@ -198,7 +196,6 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: ge-high-assurance/RACK
-        token: ${{ secrets.RACK_CI_PAT }}
         path: RACK
 
     - name: Get all files needed by rack-box

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,6 @@ jobs:
       with:
         repository: ge-high-assurance/RACK
         ref: ${{ github.event.release.tag_name }}
-        token: ${{ secrets.RACK_CI_PAT }}
         path: RACK
 
     - name: Check out RACK wiki
@@ -103,7 +102,6 @@ jobs:
       with:
         repository: ge-high-assurance/RACK
         ref: ${{ github.event.release.tag_name }}
-        token: ${{ secrets.RACK_CI_PAT }}
         path: RACK
 
     - name: Get all files needed by rack-box


### PR DESCRIPTION
Currently a CI job started from a fork's pull request will fail when
it tries to check out the RACK and RACK.wiki repositories with a
secret token since the job can't use the secret token.  Those changes
ought to allow the CI job to finish.

action.yml: Fallback to empty RACK.wiki files in CI jobs from forks.

continuous.yml: No need to use secret token to check out RACK. Skip
RACK.wiki check out in CI jobs from forks.

release.yml: No need to use secret token to check out RACK. No need to
worry about running CI jobs from forks.