### PR TITLE
migration: update commits and make them more exhaustive

### DIFF
--- a/migration/ontology_changes/__init__.py
+++ b/migration/ontology_changes/__init__.py
@@ -9,10 +9,18 @@
 # material are those of the author(s) and do not necessarily reflect the views
 # of the Defense Advanced Research Projects Agency (DARPA).
 
+from ontology_changes.add_class import AddClass
+from ontology_changes.add_property_is_a_type_of import AddPropertyIsATypeOf
+from ontology_changes.cardinality import AtMost, Cardinality, SingleValue, Unconstrained
 from ontology_changes.change_cardinality import ChangeCardinality
-from ontology_changes.change_is_a_type_of import ChangeIsATypeOf
+from ontology_changes.change_class_is_a_type_of import ChangeClassIsATypeOf
+from ontology_changes.change_property_is_a_type_of import ChangePropertyIsATypeOf
 from ontology_changes.change_property_range import ChangePropertyRange
+from ontology_changes.create_class import CreateClass
+from ontology_changes.create_property import CreateProperty
+from ontology_changes.delete_class import DeleteClass
 from ontology_changes.delete_property import DeleteProperty
 from ontology_changes.ontology_change import Commit
 from ontology_changes.rename_class import RenameClass
 from ontology_changes.rename_property import RenameProperty
+from ontology_changes.remove_is_a_type_of import RemoveIsATypeOf

--- a/migration/ontology_changes/add_class.py
+++ b/migration/ontology_changes/add_class.py
@@ -13,38 +13,29 @@ from dataclasses import dataclass
 
 import semtk
 
-from ontology_changes.ontology_change import stylize_property, OntologyChange
+from migration_helpers.name_space import NameSpace, get_uri
+from ontology_changes.ontology_change import stylize_class, OntologyChange
 
 
 @dataclass
-class ChangeIsATypeOf(OntologyChange):
+class AddClass(OntologyChange):
     """
-    Represents an ontology change from:
-
-    property_id is a type of from_property_id.
-
-    to:
-
-    property_id is a type of to_property_id.
+    Represents the addition of a new class.
     """
 
+    name_space: NameSpace
     class_id: str
-    property_id: str
-    from_property_id: str
-    to_property_id: str
 
     def text_description(self) -> str:
-        prop = stylize_property(self.property_id)
-        from_str = stylize_property(self.from_property_id)
-        to_str = stylize_property(self.to_property_id)
-        return f"Property {prop} used to be a type of {from_str}, is now a type of {to_str}"
+        class_str = stylize_class(get_uri(self.name_space, self.class_id))
+        return f"Class {class_str} was created."
 
     def migrate_json(self, json: semtk.SemTKJSON) -> None:
         json.accept(MigrationVisitor(self))
 
 
 class MigrationVisitor(semtk.DefaultSemTKVisitor):
-    def __init__(self, data: ChangeIsATypeOf):
+    def __init__(self, data: AddClass):
         self.data = data
 
     # TODO

--- a/migration/ontology_changes/add_property_is_a_type_of.py
+++ b/migration/ontology_changes/add_property_is_a_type_of.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2020, Galois, Inc.
+#
+# All Rights Reserved
+#
+# This material is based upon work supported by the Defense Advanced Research
+# Projects Agency (DARPA) under Contract No. FA8750-20-C-0203.
+#
+# Any opinions, findings and conclusions or recommendations expressed in this
+# material are those of the author(s) and do not necessarily reflect the views
+# of the Defense Advanced Research Projects Agency (DARPA).
+
+from dataclasses import dataclass
+
+import semtk
+
+from migration_helpers.name_space import NameSpace, get_uri
+from ontology_changes.ontology_change import stylize_property, OntologyChange
+
+
+@dataclass
+class AddPropertyIsATypeOf(OntologyChange):
+    """
+    Represents the addition of a line:
+
+    property_id is a type of property_id.
+    """
+
+    name_space: NameSpace
+    class_id: str
+    property_id: str
+    range_name_space: NameSpace
+    range: str
+
+    def text_description(self) -> str:
+        prop = stylize_property(get_uri(self.name_space, self.property_id))
+        range_str = stylize_property(get_uri(self.range_name_space, self.range))
+        return f"Property {prop} is now a type of {range_str}."
+
+    def migrate_json(self, json: semtk.SemTKJSON) -> None:
+        json.accept(MigrationVisitor(self))
+
+
+class MigrationVisitor(semtk.DefaultSemTKVisitor):
+    def __init__(self, data: AddPropertyIsATypeOf):
+        self.data = data
+
+    # TODO

--- a/migration/ontology_changes/cardinality.py
+++ b/migration/ontology_changes/cardinality.py
@@ -1,0 +1,34 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+
+class Cardinality(ABC):
+
+    @abstractmethod
+    def text_description(self) -> str:
+        ...
+
+
+@dataclass
+class AtMost(Cardinality):
+    at_most: int
+
+    def text_description(self) -> str:
+        if self.at_most == 1:
+            return f"at most {self.at_most} value"
+        else:
+            return f"at most {self.at_most} values"
+
+
+@dataclass
+class SingleValue(Cardinality):
+
+    def text_description(self) -> str:
+        return "single value"
+
+
+@dataclass
+class Unconstrained(Cardinality):
+
+    def text_description(self) -> str:
+        return "unconstrained"

--- a/migration/ontology_changes/change_class_is_a_type_of.py
+++ b/migration/ontology_changes/change_class_is_a_type_of.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2020, Galois, Inc.
+#
+# All Rights Reserved
+#
+# This material is based upon work supported by the Defense Advanced Research
+# Projects Agency (DARPA) under Contract No. FA8750-20-C-0203.
+#
+# Any opinions, findings and conclusions or recommendations expressed in this
+# material are those of the author(s) and do not necessarily reflect the views
+# of the Defense Advanced Research Projects Agency (DARPA).
+
+from dataclasses import dataclass
+
+import semtk
+
+from migration_helpers.name_space import NameSpace, get_uri
+from ontology_changes.ontology_change import (
+    stylize_class,
+    OntologyChange,
+)
+
+
+@dataclass
+class ChangeClassIsATypeOf(OntologyChange):
+    """
+    Represents an ontology change from:
+
+    class_id is a type of from_class_id.
+
+    to:
+
+    class_id is a type of to_class_id.
+    """
+
+    name_space: NameSpace
+    class_id: str
+
+    from_name_space: NameSpace
+    from_class_id: str
+
+    to_name_space: NameSpace
+    to_class_id: str
+
+    def text_description(self) -> str:
+        class_str = stylize_class(get_uri(self.name_space, self.class_id))
+        from_str = stylize_class(get_uri(self.name_space, self.from_class_id))
+        to_str = stylize_class(get_uri(self.name_space, self.to_class_id))
+        return f"Class {class_str} used to be a type of {from_str}, is now a type of {to_str}."
+
+    def migrate_json(self, json: semtk.SemTKJSON) -> None:
+        json.accept(MigrationVisitor(self))
+
+
+class MigrationVisitor(semtk.DefaultSemTKVisitor):
+    def __init__(self, data: ChangeClassIsATypeOf):
+        self.data = data
+
+    # TODO

--- a/migration/ontology_changes/change_property_is_a_type_of.py
+++ b/migration/ontology_changes/change_property_is_a_type_of.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2020, Galois, Inc.
+#
+# All Rights Reserved
+#
+# This material is based upon work supported by the Defense Advanced Research
+# Projects Agency (DARPA) under Contract No. FA8750-20-C-0203.
+#
+# Any opinions, findings and conclusions or recommendations expressed in this
+# material are those of the author(s) and do not necessarily reflect the views
+# of the Defense Advanced Research Projects Agency (DARPA).
+
+from dataclasses import dataclass
+
+import semtk
+
+from migration_helpers.name_space import NameSpace, get_uri
+from ontology_changes.ontology_change import stylize_property, OntologyChange
+
+
+@dataclass
+class ChangePropertyIsATypeOf(OntologyChange):
+    """
+    Represents an ontology change from:
+
+    property_id is a type of from_property_id.
+
+    to:
+
+    property_id is a type of to_property_id.
+    """
+
+    name_space: NameSpace
+    class_id: str
+    property_id: str
+
+    from_name_space: NameSpace
+    from_property_id: str
+
+    to_name_space: NameSpace
+    to_property_id: str
+
+    def text_description(self) -> str:
+        prop = stylize_property(get_uri(self.name_space, self.property_id))
+        from_str = stylize_property(get_uri(self.name_space, self.from_property_id))
+        to_str = stylize_property(get_uri(self.name_space, self.to_property_id))
+        return f"Property {prop} used to be a type of {from_str}, is now a type of {to_str}."
+
+    def migrate_json(self, json: semtk.SemTKJSON) -> None:
+        json.accept(MigrationVisitor(self))
+
+
+class MigrationVisitor(semtk.DefaultSemTKVisitor):
+    def __init__(self, data: ChangePropertyIsATypeOf):
+        self.data = data
+
+    # TODO

--- a/migration/ontology_changes/change_property_range.py
+++ b/migration/ontology_changes/change_property_range.py
@@ -51,7 +51,7 @@ class ChangePropertyRange(OntologyChange):
         prop = stylize_property(get_uri(self.prop_name_space, self.prop_name))
         from_range = stylize_class(get_uri(self.from_name_space, self.from_range))
         to_range = stylize_class(get_uri(self.to_name_space, self.to_range))
-        return f"Range of property {prop} was changed from {from_range} to {to_range}"
+        return f"Range of property {prop} was changed from {from_range} to {to_range}."
 
     def migrate_json(self, json: semtk.SemTKJSON) -> None:
         log_apply_change(self.text_description())

--- a/migration/ontology_changes/create_class.py
+++ b/migration/ontology_changes/create_class.py
@@ -14,37 +14,32 @@ from dataclasses import dataclass
 import semtk
 from migration_helpers.name_space import NameSpace, get_uri
 
-from ontology_changes.cardinality import Cardinality
 from ontology_changes.ontology_change import (
     OntologyChange,
     log_apply_change,
     stylize_class,
-    stylize_property,
 )
 
 
 @dataclass
-class ChangeCardinality(OntologyChange):
+class CreateClass(OntologyChange):
     """
-    Represents some change of cardinality.  We don't use this for migration yet.
+    Represents an ontology change where a class has been created.
     """
 
     name_space: NameSpace
     class_id: str
-    property_id: str
-    to_cardinality: Cardinality
 
     def text_description(self) -> str:
-        prop = stylize_property(get_uri(self.name_space, self.property_id))
         class_str = stylize_class(get_uri(self.name_space, self.class_id))
-        return f"Property {prop} (ranging over {class_str}) changed cardinality to {self.to_cardinality.text_description()}."
+        return f"Class {class_str} was created."
 
     def migrate_json(self, json: semtk.SemTKJSON) -> None:
         log_apply_change(self.text_description())
-        # Currently, do nothing, uncomment if you want to migrate:
+        # do nothing
         # json.accept(MigrationVisitor(self))
 
 
-# class MigrationVisitor(semtk.DefaultSemTKVisitor):
-#     def __init__(self, data: ChangeCardinality):
-#         self.data = data
+class MigrationVisitor(semtk.DefaultSemTKVisitor):
+    def __init__(self, data: CreateClass):
+        self.data = data

--- a/migration/ontology_changes/create_property.py
+++ b/migration/ontology_changes/create_property.py
@@ -14,37 +14,33 @@ from dataclasses import dataclass
 import semtk
 from migration_helpers.name_space import NameSpace, get_uri
 
-from ontology_changes.cardinality import Cardinality
 from ontology_changes.ontology_change import (
     OntologyChange,
     log_apply_change,
-    stylize_class,
     stylize_property,
 )
 
 
 @dataclass
-class ChangeCardinality(OntologyChange):
+class CreateProperty(OntologyChange):
     """
-    Represents some change of cardinality.  We don't use this for migration yet.
+    Represents an ontology change where a property has been created.
     """
 
     name_space: NameSpace
     class_id: str
     property_id: str
-    to_cardinality: Cardinality
 
     def text_description(self) -> str:
         prop = stylize_property(get_uri(self.name_space, self.property_id))
-        class_str = stylize_class(get_uri(self.name_space, self.class_id))
-        return f"Property {prop} (ranging over {class_str}) changed cardinality to {self.to_cardinality.text_description()}."
+        return f"Property {prop} was created."
 
     def migrate_json(self, json: semtk.SemTKJSON) -> None:
         log_apply_change(self.text_description())
-        # Currently, do nothing, uncomment if you want to migrate:
+        # do nothing
         # json.accept(MigrationVisitor(self))
 
 
-# class MigrationVisitor(semtk.DefaultSemTKVisitor):
-#     def __init__(self, data: ChangeCardinality):
-#         self.data = data
+class MigrationVisitor(semtk.DefaultSemTKVisitor):
+    def __init__(self, data: CreateProperty):
+        self.data = data

--- a/migration/ontology_changes/delete_class.py
+++ b/migration/ontology_changes/delete_class.py
@@ -14,37 +14,35 @@ from dataclasses import dataclass
 import semtk
 from migration_helpers.name_space import NameSpace, get_uri
 
-from ontology_changes.cardinality import Cardinality
 from ontology_changes.ontology_change import (
     OntologyChange,
     log_apply_change,
-    stylize_class,
     stylize_property,
 )
 
 
 @dataclass
-class ChangeCardinality(OntologyChange):
+class DeleteClass(OntologyChange):
     """
-    Represents some change of cardinality.  We don't use this for migration yet.
+    Represents an ontology change where a class is no longer part of the
+    ontology.
     """
 
     name_space: NameSpace
     class_id: str
-    property_id: str
-    to_cardinality: Cardinality
 
     def text_description(self) -> str:
-        prop = stylize_property(get_uri(self.name_space, self.property_id))
-        class_str = stylize_class(get_uri(self.name_space, self.class_id))
-        return f"Property {prop} (ranging over {class_str}) changed cardinality to {self.to_cardinality.text_description()}."
+        class_ = stylize_property(get_uri(self.name_space, self.class_id))
+        return f"Class {class_} was deleted."
 
     def migrate_json(self, json: semtk.SemTKJSON) -> None:
         log_apply_change(self.text_description())
-        # Currently, do nothing, uncomment if you want to migrate:
-        # json.accept(MigrationVisitor(self))
+        json.accept(MigrationVisitor(self))
 
 
-# class MigrationVisitor(semtk.DefaultSemTKVisitor):
-#     def __init__(self, data: ChangeCardinality):
-#         self.data = data
+class MigrationVisitor(semtk.DefaultSemTKVisitor):
+    def __init__(self, data: DeleteClass):
+        self.data = data
+        self.uri = get_uri(self.data.name_space, self.data.class_id)
+
+    # TODO: this can probably be implemented

--- a/migration/ontology_changes/delete_property.py
+++ b/migration/ontology_changes/delete_property.py
@@ -36,7 +36,7 @@ class DeleteProperty(OntologyChange):
 
     def text_description(self) -> str:
         prop = stylize_property(get_uri(self.name_space, self.property_id))
-        return f"{DeleteProperty.__name__} {prop}"
+        return f"Property {prop} was deleted."
 
     def migrate_json(self, json: semtk.SemTKJSON) -> None:
         log_apply_change(self.text_description())

--- a/migration/ontology_changes/remove_is_a_type_of.py
+++ b/migration/ontology_changes/remove_is_a_type_of.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2020, Galois, Inc.
+#
+# All Rights Reserved
+#
+# This material is based upon work supported by the Defense Advanced Research
+# Projects Agency (DARPA) under Contract No. FA8750-20-C-0203.
+#
+# Any opinions, findings and conclusions or recommendations expressed in this
+# material are those of the author(s) and do not necessarily reflect the views
+# of the Defense Advanced Research Projects Agency (DARPA).
+
+from dataclasses import dataclass
+
+import semtk
+
+from migration_helpers.name_space import NameSpace, get_uri
+from ontology_changes.ontology_change import stylize_property, OntologyChange
+
+
+@dataclass
+class RemoveIsATypeOf(OntologyChange):
+    """
+    Represents an ontology change where:
+
+    property_id is a type of from_property_id.
+
+    has been removed.
+    """
+
+    name_space: NameSpace
+    class_id: str
+    property_id: str
+    range_id: str
+
+    def text_description(self) -> str:
+        prop = stylize_property(self.property_id)
+        range_str = stylize_property(self.range_id)
+        return f"Property {prop} used to be a type of {range_str}, no longer."
+
+    def migrate_json(self, json: semtk.SemTKJSON) -> None:
+        json.accept(MigrationVisitor(self))
+
+
+class MigrationVisitor(semtk.DefaultSemTKVisitor):
+    def __init__(self, data: RemoveIsATypeOf):
+        self.data = data
+
+    # TODO?

--- a/migration/ontology_changes/rename_class.py
+++ b/migration/ontology_changes/rename_class.py
@@ -40,7 +40,7 @@ class RenameClass(OntologyChange):
     def text_description(self) -> str:
         from_class = stylize_class(get_uri(self.from_name_space, self.from_name))
         to_class = stylize_class(get_uri(self.to_name_space, self.to_name))
-        return f"Class {from_class} was renamed to {to_class}"
+        return f"Class {from_class} was renamed to {to_class}."
 
     def migrate_json(self, json: semtk.SemTKJSON) -> None:
         log_apply_change(self.text_description())

--- a/migration/ontology_changes/rename_property.py
+++ b/migration/ontology_changes/rename_property.py
@@ -20,6 +20,7 @@ from ontology_changes.ontology_change import (
     log_additional_change,
     log_apply_change,
     log_change,
+    stylize_class,
     stylize_json,
     stylize_property,
 )
@@ -44,7 +45,9 @@ class RenameProperty(OntologyChange):
     def text_description(self) -> str:
         from_prop = stylize_property(get_uri(self.from_name_space, self.from_name))
         to_prop = stylize_property(get_uri(self.from_name_space, self.from_name))
-        return f"Property {from_prop} was renamed to {to_prop}"
+        from_class = stylize_class(get_uri(self.from_name_space, self.from_class))
+        to_class = stylize_class(get_uri(self.from_name_space, self.to_class))
+        return f"Property {from_prop} (ranging over {from_class}) was renamed to {to_prop} (ranging over {to_class})."
 
     def migrate_json(self, json: semtk.SemTKJSON) -> None:
         log_apply_change(self.text_description())

--- a/migration/rack/commits/commit05a03cd687e3bdce425794763e0957d3ccaf8ff0.py
+++ b/migration/rack/commits/commit05a03cd687e3bdce425794763e0957d3ccaf8ff0.py
@@ -9,19 +9,52 @@
 # material are those of the author(s) and do not necessarily reflect the views
 # of the Defense Advanced Research Projects Agency (DARPA).
 
-from ontology_changes import ChangeIsATypeOf, Commit
+from migration_helpers.name_space import rack
+from ontology_changes import (
+    AtMost,
+    ChangeCardinality,
+    ChangePropertyIsATypeOf,
+    Commit,
+    RemoveIsATypeOf,
+)
 
+HAZARD = rack("HAZARD")
+PROV_S = rack("PROV-S")
 
 commit = Commit(
     number="05a03cd687e3bdce425794763e0957d3ccaf8ff0",
     changes=[
         # HAZARD.sadl
-        ChangeIsATypeOf(
+        ChangeCardinality(
+            name_space=HAZARD,
+            class_id="HAZARD",
+            property_id="definition",
+            to_cardinality=AtMost(1),
+        ),
+        RemoveIsATypeOf(
+            name_space=HAZARD,
+            class_id="HAZARD",
+            property_id="identified",
+            range_id="wasGeneratedBy",
+        ),
+        # 'severity' range changed
+        # 'likelihood' range changed
+        ChangePropertyIsATypeOf(
+            name_space=HAZARD,
             class_id="HAZARD",
             property_id="source",  # H:source?
+            from_name_space=PROV_S,
             from_property_id="wasDerivedFrom",
+            to_name_space=PROV_S,
             to_property_id="wasImpactedBy",
         ),
-        # RemoveIsATypeOf on identified?
+        RemoveIsATypeOf(
+            name_space=HAZARD,
+            class_id="HAZARD",
+            property_id="identified",
+            range_id="wasGeneratedBy",
+        ),
+        # Technically the range of 'severity' and 'likelihood' have changed, if
+        # we ever track that.
     ],
 )

--- a/migration/rack/commits/commit09b79d6c0e7f72b533a3ad21e776b200a973698a.py
+++ b/migration/rack/commits/commit09b79d6c0e7f72b533a3ad21e776b200a973698a.py
@@ -10,7 +10,7 @@
 # of the Defense Advanced Research Projects Agency (DARPA).
 
 from migration_helpers.name_space import rack
-from ontology_changes import ChangeCardinality, Commit
+from ontology_changes import AtMost, ChangeCardinality, Commit
 
 HAZARD = rack("HAZARD")
 SYSTEM = rack("SYSTEM")
@@ -24,16 +24,19 @@ commit = Commit(
             name_space=HAZARD,
             class_id="HAZARD",
             property_id="effect",
+            to_cardinality=AtMost(1),
         ),
         ChangeCardinality(
             name_space=HAZARD,
             class_id="HAZARD",
             property_id="severity",
+            to_cardinality=AtMost(1),
         ),
         ChangeCardinality(
             name_space=HAZARD,
             class_id="HAZARD",
             property_id="likelihood",
+            to_cardinality=AtMost(1),
         ),
 
         # SYSTEM.sadl
@@ -41,6 +44,7 @@ commit = Commit(
             name_space=SYSTEM,
             class_id="FUNCTION",
             property_id="parentFunction",
+            to_cardinality=AtMost(1),
         ),
 
     ],

--- a/migration/rack/commits/commit10da69db606ebdc721fd3f8e003ef2099a5fdc43.py
+++ b/migration/rack/commits/commit10da69db606ebdc721fd3f8e003ef2099a5fdc43.py
@@ -10,7 +10,7 @@
 # of the Defense Advanced Research Projects Agency (DARPA).
 
 from migration_helpers.name_space import rack
-from ontology_changes import Commit, RenameProperty
+from ontology_changes import Commit, CreateClass, RenameProperty
 
 DOCUMENT = rack("DOCUMENT")
 PROV_S = rack("PROV-S")
@@ -19,7 +19,10 @@ commit = Commit(
     number="10da69db606ebdc721fd3f8e003ef2099a5fdc43",
     changes=[
         # DOCUMENT.sadl
-        # AddedClass DOCUMENT that replaces a lot of classes!
+        CreateClass(
+            name_space=DOCUMENT,
+            class_id="DOCUMENT",
+        ),
         # DOCUMENT#DESCRIPTION
         RenameProperty(
             from_name_space=DOCUMENT,

--- a/migration/rack/commits/commit2e079bb2a32b3cc1b3153d44ad0c21e27507937f.py
+++ b/migration/rack/commits/commit2e079bb2a32b3cc1b3153d44ad0c21e27507937f.py
@@ -9,23 +9,52 @@
 # material are those of the author(s) and do not necessarily reflect the views
 # of the Defense Advanced Research Projects Agency (DARPA).
 
-# from migration_helpers.name_space import rack
-from ontology_changes import Commit, ChangeIsATypeOf
+from migration_helpers.name_space import rack
+from ontology_changes import (
+    Commit,
+    ChangeCardinality,
+    ChangePropertyIsATypeOf,
+    ChangePropertyRange,
+    SingleValue,
+)
+
+PROV_S = rack("PROV-S")
+TESTING = rack("TESTING")
 
 commit = Commit(
     number="2e079bb2a32b3cc1b3153d44ad0c21e27507937f",
     changes=[
         # TESTING.sadl
-        ChangeIsATypeOf(
+        ChangePropertyIsATypeOf(
+            name_space=TESTING,
             class_id="TEST",
             property_id="verifies",
+            from_name_space=PROV_S,
             from_property_id="wasDerivedFrom",
+            to_name_space=PROV_S,
             to_property_id="wasImpactedBy",
         ),
-        ChangeIsATypeOf(
+        ChangeCardinality(
+            name_space=TESTING,
+            class_id="TEST_RESULT",
+            property_id="result",
+            to_cardinality=SingleValue(),
+        ),
+        ChangePropertyRange(
+            prop_name_space=TESTING,
+            prop_name="confirms",
+            from_name_space=PROV_S,
+            from_range="ENTITY",
+            to_name_space=TESTING,
+            to_range="TEST",
+        ),
+        ChangePropertyIsATypeOf(
+            name_space=TESTING,
             class_id="TEST_RESULT",
             property_id="confirms",
+            from_name_space=PROV_S,
             from_property_id="wasDerivedFrom",
+            to_name_space=PROV_S,
             to_property_id="wasImpactedBy",
         ),
     ],

--- a/migration/rack/commits/commit44393cc30bb0ba7482acd21b2e68576b577179f9.py
+++ b/migration/rack/commits/commit44393cc30bb0ba7482acd21b2e68576b577179f9.py
@@ -9,19 +9,45 @@
 # material are those of the author(s) and do not necessarily reflect the views
 # of the Defense Advanced Research Projects Agency (DARPA).
 
-# from migration_helpers.name_space import rack
-from ontology_changes import Commit, ChangeIsATypeOf
+from migration_helpers.name_space import rack
+from ontology_changes import (
+    ChangeCardinality,
+    ChangeClassIsATypeOf,
+    ChangePropertyIsATypeOf,
+    Commit,
+    SingleValue,
+)
+
+DOCUMENT = rack("DOCUMENT")
+PROV_S = rack("PROV-S")
+REVIEW = rack("REVIEW")
 
 commit = Commit(
     number="44393cc30bb0ba7482acd21b2e68576b577179f9",
     changes=[
         # REVIEW.sadl
-        # ChangeClassIsATypeOf
-        ChangeIsATypeOf(
+        ChangeClassIsATypeOf(
+            name_space=REVIEW,
+            class_id="REVIEW_LOG",
+            from_name_space=PROV_S,
+            from_class_id="ENTITY",
+            to_name_space=DOCUMENT,
+            to_class_id="REPORT",
+        ),
+        ChangePropertyIsATypeOf(
+            name_space=REVIEW,
             class_id="REVIEW_LOG",
             property_id="reviews",
+            from_name_space=PROV_S,
             from_property_id="wasDerivedFrom",
+            to_name_space=PROV_S,
             to_property_id="wasImpactedBy",
+        ),
+        ChangeCardinality(
+            name_space=REVIEW,
+            class_id="REVIEW",
+            property_id="author",
+            to_cardinality=SingleValue(),
         ),
     ],
 )

--- a/migration/rack/commits/commit4f9fce78e36a6dc75f1702ab50da6a4ac801dd5e.py
+++ b/migration/rack/commits/commit4f9fce78e36a6dc75f1702ab50da6a4ac801dd5e.py
@@ -14,6 +14,6 @@ from ontology_changes import Commit
 commit = Commit(
     number="4f9fce78e36a6dc75f1702ab50da6a4ac801dd5e",
     changes=[
-        # nothing relevant
+        # note change only
     ],
 )

--- a/migration/rack/commits/commit581f1820855eee2445d9e8bfdbb639e169e9391e.py
+++ b/migration/rack/commits/commit581f1820855eee2445d9e8bfdbb639e169e9391e.py
@@ -9,13 +9,24 @@
 # material are those of the author(s) and do not necessarily reflect the views
 # of the Defense Advanced Research Projects Agency (DARPA).
 
-# from migration_helpers.name_space import rack
-from ontology_changes import Commit
+from migration_helpers.name_space import rack
+from ontology_changes import ChangeClassIsATypeOf, Commit
+
+DOCUMENT = rack("DOCUMENT")
+PROV_S = rack("PROV-S")
+REVIEW = rack("REVIEW")
 
 commit = Commit(
     number="581f1820855eee2445d9e8bfdbb639e169e9391e",
     changes=[
         # REVIEW.sadl
-        # ChangeClassIsATypeOf
+        ChangeClassIsATypeOf(
+            name_space=REVIEW,
+            class_id="REVIEW_LOG",
+            from_name_space=DOCUMENT,
+            from_class_id="REPORT",
+            to_name_space=PROV_S,
+            to_class_id="ENTITY",
+        ),
     ],
 )

--- a/migration/rack/commits/commit643839e7d8036731ba1da767942c8e74c2876e2e.py
+++ b/migration/rack/commits/commit643839e7d8036731ba1da767942c8e74c2876e2e.py
@@ -11,10 +11,13 @@
 
 from migration_helpers.name_space import rack
 from ontology_changes import (
-    ChangeIsATypeOf,
+    AtMost,
+    ChangeCardinality,
+    ChangePropertyIsATypeOf,
     ChangePropertyRange,
     Commit,
     RenameProperty,
+    SingleValue,
 )
 
 FILE = rack("FILE")
@@ -25,6 +28,12 @@ commit = Commit(
     number="643839e7d8036731ba1da767942c8e74c2876e2e",
     changes=[
         # FILE.sadl
+        ChangeCardinality(
+            name_space=FILE,
+            class_id="FILE",
+            property_id="filename",
+            to_cardinality=SingleValue(),
+        ),
         RenameProperty(
             from_name_space=FILE,
             from_class="FILE",
@@ -33,11 +42,20 @@ commit = Commit(
             to_class="FILE",
             to_name="definedIn",
         ),
-        ChangeIsATypeOf(
+        ChangePropertyIsATypeOf(
+            name_space=FILE,
             class_id="FILE",
             property_id="satisfies",
+            from_name_space=PROV_S,
             from_property_id="wasDerivedFrom",
+            to_name_space=PROV_S,
             to_property_id="wasImpactedBy",
+        ),
+        ChangeCardinality(
+            name_space=FILE,
+            class_id="FILE",
+            property_id="createBy",
+            to_cardinality=AtMost(1),
         ),
         # FILE.sadl / SOFTWARE.sadl
         RenameProperty(

--- a/migration/rack/commits/commit833ef18f5024fee255f77887de2c8e9bc136e56d.py
+++ b/migration/rack/commits/commit833ef18f5024fee255f77887de2c8e9bc136e56d.py
@@ -10,13 +10,68 @@
 # of the Defense Advanced Research Projects Agency (DARPA).
 
 from migration_helpers.name_space import rack
-from ontology_changes import Commit, RenameProperty
+from ontology_changes import AtMost, ChangeCardinality, Commit, RenameProperty
 
 PROV_S = rack("PROV-S")
 
 commit = Commit(
     number="833ef18f5024fee255f77887de2c8e9bc136e56d",
     changes=[
+        # PROV-S.sadl
+        ChangeCardinality(
+            name_space=PROV_S,
+            class_id="THING",
+            property_id="identifier",
+            to_cardinality=AtMost(1),
+        ),
+        ChangeCardinality(
+            name_space=PROV_S,
+            class_id="THING",
+            property_id="title",
+            to_cardinality=AtMost(1),
+        ),
+        ChangeCardinality(
+            name_space=PROV_S,
+            class_id="THING",
+            property_id="description",
+            to_cardinality=AtMost(1),
+        ),
+        ChangeCardinality(
+            name_space=PROV_S,
+            class_id="THING",
+            property_id="dataInsertedBy",
+            to_cardinality=AtMost(1),
+        ),
+        ChangeCardinality(
+            name_space=PROV_S,
+            class_id="ENTITY",
+            property_id="wasGeneratedBy",
+            to_cardinality=AtMost(1),
+        ),
+        ChangeCardinality(
+            name_space=PROV_S,
+            class_id="ENTITY",
+            property_id="generatedAtTime",
+            to_cardinality=AtMost(1),
+        ),
+        ChangeCardinality(
+            name_space=PROV_S,
+            class_id="ENTITY",
+            property_id="invalidatedAtTime",
+            to_cardinality=AtMost(1),
+        ),
+        ChangeCardinality(
+            name_space=PROV_S,
+            class_id="ACTIVITY",
+            property_id="startedAtTime",
+            to_cardinality=AtMost(1),
+        ),
+        ChangeCardinality(
+            name_space=PROV_S,
+            class_id="ACTIVITY",
+            property_id="endedAtTime",
+            to_cardinality=AtMost(1),
+        ),
         RenameProperty(
             from_name_space=PROV_S,
             from_class="AGENT",

--- a/migration/rack/commits/commit90f2d4f55668786ffa01bba2a646c7468849c97d.py
+++ b/migration/rack/commits/commit90f2d4f55668786ffa01bba2a646c7468849c97d.py
@@ -10,9 +10,17 @@
 # of the Defense Advanced Research Projects Agency (DARPA).
 
 from migration_helpers.name_space import rack
-from ontology_changes import Commit, ChangeIsATypeOf, RenameClass
+from ontology_changes import (
+    AtMost,
+    Commit,
+    ChangeCardinality,
+    ChangePropertyIsATypeOf,
+    RenameClass,
+    SingleValue,
+)
 
 ANALYSIS = rack("ANALYSIS")
+PROV_S = rack("PROV-S")
 
 commit = Commit(
     number="90f2d4f55668786ffa01bba2a646c7468849c97d",
@@ -24,11 +32,32 @@ commit = Commit(
             to_name_space=ANALYSIS,
             to_name="ANALYSIS_OUTPUT",
         ),
-        ChangeIsATypeOf(
+        ChangeCardinality(
+            name_space=ANALYSIS,
+            class_id="ANALYSIS_OUTPUT",
+            property_id="result",
+            to_cardinality=AtMost(1),
+        ),
+        ChangePropertyIsATypeOf(
+            name_space=ANALYSIS,
             class_id="ANALYSIS_OUTPUT",
             property_id="analyzes",
+            from_name_space=PROV_S,
             from_property_id="wasDerivedFrom",
+            to_name_space=PROV_S,
             to_property_id="wasImpactedBy",
+        ),
+        ChangeCardinality(
+            name_space=ANALYSIS,
+            class_id="ANALYSIS_ANNOTATION",
+            property_id="fromReport",
+            to_cardinality=SingleValue(),
+        ),
+        ChangeCardinality(
+            name_space=ANALYSIS,
+            class_id="ANALYSIS_ANNOTATION",
+            property_id="annotationType",
+            to_cardinality=SingleValue(),
         ),
     ],
 )

--- a/migration/rack/commits/commit9af9030fe191d564875c067f6e0319ca6b52b798.py
+++ b/migration/rack/commits/commit9af9030fe191d564875c067f6e0319ca6b52b798.py
@@ -10,7 +10,14 @@
 # of the Defense Advanced Research Projects Agency (DARPA).
 
 from migration_helpers.name_space import rack
-from ontology_changes import Commit, RenameProperty
+from ontology_changes import (
+    AtMost,
+    ChangeCardinality,
+    Commit,
+    CreateProperty,
+    DeleteClass,
+    RenameProperty,
+)
 
 AGENTS = rack("AGENTS")
 PROV_S = rack("PROV-S")
@@ -19,6 +26,12 @@ commit = Commit(
     number="9af9030fe191d564875c067f6e0319ca6b52b798",
     changes=[
         # AGENTS.sadl
+        ChangeCardinality(
+            name_space=AGENTS,
+            class_id="PERSON",
+            property_id="employedBy",
+            to_cardinality=AtMost(1),
+        ),
         RenameProperty(
             from_name_space=AGENTS,
             from_class="ORGANIZATION",
@@ -34,6 +47,21 @@ commit = Commit(
             to_name_space=PROV_S,
             to_class="AGENT",
             to_name="agentName",
+        ),
+        DeleteClass(
+            name_space=AGENTS,
+            class_id="SOFTWAREAGENT",
+        ),
+        CreateProperty(
+            name_space=AGENTS,
+            class_id="TOOL",
+            property_id="toolVersion",
+        ),
+        # PROV-S.sadl
+        CreateProperty(
+            name_space=PROV_S,
+            class_id="AGENT",
+            property_id="agentName",
         ),
     ],
 )

--- a/migration/rack/commits/commitae0a7660b0afdd53ff334577fbdea7749abe6cf6.py
+++ b/migration/rack/commits/commitae0a7660b0afdd53ff334577fbdea7749abe6cf6.py
@@ -9,13 +9,24 @@
 # material are those of the author(s) and do not necessarily reflect the views
 # of the Defense Advanced Research Projects Agency (DARPA).
 
-from ontology_changes import Commit
+from migration_helpers.name_space import rack
+from ontology_changes import Commit, CreateProperty
+
+PROV_S = rack("PROV-S")
 
 commit = Commit(
     number="ae0a7660b0afdd53ff334577fbdea7749abe6cf6",
     changes=[
         # PROV-S.sadl
-        # AddedProperty ENTITY wasRevisionOf
-        # AddedProperty ENTITY wasImpactedBy
+        CreateProperty(
+            name_space=PROV_S,
+            class_id="ENTITY",
+            property_id="wasRevisionOf",
+        ),
+        CreateProperty(
+            name_space=PROV_S,
+            class_id="ENTITY",
+            property_id="wasImpactedBy",
+        ),
     ],
 )

--- a/migration/rack/commits/commitb25d07626e4693cd370a2070e17f6baa825a1d43.py
+++ b/migration/rack/commits/commitb25d07626e4693cd370a2070e17f6baa825a1d43.py
@@ -10,15 +10,19 @@
 # of the Defense Advanced Research Projects Agency (DARPA).
 
 from migration_helpers.name_space import rack
-from ontology_changes import Commit, DeleteProperty
+from ontology_changes import AddClass, Commit, DeleteProperty
 
+MODEL = rack("MODEL")
 REQUIREMENTS = rack("REQUIREMENTS")
 
 commit = Commit(
     number="b25d07626e4693cd370a2070e17f6baa825a1d43",
     changes=[
         # MODEL.sadl
-        # AddedClass MODEL
+        AddClass(
+            name_space=MODEL,
+            class_id="MODEL",
+        ),
         # REQUIREMENTS.sadl
         DeleteProperty(name_space=REQUIREMENTS, property_id="givenText"),
         DeleteProperty(name_space=REQUIREMENTS, property_id="ifText"),

--- a/migration/rack/commits/commitb721c16f0f7420a8ccd92bda0d98a96c16dc62b8.py
+++ b/migration/rack/commits/commitb721c16f0f7420a8ccd92bda0d98a96c16dc62b8.py
@@ -9,11 +9,19 @@
 # material are those of the author(s) and do not necessarily reflect the views
 # of the Defense Advanced Research Projects Agency (DARPA).
 
-from ontology_changes import Commit
+from migration_helpers.name_space import rack
+from ontology_changes import ChangeCardinality, Commit, Unconstrained
+
+REVIEW = rack("REVIEW")
 
 commit = Commit(
     number="b721c16f0f7420a8ccd92bda0d98a96c16dc62b8",
     changes=[
-        # nothing relevant
+        ChangeCardinality(
+            name_space=REVIEW,
+            class_id="REVIEW",
+            property_id="author",
+            to_cardinality=Unconstrained(),
+        ),
     ],
 )

--- a/migration/rack/commits/commitbdfef3d7ea9b3c9fc085defa8e26256f646097d9.py
+++ b/migration/rack/commits/commitbdfef3d7ea9b3c9fc085defa8e26256f646097d9.py
@@ -11,12 +11,17 @@
 
 from migration_helpers.name_space import rack
 from ontology_changes import (
-    Commit,
-    ChangeIsATypeOf,
+    AddPropertyIsATypeOf,
+    AtMost,
+    ChangeCardinality,
+    ChangePropertyIsATypeOf,
     ChangePropertyRange,
+    Commit,
+    CreateProperty,
     DeleteProperty,
     RenameClass,
     RenameProperty,
+    RemoveIsATypeOf,
 )
 
 PROV_S = rack("PROV-S")
@@ -27,16 +32,22 @@ commit = Commit(
     number="bdfef3d7ea9b3c9fc085defa8e26256f646097d9",
     changes=[
         # SOFTWARE.sadl
-        ChangeIsATypeOf(
+        ChangePropertyIsATypeOf(
+            name_space=SOFTWARE,
             class_id="COMPILE",
             property_id="compiledBy",
+            from_name_space=PROV_S,
             from_property_id="used",
+            to_name_space=PROV_S,
             to_property_id="wasAssociatedWith",
         ),
-        ChangeIsATypeOf(
+        ChangePropertyIsATypeOf(
+            name_space=SOFTWARE,
             class_id="PACKAGE",
             property_id="packagedBy",
+            from_name_space=PROV_S,
             from_property_id="used",
+            to_name_space=PROV_S,
             to_property_id="wasAssociatedWith",
         ),
         ChangePropertyRange(
@@ -88,25 +99,89 @@ commit = Commit(
             property_id="controlFlowsToConditionally",
         ),
         # SYSTEM.sadl
-        # RemoveIsATypeOf SYSTEM partOf
-        # RemoveIsATypeOf SYSTEM provides
-        # RemoveIsATypeOf SYSTEM requires
-        ChangeIsATypeOf(
+        RemoveIsATypeOf(
+            name_space=SYSTEM,
+            class_id="SYSTEM",
+            property_id="partOf",
+            range_id="wasDerivedFrom",
+        ),
+        ChangeCardinality(
+            name_space=SYSTEM,
+            class_id="SYSTEM",
+            property_id="producedBy",
+            to_cardinality=AtMost(1),
+        ),
+        RemoveIsATypeOf(
+            name_space=SYSTEM,
+            class_id="SYSTEM",
+            property_id="provides",
+            range_id="wasDerivedFrom",
+        ),
+        RemoveIsATypeOf(
+            name_space=SYSTEM,
+            class_id="SYSTEM",
+            property_id="requires",
+            range_id="wasDerivedFrom",
+        ),
+        ChangePropertyIsATypeOf(
+            name_space=SYSTEM,
             class_id="SYSTEM",
             property_id="function",
+            from_name_space=PROV_S,
             from_property_id="wasDerivedFrom",
+            to_name_space=PROV_S,
             to_property_id="wasImpactedBy",
         ),
-        # AddedProperty commodity
-        ChangeIsATypeOf(
+        CreateProperty(
+            name_space=SYSTEM,
+            class_id="INTERFACE",
+            property_id="commodity",
+        ),
+        ChangePropertyIsATypeOf(
+            name_space=SYSTEM,
             class_id="INTERFACE",
             property_id="source",
+            from_name_space=PROV_S,
             from_property_id="wasDerivedFrom",
+            to_name_space=PROV_S,
             to_property_id="wasImpactedBy",
         ),
-        # RemoveIsATypeOf INTERFACE identifiedBy
-        # AddIsATypeOf SYSTEM_DEVELOPMENT developedBy
-        # RemoveIsATypeOf FUNCTION parentFunction
+        ChangePropertyRange(
+            prop_name_space=SYSTEM,
+            prop_name="destination",
+            from_name_space=PROV_S,
+            from_range="ENTITY",
+            to_name_space=SYSTEM,
+            to_range="SYSTEM",
+        ),
+        ChangePropertyIsATypeOf(
+            name_space=SYSTEM,
+            class_id="INTERFACE",
+            property_id="destination",
+            from_name_space=PROV_S,
+            from_property_id="wasDerivedFrom",
+            to_name_space=PROV_S,
+            to_property_id="wasImpactedBy",
+        ),
+        RemoveIsATypeOf(
+            name_space=SYSTEM,
+            class_id="INTERFACE",
+            property_id="identifiedBy",
+            range_id="wasGeneratedBy",
+        ),
+        AddPropertyIsATypeOf(
+            name_space=SYSTEM,
+            class_id="SYSTEM_DEVELOPMENT",
+            property_id="developedBy",
+            range_name_space=PROV_S,
+            range="wasAssociatedWith",
+        ),
+        RemoveIsATypeOf(
+            name_space=SYSTEM,
+            class_id="FUNCTION",
+            property_id="parentFunction",
+            range_id="wasDerivedFrom",
+        ),
         DeleteProperty(
             name_space=SYSTEM,
             property_id="envConstraint",

--- a/migration/rack/commits/commitc6692fed3e150e7df53d4a2a8f8c84f760087420.py
+++ b/migration/rack/commits/commitc6692fed3e150e7df53d4a2a8f8c84f760087420.py
@@ -14,6 +14,6 @@ from ontology_changes import Commit
 commit = Commit(
     number="c6692fed3e150e7df53d4a2a8f8c84f760087420",
     changes=[
-        # nothing relevant
+        # makes domain and range more explicit, don't think it changes?
     ],
 )

--- a/migration/rack/commits/commitd48e208669c589d070c7c5fb7e3129ababbb9193.py
+++ b/migration/rack/commits/commitd48e208669c589d070c7c5fb7e3129ababbb9193.py
@@ -14,6 +14,6 @@ from ontology_changes import Commit
 commit = Commit(
     number="d48e208669c589d070c7c5fb7e3129ababbb9193",
     changes=[
-        # nothing relevant
+        # note change only
     ],
 )

--- a/migration/rack/commits/commitd8271d216704351cf0007a04abac47f4abc993ad.py
+++ b/migration/rack/commits/commitd8271d216704351cf0007a04abac47f4abc993ad.py
@@ -9,41 +9,89 @@
 # material are those of the author(s) and do not necessarily reflect the views
 # of the Defense Advanced Research Projects Agency (DARPA).
 
-# from migration_helpers.name_space import rack
-from ontology_changes import Commit, ChangeIsATypeOf
+from migration_helpers.name_space import rack
+from ontology_changes import AtMost, ChangeCardinality, Commit, ChangePropertyIsATypeOf, SingleValue
+
+PROV_S = rack("PROV-S")
+REQUIREMENTS = rack("REQUIREMENTS")
 
 commit = Commit(
     number="d8271d216704351cf0007a04abac47f4abc993ad",
     changes=[
         # REQUIREMENTS.sadl
-        ChangeIsATypeOf(
+        ChangeCardinality(
+            name_space=REQUIREMENTS,
+            class_id="REQUIREMENT",
+            property_id="text",
+            to_cardinality=SingleValue(),
+        ),
+        ChangeCardinality(
+            name_space=REQUIREMENTS,
+            class_id="REQUIREMENT",
+            property_id="givenText",
+            to_cardinality=AtMost(1),
+        ),
+        ChangeCardinality(
+            name_space=REQUIREMENTS,
+            class_id="REQUIREMENT",
+            property_id="ifText",
+            to_cardinality=AtMost(1),
+        ),
+        ChangeCardinality(
+            name_space=REQUIREMENTS,
+            class_id="REQUIREMENT",
+            property_id="thenText",
+            to_cardinality=AtMost(1),
+        ),
+        ChangeCardinality(
+            name_space=REQUIREMENTS,
+            class_id="DATA_DICTIONARY_TERM",
+            property_id="text",
+            to_cardinality=AtMost(1),
+        ),
+        ChangePropertyIsATypeOf(
+            name_space=REQUIREMENTS,
             class_id="REQUIREMENT",
             property_id="governs",
+            from_name_space=PROV_S,
             from_property_id="wasDerivedFrom",
+            to_name_space=PROV_S,
             to_property_id="wasImpactedBy",
         ),
-        ChangeIsATypeOf(
+        ChangePropertyIsATypeOf(
+            name_space=REQUIREMENTS,
             class_id="REQUIREMENT",
             property_id="satisfies",
+            from_name_space=PROV_S,
             from_property_id="wasDerivedFrom",
+            to_name_space=PROV_S,
             to_property_id="wasImpactedBy",
         ),
-        ChangeIsATypeOf(
+        ChangePropertyIsATypeOf(
+            name_space=REQUIREMENTS,
             class_id="REQUIREMENT",
             property_id="mitigates",
+            from_name_space=PROV_S,
             from_property_id="wasDerivedFrom",
+            to_name_space=PROV_S,
             to_property_id="wasImpactedBy",
         ),
-        ChangeIsATypeOf(
+        ChangePropertyIsATypeOf(
+            name_space=REQUIREMENTS,
             class_id="DATA_DICTIONARY_TERM",
             property_id="providedBy",
+            from_name_space=PROV_S,
             from_property_id="wasDerivedFrom",
+            to_name_space=PROV_S,
             to_property_id="wasImpactedBy",
         ),
-        ChangeIsATypeOf(
+        ChangePropertyIsATypeOf(
+            name_space=REQUIREMENTS,
             class_id="DATA_DICTIONARY_TERM",
             property_id="consumedBy",
+            from_name_space=PROV_S,
             from_property_id="wasDerivedFrom",
+            to_name_space=PROV_S,
             to_property_id="wasImpactedBy",
         ),
     ],

--- a/migration/rack/commits/commitfa603aad886439eb6a94e44e2c6f4851af16c9a3.py
+++ b/migration/rack/commits/commitfa603aad886439eb6a94e44e2c6f4851af16c9a3.py
@@ -9,18 +9,29 @@
 # material are those of the author(s) and do not necessarily reflect the views
 # of the Defense Advanced Research Projects Agency (DARPA).
 
-from ontology_changes import Commit, ChangeIsATypeOf
+from migration_helpers.name_space import rack
+from ontology_changes import Commit, ChangePropertyIsATypeOf, DeleteClass
+
+CONFIDENCE = rack("CONFIDENCE")
+PROV_S = rack("PROV-S")
 
 commit = Commit(
     number="fa603aad886439eb6a94e44e2c6f4851af16c9a3",
     changes=[
         # CONFIDENCE.sadl
-        ChangeIsATypeOf(
+        ChangePropertyIsATypeOf(
+            name_space=CONFIDENCE,
             class_id="CONFIDENCE_ASSESSMENT",
             property_id="assesses",
+            from_name_space=PROV_S,
             from_property_id="wasDerivedFrom",
+            to_name_space=PROV_S,
             to_property_id="wasImpactedBy",
         ),
-        # RemoveClass Probability
+        DeleteClass(
+            name_space=CONFIDENCE,
+            class_id="Probability",
+        ),
+        # Technically the ranges of belief, disbelief, uncertainty have changed.
     ],
 )

--- a/migration/rack/commits/commitff31a28051a5e348fd2474fce5360195999ddb3a.py
+++ b/migration/rack/commits/commitff31a28051a5e348fd2474fce5360195999ddb3a.py
@@ -9,11 +9,31 @@
 # material are those of the author(s) and do not necessarily reflect the views
 # of the Defense Advanced Research Projects Agency (DARPA).
 
-from ontology_changes import Commit
+from migration_helpers.name_space import rack
+from ontology_changes import ChangeCardinality, Commit, Unconstrained
+
+REQUIREMENTS = rack("REQUIREMENTS")
 
 commit = Commit(
     number="ff31a28051a5e348fd2474fce5360195999ddb3a",
     changes=[
-        # nothing relevant
+        ChangeCardinality(
+            name_space=REQUIREMENTS,
+            class_id="REQUIREMENT",
+            property_id="givenText",
+            to_cardinality=Unconstrained(),
+        ),
+        ChangeCardinality(
+            name_space=REQUIREMENTS,
+            class_id="REQUIREMENT",
+            property_id="ifText",
+            to_cardinality=Unconstrained(),
+        ),
+        ChangeCardinality(
+            name_space=REQUIREMENTS,
+            class_id="REQUIREMENT",
+            property_id="thenText",
+            to_cardinality=Unconstrained(),
+        ),
     ],
 )


### PR DESCRIPTION
We were not initially tracking all types of changes that were not relevant to
the migration process.  For the sake of generating exhaustive change logs, we
now track many more changes.