### PR TITLE
query: added Boeing data validation query nodegroup

### DIFF
--- a/nodegroups/queries/query dataVal INTERFACE without destination SYSTEM.json
+++ b/nodegroups/queries/query dataVal INTERFACE without destination SYSTEM.json
@@ -1,0 +1,113 @@
+{
+	"version": 3,
+	"sparqlConn": {
+		"name": "RACK",
+		"domain": "",
+		"enableOwlImports": false,
+		"model": [
+			{
+				"type": "fuseki",
+				"url": "http://localhost:3030/RACK",
+				"graph": "http://rack001/model"
+			}
+		],
+		"data": [
+			{
+				"type": "fuseki",
+				"url": "http://localhost:3030/RACK",
+				"graph": "http://rack001/data"
+			}
+		]
+	},
+	"sNodeGroup": {
+		"version": 12,
+		"limit": 0,
+		"offset": 0,
+		"sNodeList": [
+			{
+				"propList": [],
+				"nodeList": [],
+				"NodeName": "SYSTEM",
+				"fullURIName": "http://arcos.rack/SYSTEM#SYSTEM",
+				"SparqlID": "?SYSTEM",
+				"isReturned": false,
+				"isRuntimeConstrained": false,
+				"valueConstraint": "",
+				"instanceValue": null,
+				"deletionMode": "NO_DELETE"
+			},
+			{
+				"propList": [
+					{
+						"KeyName": "identifier",
+						"ValueType": "string",
+						"relationship": "http://www.w3.org/2001/XMLSchema#string",
+						"UriRelationship": "http://arcos.rack/PROV-S#identifier",
+						"Constraints": "",
+						"SparqlID": "?identifier",
+						"isReturned": true,
+						"optMinus": 0,
+						"isRuntimeConstrained": false,
+						"instanceValues": [],
+						"isMarkedForDeletion": false
+					}
+				],
+				"nodeList": [
+					{
+						"SnodeSparqlIDs": [
+							"?SYSTEM"
+						],
+						"OptionalMinus": [
+							2
+						],
+						"Qualifiers": [
+							""
+						],
+						"DeletionMarkers": [
+							false
+						],
+						"KeyName": "destination",
+						"ValueType": "SYSTEM",
+						"UriValueType": "http://arcos.rack/SYSTEM#SYSTEM",
+						"ConnectBy": "destination",
+						"Connected": true,
+						"UriConnectBy": "http://arcos.rack/SYSTEM#destination"
+					}
+				],
+				"NodeName": "INTERFACE",
+				"fullURIName": "http://arcos.rack/SYSTEM#INTERFACE",
+				"SparqlID": "?INTERFACE",
+				"isReturned": false,
+				"isRuntimeConstrained": false,
+				"valueConstraint": "",
+				"instanceValue": null,
+				"deletionMode": "NO_DELETE"
+			}
+		],
+		"orderBy": [],
+		"unionHash": {}
+	},
+	"importSpec": {
+		"version": "1",
+		"baseURI": "",
+		"columns": [],
+		"dataValidator": [],
+		"texts": [],
+		"transforms": [],
+		"nodes": [
+			{
+				"sparqlID": "?INTERFACE",
+				"type": "http://arcos.rack/SYSTEM#INTERFACE",
+				"mapping": [],
+				"props": []
+			},
+			{
+				"sparqlID": "?SYSTEM",
+				"type": "http://arcos.rack/SYSTEM#SYSTEM",
+				"mapping": [],
+				"props": []
+			}
+		]
+	},
+	"plotSpecs": null
+}

--- a/nodegroups/queries/query dataVal INTERFACE without source SYSTEM.json
+++ b/nodegroups/queries/query dataVal INTERFACE without source SYSTEM.json
@@ -1,0 +1,113 @@
+{
+	"version": 3,
+	"sparqlConn": {
+		"name": "RACK",
+		"domain": "",
+		"enableOwlImports": false,
+		"model": [
+			{
+				"type": "fuseki",
+				"url": "http://localhost:3030/RACK",
+				"graph": "http://rack001/model"
+			}
+		],
+		"data": [
+			{
+				"type": "fuseki",
+				"url": "http://localhost:3030/RACK",
+				"graph": "http://rack001/data"
+			}
+		]
+	},
+	"sNodeGroup": {
+		"version": 12,
+		"limit": 0,
+		"offset": 0,
+		"sNodeList": [
+			{
+				"propList": [],
+				"nodeList": [],
+				"NodeName": "SYSTEM",
+				"fullURIName": "http://arcos.rack/SYSTEM#SYSTEM",
+				"SparqlID": "?SYSTEM",
+				"isReturned": false,
+				"isRuntimeConstrained": false,
+				"valueConstraint": "",
+				"instanceValue": null,
+				"deletionMode": "NO_DELETE"
+			},
+			{
+				"propList": [
+					{
+						"KeyName": "identifier",
+						"ValueType": "string",
+						"relationship": "http://www.w3.org/2001/XMLSchema#string",
+						"UriRelationship": "http://arcos.rack/PROV-S#identifier",
+						"Constraints": "",
+						"SparqlID": "?identifier",
+						"isReturned": true,
+						"optMinus": 0,
+						"isRuntimeConstrained": false,
+						"instanceValues": [],
+						"isMarkedForDeletion": false
+					}
+				],
+				"nodeList": [
+					{
+						"SnodeSparqlIDs": [
+							"?SYSTEM"
+						],
+						"OptionalMinus": [
+							2
+						],
+						"Qualifiers": [
+							""
+						],
+						"DeletionMarkers": [
+							false
+						],
+						"KeyName": "source",
+						"ValueType": "SYSTEM",
+						"UriValueType": "http://arcos.rack/SYSTEM#SYSTEM",
+						"ConnectBy": "source",
+						"Connected": true,
+						"UriConnectBy": "http://arcos.rack/SYSTEM#source"
+					}
+				],
+				"NodeName": "INTERFACE",
+				"fullURIName": "http://arcos.rack/SYSTEM#INTERFACE",
+				"SparqlID": "?INTERFACE",
+				"isReturned": false,
+				"isRuntimeConstrained": false,
+				"valueConstraint": "",
+				"instanceValue": null,
+				"deletionMode": "NO_DELETE"
+			}
+		],
+		"orderBy": [],
+		"unionHash": {}
+	},
+	"importSpec": {
+		"version": "1",
+		"baseURI": "",
+		"columns": [],
+		"dataValidator": [],
+		"texts": [],
+		"transforms": [],
+		"nodes": [
+			{
+				"sparqlID": "?INTERFACE",
+				"type": "http://arcos.rack/SYSTEM#INTERFACE",
+				"mapping": [],
+				"props": []
+			},
+			{
+				"sparqlID": "?SYSTEM",
+				"type": "http://arcos.rack/SYSTEM#SYSTEM",
+				"mapping": [],
+				"props": []
+			}
+		]
+	},
+	"plotSpecs": null
+}

--- a/nodegroups/queries/query dataVal SBVT_Result without confirms_SBVT_Test.json
+++ b/nodegroups/queries/query dataVal SBVT_Result without confirms_SBVT_Test.json
@@ -1,0 +1,113 @@
+{
+	"version": 3,
+	"sparqlConn": {
+		"name": "RACK",
+		"domain": "",
+		"enableOwlImports": false,
+		"model": [
+			{
+				"type": "fuseki",
+				"url": "http://localhost:3030/RACK",
+				"graph": "http://rack001/model"
+			}
+		],
+		"data": [
+			{
+				"type": "fuseki",
+				"url": "http://localhost:3030/RACK",
+				"graph": "http://rack001/data"
+			}
+		]
+	},
+	"sNodeGroup": {
+		"version": 12,
+		"limit": 0,
+		"offset": 0,
+		"sNodeList": [
+			{
+				"propList": [],
+				"nodeList": [],
+				"NodeName": "SBVT_Test",
+				"fullURIName": "http://arcos.AH-64D/Boeing#SBVT_Test",
+				"SparqlID": "?SBVT_Test",
+				"isReturned": false,
+				"isRuntimeConstrained": false,
+				"valueConstraint": "",
+				"instanceValue": null,
+				"deletionMode": "NO_DELETE"
+			},
+			{
+				"propList": [
+					{
+						"KeyName": "identifier",
+						"ValueType": "string",
+						"relationship": "http://www.w3.org/2001/XMLSchema#string",
+						"UriRelationship": "http://arcos.rack/PROV-S#identifier",
+						"Constraints": "",
+						"SparqlID": "?identifier",
+						"isReturned": true,
+						"optMinus": 0,
+						"isRuntimeConstrained": false,
+						"instanceValues": [],
+						"isMarkedForDeletion": false
+					}
+				],
+				"nodeList": [
+					{
+						"SnodeSparqlIDs": [
+							"?SBVT_Test"
+						],
+						"OptionalMinus": [
+							2
+						],
+						"Qualifiers": [
+							""
+						],
+						"DeletionMarkers": [
+							false
+						],
+						"KeyName": "confirms",
+						"ValueType": "TEST",
+						"UriValueType": "http://arcos.rack/TESTING#TEST",
+						"ConnectBy": "confirms",
+						"Connected": true,
+						"UriConnectBy": "http://arcos.rack/TESTING#confirms"
+					}
+				],
+				"NodeName": "SBVT_Result",
+				"fullURIName": "http://arcos.AH-64D/Boeing#SBVT_Result",
+				"SparqlID": "?SBVT_Result",
+				"isReturned": false,
+				"isRuntimeConstrained": false,
+				"valueConstraint": "",
+				"instanceValue": null,
+				"deletionMode": "NO_DELETE"
+			}
+		],
+		"orderBy": [],
+		"unionHash": {}
+	},
+	"importSpec": {
+		"version": "1",
+		"baseURI": "",
+		"columns": [],
+		"dataValidator": [],
+		"texts": [],
+		"transforms": [],
+		"nodes": [
+			{
+				"sparqlID": "?SBVT_Result",
+				"type": "http://arcos.AH-64D/Boeing#SBVT_Result",
+				"mapping": [],
+				"props": []
+			},
+			{
+				"sparqlID": "?SBVT_Test",
+				"type": "http://arcos.AH-64D/Boeing#SBVT_Test",
+				"mapping": [],
+				"props": []
+			}
+		]
+	},
+	"plotSpecs": null
+}

--- a/nodegroups/queries/query dataVal SBVT_Test without REQUIREMENT.json
+++ b/nodegroups/queries/query dataVal SBVT_Test without REQUIREMENT.json
@@ -1,0 +1,113 @@
+{
+	"version": 3,
+	"sparqlConn": {
+		"name": "RACK",
+		"domain": "",
+		"enableOwlImports": false,
+		"model": [
+			{
+				"type": "fuseki",
+				"url": "http://localhost:3030/RACK",
+				"graph": "http://rack001/model"
+			}
+		],
+		"data": [
+			{
+				"type": "fuseki",
+				"url": "http://localhost:3030/RACK",
+				"graph": "http://rack001/data"
+			}
+		]
+	},
+	"sNodeGroup": {
+		"version": 12,
+		"limit": 0,
+		"offset": 0,
+		"sNodeList": [
+			{
+				"propList": [],
+				"nodeList": [],
+				"NodeName": "REQUIREMENT",
+				"fullURIName": "http://arcos.rack/REQUIREMENTS#REQUIREMENT",
+				"SparqlID": "?REQUIREMENT",
+				"isReturned": false,
+				"isRuntimeConstrained": false,
+				"valueConstraint": "",
+				"instanceValue": null,
+				"deletionMode": "NO_DELETE"
+			},
+			{
+				"propList": [
+					{
+						"KeyName": "identifier",
+						"ValueType": "string",
+						"relationship": "http://www.w3.org/2001/XMLSchema#string",
+						"UriRelationship": "http://arcos.rack/PROV-S#identifier",
+						"Constraints": "",
+						"SparqlID": "?identifier",
+						"isReturned": true,
+						"optMinus": 0,
+						"isRuntimeConstrained": false,
+						"instanceValues": [],
+						"isMarkedForDeletion": false
+					}
+				],
+				"nodeList": [
+					{
+						"SnodeSparqlIDs": [
+							"?REQUIREMENT"
+						],
+						"OptionalMinus": [
+							2
+						],
+						"Qualifiers": [
+							""
+						],
+						"DeletionMarkers": [
+							false
+						],
+						"KeyName": "verifies",
+						"ValueType": "ENTITY",
+						"UriValueType": "http://arcos.rack/PROV-S#ENTITY",
+						"ConnectBy": "verifies",
+						"Connected": true,
+						"UriConnectBy": "http://arcos.rack/TESTING#verifies"
+					}
+				],
+				"NodeName": "SBVT_Test",
+				"fullURIName": "http://arcos.AH-64D/Boeing#SBVT_Test",
+				"SparqlID": "?SBVT_Test",
+				"isReturned": false,
+				"isRuntimeConstrained": false,
+				"valueConstraint": "",
+				"instanceValue": null,
+				"deletionMode": "NO_DELETE"
+			}
+		],
+		"orderBy": [],
+		"unionHash": {}
+	},
+	"importSpec": {
+		"version": "1",
+		"baseURI": "",
+		"columns": [],
+		"dataValidator": [],
+		"texts": [],
+		"transforms": [],
+		"nodes": [
+			{
+				"sparqlID": "?SBVT_Test",
+				"type": "http://arcos.AH-64D/Boeing#SBVT_Test",
+				"mapping": [],
+				"props": []
+			},
+			{
+				"sparqlID": "?REQUIREMENT",
+				"type": "http://arcos.rack/REQUIREMENTS#REQUIREMENT",
+				"mapping": [],
+				"props": []
+			}
+		]
+	},
+	"plotSpecs": null
+}

--- a/nodegroups/queries/query dataVal SRS_Req dataInsertedBy other than SRS Data Ingestion.json
+++ b/nodegroups/queries/query dataVal SRS_Req dataInsertedBy other than SRS Data Ingestion.json
@@ -1,0 +1,129 @@
+{
+	"version": 3,
+	"sparqlConn": {
+		"name": "RACK local fuseki",
+		"domain": "",
+		"enableOwlImports": false,
+		"model": [
+			{
+				"type": "fuseki",
+				"url": "http://localhost:3030/RACK",
+				"graph": "http://rack001/model"
+			}
+		],
+		"data": [
+			{
+				"type": "fuseki",
+				"url": "http://localhost:3030/RACK",
+				"graph": "http://rack001/data"
+			}
+		]
+	},
+	"sNodeGroup": {
+		"version": 12,
+		"limit": 0,
+		"offset": 0,
+		"sNodeList": [
+			{
+				"propList": [
+					{
+						"KeyName": "identifier",
+						"ValueType": "string",
+						"relationship": "http://www.w3.org/2001/XMLSchema#string",
+						"UriRelationship": "http://arcos.rack/PROV-S#identifier",
+						"Constraints": "FILTER (?identifier_ACTIVITY != \"SRS Data Ingestion\")",
+						"SparqlID": "?identifier_0",
+						"isReturned": false,
+						"optMinus": 0,
+						"isRuntimeConstrained": false,
+						"instanceValues": [],
+						"isMarkedForDeletion": false,
+						"binding": "?identifier_ACTIVITY",
+						"isBindingReturned": true
+					}
+				],
+				"nodeList": [],
+				"NodeName": "ACTIVITY",
+				"fullURIName": "http://arcos.rack/PROV-S#ACTIVITY",
+				"SparqlID": "?ACTIVITY",
+				"isReturned": false,
+				"isRuntimeConstrained": false,
+				"valueConstraint": "",
+				"instanceValue": null,
+				"deletionMode": "NO_DELETE"
+			},
+			{
+				"propList": [
+					{
+						"KeyName": "identifier",
+						"ValueType": "string",
+						"relationship": "http://www.w3.org/2001/XMLSchema#string",
+						"UriRelationship": "http://arcos.rack/PROV-S#identifier",
+						"Constraints": "",
+						"SparqlID": "?identifier",
+						"isReturned": true,
+						"optMinus": 0,
+						"isRuntimeConstrained": false,
+						"instanceValues": [],
+						"isMarkedForDeletion": false
+					}
+				],
+				"nodeList": [
+					{
+						"SnodeSparqlIDs": [
+							"?ACTIVITY"
+						],
+						"OptionalMinus": [
+							0
+						],
+						"Qualifiers": [
+							""
+						],
+						"DeletionMarkers": [
+							false
+						],
+						"KeyName": "dataInsertedBy",
+						"ValueType": "ACTIVITY",
+						"UriValueType": "http://arcos.rack/PROV-S#ACTIVITY",
+						"ConnectBy": "dataInsertedBy",
+						"Connected": true,
+						"UriConnectBy": "http://arcos.rack/PROV-S#dataInsertedBy"
+					}
+				],
+				"NodeName": "SRS_Req",
+				"fullURIName": "http://arcos.AH-64D/Boeing#SRS_Req",
+				"SparqlID": "?SRS_Req",
+				"isReturned": false,
+				"isRuntimeConstrained": false,
+				"valueConstraint": "",
+				"instanceValue": null,
+				"deletionMode": "NO_DELETE"
+			}
+		],
+		"orderBy": [],
+		"unionHash": {}
+	},
+	"importSpec": {
+		"version": "1",
+		"baseURI": "",
+		"columns": [],
+		"dataValidator": [],
+		"texts": [],
+		"transforms": [],
+		"nodes": [
+			{
+				"sparqlID": "?SRS_Req",
+				"type": "http://arcos.AH-64D/Boeing#SRS_Req",
+				"mapping": [],
+				"props": []
+			},
+			{
+				"sparqlID": "?ACTIVITY",
+				"type": "http://arcos.rack/PROV-S#ACTIVITY",
+				"mapping": [],
+				"props": []
+			}
+		]
+	},
+	"plotSpecs": []
+}

--- a/nodegroups/queries/query dataVal SRS_Req without CSID_PIDS.json
+++ b/nodegroups/queries/query dataVal SRS_Req without CSID_PIDS.json
@@ -1,0 +1,165 @@
+{
+	"version": 3,
+	"sparqlConn": {
+		"name": "RACK",
+		"domain": "",
+		"enableOwlImports": false,
+		"model": [
+			{
+				"type": "fuseki",
+				"url": "http://localhost:3030/RACK",
+				"graph": "http://rack001/model"
+			}
+		],
+		"data": [
+			{
+				"type": "fuseki",
+				"url": "http://localhost:3030/RACK",
+				"graph": "http://rack001/data"
+			}
+		]
+	},
+	"sNodeGroup": {
+		"version": 12,
+		"limit": 0,
+		"offset": 0,
+		"sNodeList": [
+			{
+				"propList": [
+					{
+						"KeyName": "identifier",
+						"ValueType": "string",
+						"relationship": "http://www.w3.org/2001/XMLSchema#string",
+						"UriRelationship": "http://arcos.rack/PROV-S#identifier",
+						"Constraints": "",
+						"SparqlID": "?identifier_2",
+						"isReturned": true,
+						"optMinus": 0,
+						"isRuntimeConstrained": false,
+						"instanceValues": [],
+						"isMarkedForDeletion": false
+					}
+				],
+				"nodeList": [],
+				"NodeName": "PIDS_Req",
+				"fullURIName": "http://arcos.AH-64D/Boeing#PIDS_Req",
+				"SparqlID": "?PIDS_Req",
+				"isReturned": false,
+				"isRuntimeConstrained": false,
+				"valueConstraint": "",
+				"instanceValue": null,
+				"deletionMode": "NO_DELETE"
+			},
+			{
+				"propList": [
+					{
+						"KeyName": "identifier",
+						"ValueType": "string",
+						"relationship": "http://www.w3.org/2001/XMLSchema#string",
+						"UriRelationship": "http://arcos.rack/PROV-S#identifier",
+						"Constraints": "",
+						"SparqlID": "?identifier_1",
+						"isReturned": false,
+						"optMinus": 0,
+						"isRuntimeConstrained": false,
+						"instanceValues": [],
+						"isMarkedForDeletion": false,
+						"binding": "?identifier_0",
+						"isBindingReturned": true
+					}
+				],
+				"nodeList": [],
+				"NodeName": "CSID_Req",
+				"fullURIName": "http://arcos.AH-64D/Boeing#CSID_Req",
+				"SparqlID": "?CSID_Req",
+				"isReturned": false,
+				"isRuntimeConstrained": false,
+				"valueConstraint": "",
+				"instanceValue": null,
+				"deletionMode": "NO_DELETE"
+			},
+			{
+				"propList": [
+					{
+						"KeyName": "identifier",
+						"ValueType": "string",
+						"relationship": "http://www.w3.org/2001/XMLSchema#string",
+						"UriRelationship": "http://arcos.rack/PROV-S#identifier",
+						"Constraints": "",
+						"SparqlID": "?identifier",
+						"isReturned": true,
+						"optMinus": 0,
+						"isRuntimeConstrained": false,
+						"instanceValues": [],
+						"isMarkedForDeletion": false
+					}
+				],
+				"nodeList": [
+					{
+						"SnodeSparqlIDs": [
+							"?CSID_Req",
+							"?PIDS_Req"
+						],
+						"OptionalMinus": [
+							2,
+							2
+						],
+						"Qualifiers": [
+							"",
+							""
+						],
+						"DeletionMarkers": [
+							false,
+							false
+						],
+						"KeyName": "satisfies",
+						"ValueType": "ENTITY",
+						"UriValueType": "http://arcos.rack/PROV-S#ENTITY",
+						"ConnectBy": "satisfies",
+						"Connected": true,
+						"UriConnectBy": "http://arcos.rack/REQUIREMENTS#satisfies"
+					}
+				],
+				"NodeName": "SRS_Req",
+				"fullURIName": "http://arcos.AH-64D/Boeing#SRS_Req",
+				"SparqlID": "?SRS_Req",
+				"isReturned": false,
+				"isRuntimeConstrained": false,
+				"valueConstraint": "",
+				"instanceValue": null,
+				"deletionMode": "NO_DELETE"
+			}
+		],
+		"orderBy": [],
+		"unionHash": {}
+	},
+	"importSpec": {
+		"version": "1",
+		"baseURI": "",
+		"columns": [],
+		"dataValidator": [],
+		"texts": [],
+		"transforms": [],
+		"nodes": [
+			{
+				"sparqlID": "?SRS_Req",
+				"type": "http://arcos.AH-64D/Boeing#SRS_Req",
+				"mapping": [],
+				"props": []
+			},
+			{
+				"sparqlID": "?CSID_Req",
+				"type": "http://arcos.AH-64D/Boeing#CSID_Req",
+				"mapping": [],
+				"props": []
+			},
+			{
+				"sparqlID": "?PIDS_Req",
+				"type": "http://arcos.AH-64D/Boeing#PIDS_Req",
+				"mapping": [],
+				"props": []
+			}
+		]
+	},
+	"plotSpecs": null
+}

--- a/nodegroups/queries/query dataVal SRS_Req without description.json
+++ b/nodegroups/queries/query dataVal SRS_Req without description.json
@@ -1,0 +1,86 @@
+{
+	"version": 2,
+	"sparqlConn": {
+		"name": "RACK",
+		"domain": "",
+		"enableOwlImports": false,
+		"model": [
+			{
+				"type": "fuseki",
+				"url": "http://localhost:3030/RACK",
+				"graph": "http://rack001/model"
+			}
+		],
+		"data": [
+			{
+				"type": "fuseki",
+				"url": "http://localhost:3030/RACK",
+				"graph": "http://rack001/data"
+			}
+		]
+	},
+	"sNodeGroup": {
+		"version": 12,
+		"limit": 0,
+		"offset": 0,
+		"sNodeList": [
+			{
+				"propList": [
+					{
+						"KeyName": "description",
+						"ValueType": "string",
+						"relationship": "http://www.w3.org/2001/XMLSchema#string",
+						"UriRelationship": "http://arcos.rack/PROV-S#description",
+						"Constraints": "",
+						"SparqlID": "?description",
+						"isReturned": true,
+						"optMinus": 2,
+						"isRuntimeConstrained": false,
+						"instanceValues": [],
+						"isMarkedForDeletion": false
+					},
+					{
+						"KeyName": "identifier",
+						"ValueType": "string",
+						"relationship": "http://www.w3.org/2001/XMLSchema#string",
+						"UriRelationship": "http://arcos.rack/PROV-S#identifier",
+						"Constraints": "",
+						"SparqlID": "?identifier",
+						"isReturned": true,
+						"optMinus": 0,
+						"isRuntimeConstrained": false,
+						"instanceValues": [],
+						"isMarkedForDeletion": false
+					}
+				],
+				"nodeList": [],
+				"NodeName": "SRS_Req",
+				"fullURIName": "http://arcos.AH-64D/Boeing#SRS_Req",
+				"SparqlID": "?SRS_Req",
+				"isReturned": false,
+				"isRuntimeConstrained": false,
+				"valueConstraint": "",
+				"instanceValue": null,
+				"deletionMode": "NO_DELETE"
+			}
+		],
+		"orderBy": [],
+		"unionHash": {}
+	},
+	"importSpec": {
+		"version": "1",
+		"baseURI": "",
+		"columns": [],
+		"dataValidator": [],
+		"texts": [],
+		"transforms": [],
+		"nodes": [
+			{
+				"sparqlID": "?SRS_Req",
+				"type": "http://arcos.AH-64D/Boeing#SRS_Req",
+				"mapping": [],
+				"props": []
+			}
+		]
+	}
+}

--- a/nodegroups/queries/query dataVal SRS_Req without verifies SBVT_Test.json
+++ b/nodegroups/queries/query dataVal SRS_Req without verifies SBVT_Test.json
@@ -1,0 +1,113 @@
+{
+	"version": 3,
+	"sparqlConn": {
+		"name": "RACK",
+		"domain": "",
+		"enableOwlImports": false,
+		"model": [
+			{
+				"type": "fuseki",
+				"url": "http://localhost:3030/RACK",
+				"graph": "http://rack001/model"
+			}
+		],
+		"data": [
+			{
+				"type": "fuseki",
+				"url": "http://localhost:3030/RACK",
+				"graph": "http://rack001/data"
+			}
+		]
+	},
+	"sNodeGroup": {
+		"version": 12,
+		"limit": 0,
+		"offset": 0,
+		"sNodeList": [
+			{
+				"propList": [
+					{
+						"KeyName": "identifier",
+						"ValueType": "string",
+						"relationship": "http://www.w3.org/2001/XMLSchema#string",
+						"UriRelationship": "http://arcos.rack/PROV-S#identifier",
+						"Constraints": "",
+						"SparqlID": "?identifier",
+						"isReturned": true,
+						"optMinus": 0,
+						"isRuntimeConstrained": false,
+						"instanceValues": [],
+						"isMarkedForDeletion": false
+					}
+				],
+				"nodeList": [],
+				"NodeName": "SRS_Req",
+				"fullURIName": "http://arcos.AH-64D/Boeing#SRS_Req",
+				"SparqlID": "?SRS_Req",
+				"isReturned": false,
+				"isRuntimeConstrained": false,
+				"valueConstraint": "",
+				"instanceValue": null,
+				"deletionMode": "NO_DELETE"
+			},
+			{
+				"propList": [],
+				"nodeList": [
+					{
+						"SnodeSparqlIDs": [
+							"?SRS_Req"
+						],
+						"OptionalMinus": [
+							2
+						],
+						"Qualifiers": [
+							""
+						],
+						"DeletionMarkers": [
+							false
+						],
+						"KeyName": "verifies",
+						"ValueType": "ENTITY",
+						"UriValueType": "http://arcos.rack/PROV-S#ENTITY",
+						"ConnectBy": "verifies",
+						"Connected": true,
+						"UriConnectBy": "http://arcos.rack/TESTING#verifies"
+					}
+				],
+				"NodeName": "SBVT_Test",
+				"fullURIName": "http://arcos.AH-64D/Boeing#SBVT_Test",
+				"SparqlID": "?SBVT_Test",
+				"isReturned": false,
+				"isRuntimeConstrained": false,
+				"valueConstraint": "",
+				"instanceValue": null,
+				"deletionMode": "NO_DELETE"
+			}
+		],
+		"orderBy": [],
+		"unionHash": {}
+	},
+	"importSpec": {
+		"version": "1",
+		"baseURI": "",
+		"columns": [],
+		"dataValidator": [],
+		"texts": [],
+		"transforms": [],
+		"nodes": [
+			{
+				"sparqlID": "?SBVT_Test",
+				"type": "http://arcos.AH-64D/Boeing#SBVT_Test",
+				"mapping": [],
+				"props": []
+			},
+			{
+				"sparqlID": "?SRS_Req",
+				"type": "http://arcos.AH-64D/Boeing#SRS_Req",
+				"mapping": [],
+				"props": []
+			}
+		]
+	},
+	"plotSpecs": null
+}

--- a/nodegroups/queries/query dataVal SYSTEM without partOf SYSTEM.json
+++ b/nodegroups/queries/query dataVal SYSTEM without partOf SYSTEM.json
@@ -1,0 +1,113 @@
+{
+	"version": 3,
+	"sparqlConn": {
+		"name": "RACK",
+		"domain": "",
+		"enableOwlImports": false,
+		"model": [
+			{
+				"type": "fuseki",
+				"url": "http://localhost:3030/RACK",
+				"graph": "http://rack001/model"
+			}
+		],
+		"data": [
+			{
+				"type": "fuseki",
+				"url": "http://localhost:3030/RACK",
+				"graph": "http://rack001/data"
+			}
+		]
+	},
+	"sNodeGroup": {
+		"version": 12,
+		"limit": 0,
+		"offset": 0,
+		"sNodeList": [
+			{
+				"propList": [],
+				"nodeList": [],
+				"NodeName": "SYSTEM",
+				"fullURIName": "http://arcos.rack/SYSTEM#SYSTEM",
+				"SparqlID": "?SYSTEM_0",
+				"isReturned": false,
+				"isRuntimeConstrained": false,
+				"valueConstraint": "",
+				"instanceValue": null,
+				"deletionMode": "NO_DELETE"
+			},
+			{
+				"propList": [
+					{
+						"KeyName": "identifier",
+						"ValueType": "string",
+						"relationship": "http://www.w3.org/2001/XMLSchema#string",
+						"UriRelationship": "http://arcos.rack/PROV-S#identifier",
+						"Constraints": "",
+						"SparqlID": "?identifier",
+						"isReturned": true,
+						"optMinus": 0,
+						"isRuntimeConstrained": false,
+						"instanceValues": [],
+						"isMarkedForDeletion": false
+					}
+				],
+				"nodeList": [
+					{
+						"SnodeSparqlIDs": [
+							"?SYSTEM_0"
+						],
+						"OptionalMinus": [
+							2
+						],
+						"Qualifiers": [
+							""
+						],
+						"DeletionMarkers": [
+							false
+						],
+						"KeyName": "partOf",
+						"ValueType": "SYSTEM",
+						"UriValueType": "http://arcos.rack/SYSTEM#SYSTEM",
+						"ConnectBy": "partOf",
+						"Connected": true,
+						"UriConnectBy": "http://arcos.rack/SYSTEM#partOf"
+					}
+				],
+				"NodeName": "SYSTEM",
+				"fullURIName": "http://arcos.rack/SYSTEM#SYSTEM",
+				"SparqlID": "?SYSTEM",
+				"isReturned": false,
+				"isRuntimeConstrained": false,
+				"valueConstraint": "",
+				"instanceValue": null,
+				"deletionMode": "NO_DELETE"
+			}
+		],
+		"orderBy": [],
+		"unionHash": {}
+	},
+	"importSpec": {
+		"version": "1",
+		"baseURI": "",
+		"columns": [],
+		"dataValidator": [],
+		"texts": [],
+		"transforms": [],
+		"nodes": [
+			{
+				"sparqlID": "?SYSTEM",
+				"type": "http://arcos.rack/SYSTEM#SYSTEM",
+				"mapping": [],
+				"props": []
+			},
+			{
+				"sparqlID": "?SYSTEM_0",
+				"type": "http://arcos.rack/SYSTEM#SYSTEM",
+				"mapping": [],
+				"props": []
+			}
+		]
+	},
+	"plotSpecs": null
+}

--- a/nodegroups/queries/query dataVal SubDD_Req without satisfies SRS_Req.json
+++ b/nodegroups/queries/query dataVal SubDD_Req without satisfies SRS_Req.json
@@ -1,0 +1,113 @@
+{
+	"version": 3,
+	"sparqlConn": {
+		"name": "RACK",
+		"domain": "",
+		"enableOwlImports": false,
+		"model": [
+			{
+				"type": "fuseki",
+				"url": "http://localhost:3030/RACK",
+				"graph": "http://rack001/model"
+			}
+		],
+		"data": [
+			{
+				"type": "fuseki",
+				"url": "http://localhost:3030/RACK",
+				"graph": "http://rack001/data"
+			}
+		]
+	},
+	"sNodeGroup": {
+		"version": 12,
+		"limit": 0,
+		"offset": 0,
+		"sNodeList": [
+			{
+				"propList": [],
+				"nodeList": [],
+				"NodeName": "SRS_Req",
+				"fullURIName": "http://arcos.AH-64D/Boeing#SRS_Req",
+				"SparqlID": "?SRS_Req",
+				"isReturned": false,
+				"isRuntimeConstrained": false,
+				"valueConstraint": "",
+				"instanceValue": null,
+				"deletionMode": "NO_DELETE"
+			},
+			{
+				"propList": [
+					{
+						"KeyName": "identifier",
+						"ValueType": "string",
+						"relationship": "http://www.w3.org/2001/XMLSchema#string",
+						"UriRelationship": "http://arcos.rack/PROV-S#identifier",
+						"Constraints": "",
+						"SparqlID": "?identifier",
+						"isReturned": true,
+						"optMinus": 0,
+						"isRuntimeConstrained": false,
+						"instanceValues": [],
+						"isMarkedForDeletion": false
+					}
+				],
+				"nodeList": [
+					{
+						"SnodeSparqlIDs": [
+							"?SRS_Req"
+						],
+						"OptionalMinus": [
+							2
+						],
+						"Qualifiers": [
+							""
+						],
+						"DeletionMarkers": [
+							false
+						],
+						"KeyName": "satisfies",
+						"ValueType": "ENTITY",
+						"UriValueType": "http://arcos.rack/PROV-S#ENTITY",
+						"ConnectBy": "satisfies",
+						"Connected": true,
+						"UriConnectBy": "http://arcos.rack/REQUIREMENTS#satisfies"
+					}
+				],
+				"NodeName": "SubDD_Req",
+				"fullURIName": "http://arcos.AH-64D/Boeing#SubDD_Req",
+				"SparqlID": "?SubDD_Req",
+				"isReturned": false,
+				"isRuntimeConstrained": false,
+				"valueConstraint": "",
+				"instanceValue": null,
+				"deletionMode": "NO_DELETE"
+			}
+		],
+		"orderBy": [],
+		"unionHash": {}
+	},
+	"importSpec": {
+		"version": "1",
+		"baseURI": "",
+		"columns": [],
+		"dataValidator": [],
+		"texts": [],
+		"transforms": [],
+		"nodes": [
+			{
+				"sparqlID": "?SubDD_Req",
+				"type": "http://arcos.AH-64D/Boeing#SubDD_Req",
+				"mapping": [],
+				"props": []
+			},
+			{
+				"sparqlID": "?SRS_Req",
+				"type": "http://arcos.AH-64D/Boeing#SRS_Req",
+				"mapping": [],
+				"props": []
+			}
+		]
+	},
+	"plotSpecs": null
+}

--- a/nodegroups/queries/query dataVal only REQUIREMENT subclasses.json
+++ b/nodegroups/queries/query dataVal only REQUIREMENT subclasses.json
@@ -1,0 +1,74 @@
+{
+	"version": 3,
+	"sparqlConn": {
+		"name": "RACK local fuseki",
+		"domain": "",
+		"enableOwlImports": false,
+		"model": [
+			{
+				"type": "fuseki",
+				"url": "http://localhost:3030/RACK",
+				"graph": "http://rack001/model"
+			}
+		],
+		"data": [
+			{
+				"type": "fuseki",
+				"url": "http://localhost:3030/RACK",
+				"graph": "http://rack001/data"
+			}
+		]
+	},
+	"sNodeGroup": {
+		"version": 12,
+		"limit": 0,
+		"offset": 0,
+		"sNodeList": [
+			{
+				"propList": [
+					{
+						"KeyName": "identifier",
+						"ValueType": "string",
+						"relationship": "http://www.w3.org/2001/XMLSchema#string",
+						"UriRelationship": "http://arcos.rack/PROV-S#identifier",
+						"Constraints": "",
+						"SparqlID": "?identifier",
+						"isReturned": true,
+						"optMinus": 0,
+						"isRuntimeConstrained": false,
+						"instanceValues": [],
+						"isMarkedForDeletion": false
+					}
+				],
+				"nodeList": [],
+				"NodeName": "REQUIREMENT",
+				"fullURIName": "http://arcos.rack/REQUIREMENTS#REQUIREMENT",
+				"SparqlID": "?REQUIREMENT",
+				"isReturned": false,
+				"isRuntimeConstrained": false,
+				"valueConstraint": "?REQUIREMENT a  REQUIREMENTS:REQUIREMENT",
+				"instanceValue": null,
+				"deletionMode": "NO_DELETE"
+			}
+		],
+		"orderBy": [],
+		"unionHash": {}
+	},
+	"importSpec": {
+		"version": "1",
+		"baseURI": "",
+		"columns": [],
+		"dataValidator": [],
+		"texts": [],
+		"transforms": [],
+		"nodes": [
+			{
+				"sparqlID": "?REQUIREMENT",
+				"type": "http://arcos.rack/REQUIREMENTS#REQUIREMENT",
+				"mapping": [],
+				"props": []
+			}
+		]
+	},
+	"plotSpecs": []
+}

--- a/nodegroups/queries/store_data.csv
+++ b/nodegroups/queries/store_data.csv
@@ -17,3 +17,14 @@ query test empty thing,Check for non-SYSTEM typed things with identifer and no o
 query Requirements without passed test,"No Test, or no test result, or failure",200001934,query Requirements without passed test.json
 query Models for Thing,Query that finds all the models and their types given a target THING identifier,em,query Models for Thing.json
 query Get DataInsertedBy From Guid,Query that finds all all dataInsertedBy infromation for a THING selected by guid,dr,GetDataInsertedByFromGuid.json
+query dataVal INTERFACE without destination SYSTEM,number of INTERFACE w/o -destination-> SYSTEM should be 0,rack,query dataVal INTERFACE without destination SYSTEM.json
+query dataVal INTERFACE without source SYSTEM,number of INTERFACE w/o -source-> SYSTEM should be 0,rack,query dataVal INTERFACE without source SYSTEM.json
+query dataVal only REQUIREMENT subclasses,number of REQUIREMENT != {SRS_Req or SubDD or CIDS or PIDS} should be 0,rack,query dataVal only REQUIREMENT subclasses.json
+query dataVal SBVT_Result without confirms_SBVT_Test,number of SBVT_Result w/o -confirms->SBVT_Test should be 0,rack,SBVT_Result without confirms_SBVT_Test.json
+query dataVal SBVT_Test without REQUIREMENT,number of SBVT_Test w/o -verifies->REQUIREMENT should be 0,rack,SBVT_Test without REQUIREMENT.json
+query dataVal SRS_Req dataInsertedBy other than SRS Data Ingestion,number of SRS_Req w/o -dataInsertedBy-> “SRS Data Ingestion” should be 0,rack,query dataVal SRS_Req dataInsertedBy other than SRS Data Ingestion.json
+query dataVal SRS_Req without CSID or PIDS,number of SRS_Req w/o -satisfies-> {CSID or PIDS} should be 0,rack,query dataVal SRS_Req without CSID_PIDS.json
+query dataVal SRS_Req without description,number of SRS_Req w/o descriptions should be 0,rack,query dataVal SRS_Req without description.json
+query dataVal SRS_Req without verifies SBVT_Test,number of SRS_Req w/o <-verifies- SBVT_Test should be 0,rack,query dataVal SRS_Req without verifies SBVT_Test.json
+query dataVal SubDD_Req without satisfies SRS_Req,number of SubDD w/o –satisfies-> SRS_Req should be 0,rack,query dataVal SubDD_Req without satisfies SRS_Req.json
+query dataVal SYSTEM without partOf SYSTEM,number of SYSTEM w/o –partOf-> SYSTEM should be 1,rack,query dataVal SYSTEM without partOf SYSTEM.json

--- a/nodegroups/queries/store_data.csv
+++ b/nodegroups/queries/store_data.csv
@@ -20,8 +20,8 @@ query Get DataInsertedBy From Guid,Query that finds all all dataInsertedBy infro
 query dataVal INTERFACE without destination SYSTEM,number of INTERFACE w/o -destination-> SYSTEM should be 0,rack,query dataVal INTERFACE without destination SYSTEM.json
 query dataVal INTERFACE without source SYSTEM,number of INTERFACE w/o -source-> SYSTEM should be 0,rack,query dataVal INTERFACE without source SYSTEM.json
 query dataVal only REQUIREMENT subclasses,number of REQUIREMENT != {SRS_Req or SubDD or CIDS or PIDS} should be 0,rack,query dataVal only REQUIREMENT subclasses.json
-query dataVal SBVT_Result without confirms_SBVT_Test,number of SBVT_Result w/o -confirms->SBVT_Test should be 0,rack,SBVT_Result without confirms_SBVT_Test.json
-query dataVal SBVT_Test without REQUIREMENT,number of SBVT_Test w/o -verifies->REQUIREMENT should be 0,rack,SBVT_Test without REQUIREMENT.json
+query dataVal SBVT_Result without confirms_SBVT_Test,number of SBVT_Result w/o -confirms->SBVT_Test should be 0,rack,query dataVal SBVT_Result without confirms_SBVT_Test.json
+query dataVal SBVT_Test without REQUIREMENT,number of SBVT_Test w/o -verifies->REQUIREMENT should be 0,rack,query dataVal SBVT_Test without REQUIREMENT.json
 query dataVal SRS_Req dataInsertedBy other than SRS Data Ingestion,number of SRS_Req w/o -dataInsertedBy-> SRS Data Ingestion should be 0,rack,query dataVal SRS_Req dataInsertedBy other than SRS Data Ingestion.json
 query dataVal SRS_Req without CSID or PIDS,number of SRS_Req w/o -satisfies-> {CSID or PIDS} should be 0,rack,query dataVal SRS_Req without CSID_PIDS.json
 query dataVal SRS_Req without description,number of SRS_Req w/o descriptions should be 0,rack,query dataVal SRS_Req without description.json

--- a/nodegroups/queries/store_data.csv
+++ b/nodegroups/queries/store_data.csv
@@ -22,9 +22,9 @@ query dataVal INTERFACE without source SYSTEM,number of INTERFACE w/o -source-> 
 query dataVal only REQUIREMENT subclasses,number of REQUIREMENT != {SRS_Req or SubDD or CIDS or PIDS} should be 0,rack,query dataVal only REQUIREMENT subclasses.json
 query dataVal SBVT_Result without confirms_SBVT_Test,number of SBVT_Result w/o -confirms->SBVT_Test should be 0,rack,SBVT_Result without confirms_SBVT_Test.json
 query dataVal SBVT_Test without REQUIREMENT,number of SBVT_Test w/o -verifies->REQUIREMENT should be 0,rack,SBVT_Test without REQUIREMENT.json
-query dataVal SRS_Req dataInsertedBy other than SRS Data Ingestion,number of SRS_Req w/o -dataInsertedBy-> “SRS Data Ingestion” should be 0,rack,query dataVal SRS_Req dataInsertedBy other than SRS Data Ingestion.json
+query dataVal SRS_Req dataInsertedBy other than SRS Data Ingestion,number of SRS_Req w/o -dataInsertedBy-> SRS Data Ingestion should be 0,rack,query dataVal SRS_Req dataInsertedBy other than SRS Data Ingestion.json
 query dataVal SRS_Req without CSID or PIDS,number of SRS_Req w/o -satisfies-> {CSID or PIDS} should be 0,rack,query dataVal SRS_Req without CSID_PIDS.json
 query dataVal SRS_Req without description,number of SRS_Req w/o descriptions should be 0,rack,query dataVal SRS_Req without description.json
 query dataVal SRS_Req without verifies SBVT_Test,number of SRS_Req w/o <-verifies- SBVT_Test should be 0,rack,query dataVal SRS_Req without verifies SBVT_Test.json
-query dataVal SubDD_Req without satisfies SRS_Req,number of SubDD w/o –satisfies-> SRS_Req should be 0,rack,query dataVal SubDD_Req without satisfies SRS_Req.json
-query dataVal SYSTEM without partOf SYSTEM,number of SYSTEM w/o –partOf-> SYSTEM should be 1,rack,query dataVal SYSTEM without partOf SYSTEM.json
+query dataVal SubDD_Req without satisfies SRS_Req,number of SubDD w/o -satisfies-> SRS_Req should be 0,rack,query dataVal SubDD_Req without satisfies SRS_Req.json
+query dataVal SYSTEM without partOf SYSTEM,number of SYSTEM w/o -partOf-> SYSTEM should be 1,rack,query dataVal SYSTEM without partOf SYSTEM.json


### PR DESCRIPTION
Added query nodegroups for doing validation on Boeing data.