### PR TITLE
changed casing in SACM ontology overlay

### DIFF
--- a/LM-Ontology/OwlModels/SACM.owl
+++ b/LM-Ontology/OwlModels/SACM.owl
@@ -1,6 +1,5 @@
 <rdf:RDF
     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-    xmlns:provs="http://arcos.rack/PROV-S#"
     xmlns:builtinfunctions="http://sadl.org/builtinfunctions#"
     xmlns:owl="http://www.w3.org/2002/07/owl#"
     xmlns:sacm="http://arcos.rack/SACM#"
@@ -16,173 +15,27 @@
     <owl:imports rdf:resource="http://sadl.org/sadlbasemodel"/>
     <rdfs:comment xml:lang="en">This ontology was created from a SADL file 'SACM.sadl' and should not be directly edited.</rdfs:comment>
   </owl:Ontology>
-  <owl:Class rdf:ID="Tagged_Value">
+  <owl:Class rdf:ID="AssertedEvidence">
     <rdfs:subClassOf>
-      <owl:Class rdf:ID="Utility_Element"/>
-    </rdfs:subClassOf>
-  </owl:Class>
-  <owl:Class rdf:ID="Terminology_Asset">
-    <rdfs:subClassOf>
-      <owl:Class rdf:ID="Terminology_Element"/>
+      <owl:Class rdf:ID="AssertedRelationship"/>
     </rdfs:subClassOf>
   </owl:Class>
   <owl:Class rdf:ID="Resource">
     <rdfs:subClassOf>
-      <owl:Class rdf:ID="Artifact_Asset"/>
+      <owl:Class rdf:ID="ArtifactAsset"/>
     </rdfs:subClassOf>
   </owl:Class>
-  <owl:Class rdf:ID="Activity">
+  <owl:Class rdf:ID="UtilityElement">
     <rdfs:subClassOf>
-      <owl:Class rdf:about="#Artifact_Asset"/>
+      <owl:Class rdf:ID="SacmElement"/>
     </rdfs:subClassOf>
   </owl:Class>
-  <owl:Class rdf:ID="Artifact">
+  <owl:Class rdf:ID="TerminologyGroup">
     <rdfs:subClassOf>
-      <owl:Class rdf:about="#Artifact_Asset"/>
+      <owl:Class rdf:ID="TerminologyElement"/>
     </rdfs:subClassOf>
   </owl:Class>
-  <owl:Class rdf:ID="Term">
-    <rdfs:subClassOf>
-      <owl:Class rdf:ID="Expression_Element"/>
-    </rdfs:subClassOf>
-  </owl:Class>
-  <owl:Class rdf:ID="Lang_String">
-    <rdfs:subClassOf>
-      <owl:Restriction>
-        <owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >1</owl:maxCardinality>
-        <owl:onProperty>
-          <owl:DatatypeProperty rdf:ID="contents"/>
-        </owl:onProperty>
-      </owl:Restriction>
-    </rdfs:subClassOf>
-    <rdfs:subClassOf>
-      <owl:Restriction>
-        <owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >1</owl:maxCardinality>
-        <owl:onProperty>
-          <owl:DatatypeProperty rdf:ID="lang"/>
-        </owl:onProperty>
-      </owl:Restriction>
-    </rdfs:subClassOf>
-    <rdfs:subClassOf>
-      <owl:Class rdf:ID="Element"/>
-    </rdfs:subClassOf>
-  </owl:Class>
-  <owl:Class rdf:ID="Assurance_Case_Package">
-    <rdfs:subClassOf>
-      <owl:Class rdf:ID="Artifact_Element"/>
-    </rdfs:subClassOf>
-  </owl:Class>
-  <owl:Class rdf:about="#Artifact_Asset">
-    <rdfs:subClassOf>
-      <owl:Class rdf:about="#Artifact_Element"/>
-    </rdfs:subClassOf>
-  </owl:Class>
-  <owl:Class rdf:ID="Participant">
-    <rdfs:subClassOf rdf:resource="#Artifact_Asset"/>
-  </owl:Class>
-  <owl:Class rdf:ID="Expression_Lang_String">
-    <rdfs:subClassOf rdf:resource="#Lang_String"/>
-  </owl:Class>
-  <owl:Class rdf:ID="Claim">
-    <rdfs:subClassOf>
-      <owl:Class rdf:ID="Assertion"/>
-    </rdfs:subClassOf>
-  </owl:Class>
-  <owl:Class rdf:ID="Property">
-    <rdfs:subClassOf rdf:resource="#Artifact_Asset"/>
-  </owl:Class>
-  <owl:Class rdf:ID="Asserted_Evidence">
-    <rdfs:subClassOf>
-      <owl:Class rdf:ID="Asserted_Relationship"/>
-    </rdfs:subClassOf>
-  </owl:Class>
-  <owl:Class rdf:ID="Model_Element">
-    <rdfs:subClassOf>
-      <owl:Class rdf:ID="Sacm_Element"/>
-    </rdfs:subClassOf>
-  </owl:Class>
-  <owl:Class rdf:ID="Argument_Reasoning">
-    <rdfs:subClassOf>
-      <owl:Class rdf:ID="Argument_Asset"/>
-    </rdfs:subClassOf>
-  </owl:Class>
-  <owl:Class rdf:ID="Technique">
-    <rdfs:subClassOf rdf:resource="#Artifact_Asset"/>
-  </owl:Class>
-  <owl:Class rdf:ID="Argument_Package">
-    <rdfs:subClassOf>
-      <owl:Class rdf:ID="Argumentation_Element"/>
-    </rdfs:subClassOf>
-  </owl:Class>
-  <owl:Class rdf:ID="Note">
-    <rdfs:subClassOf>
-      <owl:Class rdf:about="#Utility_Element"/>
-    </rdfs:subClassOf>
-  </owl:Class>
-  <owl:Class rdf:ID="Terminology_Group">
-    <rdfs:subClassOf>
-      <owl:Class rdf:about="#Terminology_Element"/>
-    </rdfs:subClassOf>
-  </owl:Class>
-  <owl:Class rdf:about="#Asserted_Relationship">
-    <rdfs:subClassOf>
-      <owl:Class rdf:about="#Assertion"/>
-    </rdfs:subClassOf>
-  </owl:Class>
-  <owl:Class rdf:about="#Artifact_Element">
-    <rdfs:subClassOf rdf:resource="#Model_Element"/>
-  </owl:Class>
-  <owl:Class rdf:about="#Argumentation_Element">
-    <rdfs:subClassOf rdf:resource="#Artifact_Element"/>
-  </owl:Class>
-  <owl:Class rdf:ID="Expression">
-    <rdfs:subClassOf>
-      <owl:Class rdf:about="#Expression_Element"/>
-    </rdfs:subClassOf>
-  </owl:Class>
-  <owl:Class rdf:ID="Artifact_Asset_Relationship">
-    <rdfs:subClassOf rdf:resource="#Artifact_Asset"/>
-  </owl:Class>
-  <owl:Class rdf:ID="Multi_Lang_String">
-    <rdfs:subClassOf>
-      <owl:Class rdf:about="#Element"/>
-    </rdfs:subClassOf>
-  </owl:Class>
-  <owl:Class rdf:about="#Element">
-    <rdfs:subClassOf>
-      <owl:Restriction>
-        <owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >1</owl:cardinality>
-        <owl:onProperty>
-          <owl:DatatypeProperty rdf:ID="uuid"/>
-        </owl:onProperty>
-      </owl:Restriction>
-    </rdfs:subClassOf>
-    <rdfs:subClassOf rdf:resource="PROV-S#ENTITY"/>
-  </owl:Class>
-  <owl:Class rdf:ID="Implementation_Constraint">
-    <rdfs:subClassOf>
-      <owl:Class rdf:about="#Utility_Element"/>
-    </rdfs:subClassOf>
-  </owl:Class>
-  <owl:Class rdf:ID="Asserted_Context">
-    <rdfs:subClassOf rdf:resource="#Asserted_Relationship"/>
-  </owl:Class>
-  <owl:Class rdf:about="#Argument_Asset">
-    <rdfs:subClassOf rdf:resource="#Argumentation_Element"/>
-  </owl:Class>
-  <owl:Class rdf:ID="Event">
-    <rdfs:subClassOf rdf:resource="#Artifact_Asset"/>
-  </owl:Class>
-  <owl:Class rdf:about="#Terminology_Element">
-    <rdfs:subClassOf rdf:resource="#Artifact_Element"/>
-  </owl:Class>
-  <owl:Class rdf:about="#Assertion">
-    <rdfs:subClassOf rdf:resource="#Argument_Asset"/>
-  </owl:Class>
-  <owl:Class rdf:about="#Sacm_Element">
+  <owl:Class rdf:about="#SacmElement">
     <rdfs:subClassOf>
       <owl:Restriction>
         <owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
@@ -210,27 +63,154 @@
         </owl:onProperty>
       </owl:Restriction>
     </rdfs:subClassOf>
+    <rdfs:subClassOf>
+      <owl:Class rdf:ID="Element"/>
+    </rdfs:subClassOf>
+  </owl:Class>
+  <owl:Class rdf:ID="ArgumentPackage">
+    <rdfs:subClassOf>
+      <owl:Class rdf:ID="ArgumentationElement"/>
+    </rdfs:subClassOf>
+  </owl:Class>
+  <owl:Class rdf:ID="Artifact">
+    <rdfs:subClassOf>
+      <owl:Class rdf:about="#ArtifactAsset"/>
+    </rdfs:subClassOf>
+  </owl:Class>
+  <owl:Class rdf:ID="Term">
+    <rdfs:subClassOf>
+      <owl:Class rdf:ID="ExpressionElement"/>
+    </rdfs:subClassOf>
+  </owl:Class>
+  <owl:Class rdf:ID="ArgumentReasoning">
+    <rdfs:subClassOf>
+      <owl:Class rdf:ID="ArgumentAsset"/>
+    </rdfs:subClassOf>
+  </owl:Class>
+  <owl:Class rdf:ID="TerminologyPackage">
+    <rdfs:subClassOf>
+      <owl:Class rdf:about="#TerminologyElement"/>
+    </rdfs:subClassOf>
+  </owl:Class>
+  <owl:Class rdf:ID="ImplementationConstraint">
+    <rdfs:subClassOf rdf:resource="#UtilityElement"/>
+  </owl:Class>
+  <owl:Class rdf:ID="Participant">
+    <rdfs:subClassOf>
+      <owl:Class rdf:about="#ArtifactAsset"/>
+    </rdfs:subClassOf>
+  </owl:Class>
+  <owl:Class rdf:ID="ExpressionLangString">
+    <rdfs:subClassOf>
+      <owl:Class rdf:ID="LangString"/>
+    </rdfs:subClassOf>
+  </owl:Class>
+  <owl:Class rdf:ID="Claim">
+    <rdfs:subClassOf>
+      <owl:Class rdf:ID="Assertion"/>
+    </rdfs:subClassOf>
+  </owl:Class>
+  <owl:Class rdf:ID="Property">
+    <rdfs:subClassOf>
+      <owl:Class rdf:about="#ArtifactAsset"/>
+    </rdfs:subClassOf>
+  </owl:Class>
+  <owl:Class rdf:about="#TerminologyElement">
+    <rdfs:subClassOf>
+      <owl:Class rdf:ID="ArtifactElement"/>
+    </rdfs:subClassOf>
+  </owl:Class>
+  <owl:Class rdf:ID="Technique">
+    <rdfs:subClassOf>
+      <owl:Class rdf:about="#ArtifactAsset"/>
+    </rdfs:subClassOf>
+  </owl:Class>
+  <owl:Class rdf:ID="MultiLangString">
+    <rdfs:subClassOf>
+      <owl:Class rdf:about="#Element"/>
+    </rdfs:subClassOf>
+  </owl:Class>
+  <owl:Class rdf:ID="ModelElement">
+    <rdfs:subClassOf rdf:resource="#SacmElement"/>
+  </owl:Class>
+  <owl:Class rdf:ID="SacmActivity">
+    <rdfs:subClassOf>
+      <owl:Class rdf:about="#ArtifactAsset"/>
+    </rdfs:subClassOf>
+  </owl:Class>
+  <owl:Class rdf:ID="Note">
+    <rdfs:subClassOf rdf:resource="#UtilityElement"/>
+  </owl:Class>
+  <owl:Class rdf:ID="ArtifactPackage">
+    <rdfs:subClassOf>
+      <owl:Class rdf:about="#ArtifactElement"/>
+    </rdfs:subClassOf>
+  </owl:Class>
+  <owl:Class rdf:ID="Expression">
+    <rdfs:subClassOf>
+      <owl:Class rdf:about="#ExpressionElement"/>
+    </rdfs:subClassOf>
+  </owl:Class>
+  <owl:Class rdf:about="#Element">
+    <rdfs:subClassOf>
+      <owl:Restriction>
+        <owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >1</owl:cardinality>
+        <owl:onProperty>
+          <owl:DatatypeProperty rdf:ID="uuid"/>
+        </owl:onProperty>
+      </owl:Restriction>
+    </rdfs:subClassOf>
+    <rdfs:subClassOf rdf:resource="PROV-S#ENTITY"/>
+  </owl:Class>
+  <owl:Class rdf:about="#ArgumentAsset">
+    <rdfs:subClassOf>
+      <owl:Class rdf:about="#ArgumentationElement"/>
+    </rdfs:subClassOf>
+  </owl:Class>
+  <owl:Class rdf:about="#ArgumentationElement">
+    <rdfs:subClassOf>
+      <owl:Class rdf:about="#ArtifactElement"/>
+    </rdfs:subClassOf>
+  </owl:Class>
+  <owl:Class rdf:ID="TerminologyAsset">
+    <rdfs:subClassOf rdf:resource="#TerminologyElement"/>
+  </owl:Class>
+  <owl:Class rdf:ID="ArtifactAssetRelationship">
+    <rdfs:subClassOf>
+      <owl:Class rdf:about="#ArtifactAsset"/>
+    </rdfs:subClassOf>
+  </owl:Class>
+  <owl:Class rdf:ID="Event">
+    <rdfs:subClassOf>
+      <owl:Class rdf:about="#ArtifactAsset"/>
+    </rdfs:subClassOf>
+  </owl:Class>
+  <owl:Class rdf:about="#LangString">
+    <rdfs:subClassOf>
+      <owl:Restriction>
+        <owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >1</owl:maxCardinality>
+        <owl:onProperty>
+          <owl:DatatypeProperty rdf:ID="contents"/>
+        </owl:onProperty>
+      </owl:Restriction>
+    </rdfs:subClassOf>
+    <rdfs:subClassOf>
+      <owl:Restriction>
+        <owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >1</owl:maxCardinality>
+        <owl:onProperty>
+          <owl:DatatypeProperty rdf:ID="lang"/>
+        </owl:onProperty>
+      </owl:Restriction>
+    </rdfs:subClassOf>
     <rdfs:subClassOf rdf:resource="#Element"/>
   </owl:Class>
-  <owl:Class rdf:about="#Utility_Element">
-    <rdfs:subClassOf rdf:resource="#Sacm_Element"/>
+  <owl:Class rdf:ID="TaggedValue">
+    <rdfs:subClassOf rdf:resource="#UtilityElement"/>
   </owl:Class>
-  <owl:Class rdf:ID="Artifact_Reference">
-    <rdfs:subClassOf rdf:resource="#Argument_Asset"/>
-  </owl:Class>
-  <owl:Class rdf:ID="Category">
-    <rdfs:subClassOf rdf:resource="#Terminology_Asset"/>
-  </owl:Class>
-  <owl:Class rdf:ID="Description">
-    <rdfs:subClassOf rdf:resource="#Utility_Element"/>
-  </owl:Class>
-  <owl:Class rdf:ID="Artifact_Package">
-    <rdfs:subClassOf rdf:resource="#Artifact_Element"/>
-  </owl:Class>
-  <owl:Class rdf:ID="Terminology_Package">
-    <rdfs:subClassOf rdf:resource="#Terminology_Element"/>
-  </owl:Class>
-  <owl:Class rdf:about="#Expression_Element">
+  <owl:Class rdf:about="#ExpressionElement">
     <rdfs:subClassOf>
       <owl:Restriction>
         <owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
@@ -240,149 +220,180 @@
         </owl:onProperty>
       </owl:Restriction>
     </rdfs:subClassOf>
-    <rdfs:subClassOf rdf:resource="#Terminology_Asset"/>
+    <rdfs:subClassOf rdf:resource="#TerminologyAsset"/>
+  </owl:Class>
+  <owl:Class rdf:about="#Assertion">
+    <rdfs:subClassOf rdf:resource="#ArgumentAsset"/>
+  </owl:Class>
+  <owl:Class rdf:about="#ArtifactAsset">
+    <rdfs:subClassOf>
+      <owl:Class rdf:about="#ArtifactElement"/>
+    </rdfs:subClassOf>
+  </owl:Class>
+  <owl:Class rdf:ID="AssertedContext">
+    <rdfs:subClassOf>
+      <owl:Class rdf:about="#AssertedRelationship"/>
+    </rdfs:subClassOf>
+  </owl:Class>
+  <owl:Class rdf:ID="Category">
+    <rdfs:subClassOf rdf:resource="#TerminologyAsset"/>
+  </owl:Class>
+  <owl:Class rdf:ID="Description">
+    <rdfs:subClassOf rdf:resource="#UtilityElement"/>
+  </owl:Class>
+  <owl:Class rdf:about="#ArtifactElement">
+    <rdfs:subClassOf rdf:resource="#ModelElement"/>
+  </owl:Class>
+  <owl:Class rdf:ID="ArtifactReference">
+    <rdfs:subClassOf rdf:resource="#ArgumentAsset"/>
+  </owl:Class>
+  <owl:Class rdf:ID="AssuranceCasePackage">
+    <rdfs:subClassOf rdf:resource="#ArtifactElement"/>
+  </owl:Class>
+  <owl:Class rdf:about="#AssertedRelationship">
+    <rdfs:subClassOf rdf:resource="#Assertion"/>
   </owl:Class>
   <owl:ObjectProperty rdf:ID="hasImplementationConstraint">
-    <rdfs:range rdf:resource="#Implementation_Constraint"/>
-    <rdfs:domain rdf:resource="#Model_Element"/>
+    <rdfs:range rdf:resource="#ImplementationConstraint"/>
+    <rdfs:domain rdf:resource="#ModelElement"/>
   </owl:ObjectProperty>
   <owl:ObjectProperty rdf:ID="hasElement">
     <rdfs:subPropertyOf rdf:resource="PROV-S#wasDerivedFrom"/>
     <rdfs:range>
       <owl:Class>
         <owl:unionOf rdf:parseType="Collection">
-          <owl:Class rdf:about="#Terminology_Element"/>
-          <owl:Class rdf:about="#Argumentation_Element"/>
+          <owl:Class rdf:about="#TerminologyElement"/>
+          <owl:Class rdf:about="#ArgumentationElement"/>
         </owl:unionOf>
       </owl:Class>
     </rdfs:range>
     <rdfs:domain>
       <owl:Class>
         <owl:unionOf rdf:parseType="Collection">
-          <owl:Class rdf:about="#Terminology_Package"/>
-          <owl:Class rdf:about="#Terminology_Group"/>
-          <owl:Class rdf:about="#Argument_Package"/>
+          <owl:Class rdf:about="#TerminologyPackage"/>
+          <owl:Class rdf:about="#TerminologyGroup"/>
+          <owl:Class rdf:about="#ArgumentPackage"/>
         </owl:unionOf>
       </owl:Class>
     </rdfs:domain>
   </owl:ObjectProperty>
   <owl:ObjectProperty rdf:ID="hasName">
-    <rdfs:range rdf:resource="#Lang_String"/>
-    <rdfs:domain rdf:resource="#Model_Element"/>
+    <rdfs:range rdf:resource="#LangString"/>
+    <rdfs:domain rdf:resource="#ModelElement"/>
   </owl:ObjectProperty>
   <owl:ObjectProperty rdf:ID="hasValue">
-    <rdfs:range rdf:resource="#Lang_String"/>
-    <rdfs:domain rdf:resource="#Multi_Lang_String"/>
+    <rdfs:range rdf:resource="#LangString"/>
+    <rdfs:domain rdf:resource="#MultiLangString"/>
   </owl:ObjectProperty>
   <owl:ObjectProperty rdf:ID="hasArgument">
-    <rdfs:range rdf:resource="#Argument_Package"/>
-    <rdfs:domain rdf:resource="#Assurance_Case_Package"/>
+    <rdfs:range rdf:resource="#ArgumentPackage"/>
+    <rdfs:domain rdf:resource="#AssuranceCasePackage"/>
   </owl:ObjectProperty>
   <owl:ObjectProperty rdf:ID="inCategory">
     <rdfs:range rdf:resource="#Category"/>
-    <rdfs:domain rdf:resource="#Expression_Element"/>
+    <rdfs:domain rdf:resource="#ExpressionElement"/>
   </owl:ObjectProperty>
   <owl:ObjectProperty rdf:ID="references">
-    <rdfs:range rdf:resource="#Artifact_Element"/>
-    <rdfs:domain rdf:resource="#Artifact_Reference"/>
+    <rdfs:range rdf:resource="#ArtifactElement"/>
+    <rdfs:domain rdf:resource="#ArtifactReference"/>
   </owl:ObjectProperty>
   <owl:ObjectProperty rdf:ID="hasNote">
     <rdfs:range rdf:resource="#Note"/>
-    <rdfs:domain rdf:resource="#Model_Element"/>
+    <rdfs:domain rdf:resource="#ModelElement"/>
   </owl:ObjectProperty>
   <owl:ObjectProperty rdf:ID="source">
     <rdfs:range>
       <owl:Class>
         <owl:unionOf rdf:parseType="Collection">
-          <owl:Class rdf:about="#Argument_Asset"/>
-          <owl:Class rdf:about="#Artifact_Asset"/>
+          <owl:Class rdf:about="#ArgumentAsset"/>
+          <owl:Class rdf:about="#ArtifactAsset"/>
         </owl:unionOf>
       </owl:Class>
     </rdfs:range>
     <rdfs:domain>
       <owl:Class>
         <owl:unionOf rdf:parseType="Collection">
-          <owl:Class rdf:about="#Asserted_Relationship"/>
-          <owl:Class rdf:about="#Artifact_Asset_Relationship"/>
+          <owl:Class rdf:about="#AssertedRelationship"/>
+          <owl:Class rdf:about="#ArtifactAssetRelationship"/>
         </owl:unionOf>
       </owl:Class>
     </rdfs:domain>
     <rdfs:subPropertyOf rdf:resource="PROV-S#wasDerivedFrom"/>
   </owl:ObjectProperty>
   <owl:ObjectProperty rdf:ID="hasTaggedValue">
-    <rdfs:range rdf:resource="#Tagged_Value"/>
-    <rdfs:domain rdf:resource="#Model_Element"/>
+    <rdfs:range rdf:resource="#TaggedValue"/>
+    <rdfs:domain rdf:resource="#ModelElement"/>
   </owl:ObjectProperty>
   <owl:ObjectProperty rdf:ID="hasContent">
     <rdfs:domain>
       <owl:Class>
         <owl:unionOf rdf:parseType="Collection">
-          <owl:Class rdf:about="#Utility_Element"/>
-          <owl:Class rdf:about="#Argument_Asset"/>
+          <owl:Class rdf:about="#UtilityElement"/>
+          <owl:Class rdf:about="#ArgumentAsset"/>
         </owl:unionOf>
       </owl:Class>
     </rdfs:domain>
-    <rdfs:range rdf:resource="#Multi_Lang_String"/>
+    <rdfs:range rdf:resource="#MultiLangString"/>
   </owl:ObjectProperty>
   <owl:ObjectProperty rdf:ID="hasPackage">
-    <rdfs:range rdf:resource="#Assurance_Case_Package"/>
-    <rdfs:domain rdf:resource="#Assurance_Case_Package"/>
+    <rdfs:range rdf:resource="#AssuranceCasePackage"/>
+    <rdfs:domain rdf:resource="#AssuranceCasePackage"/>
   </owl:ObjectProperty>
   <owl:ObjectProperty rdf:ID="cites">
-    <rdfs:range rdf:resource="#Sacm_Element"/>
-    <rdfs:domain rdf:resource="#Sacm_Element"/>
+    <rdfs:range rdf:resource="#SacmElement"/>
+    <rdfs:domain rdf:resource="#SacmElement"/>
   </owl:ObjectProperty>
   <owl:ObjectProperty rdf:ID="implements">
-    <rdfs:range rdf:resource="#Sacm_Element"/>
-    <rdfs:domain rdf:resource="#Sacm_Element"/>
+    <rdfs:range rdf:resource="#SacmElement"/>
+    <rdfs:domain rdf:resource="#SacmElement"/>
   </owl:ObjectProperty>
   <owl:ObjectProperty rdf:ID="reasoning">
     <rdfs:subPropertyOf rdf:resource="PROV-S#wasDerivedFrom"/>
-    <rdfs:range rdf:resource="#Argument_Reasoning"/>
-    <rdfs:domain rdf:resource="#Asserted_Relationship"/>
+    <rdfs:range rdf:resource="#ArgumentReasoning"/>
+    <rdfs:domain rdf:resource="#AssertedRelationship"/>
   </owl:ObjectProperty>
   <owl:ObjectProperty rdf:ID="expresses">
-    <rdfs:range rdf:resource="#Expression_Element"/>
-    <rdfs:domain rdf:resource="#Expression_Lang_String"/>
+    <rdfs:range rdf:resource="#ExpressionElement"/>
+    <rdfs:domain rdf:resource="#ExpressionLangString"/>
   </owl:ObjectProperty>
   <owl:ObjectProperty rdf:ID="hasDescription">
     <rdfs:range rdf:resource="#Description"/>
-    <rdfs:domain rdf:resource="#Model_Element"/>
+    <rdfs:domain rdf:resource="#ModelElement"/>
   </owl:ObjectProperty>
   <owl:ObjectProperty rdf:ID="hasOrigin">
-    <rdfs:range rdf:resource="#Model_Element"/>
+    <rdfs:range rdf:resource="#ModelElement"/>
     <rdfs:domain rdf:resource="#Term"/>
   </owl:ObjectProperty>
   <owl:ObjectProperty rdf:ID="hasKey">
-    <rdfs:range rdf:resource="#Multi_Lang_String"/>
-    <rdfs:domain rdf:resource="#Tagged_Value"/>
+    <rdfs:range rdf:resource="#MultiLangString"/>
+    <rdfs:domain rdf:resource="#TaggedValue"/>
   </owl:ObjectProperty>
   <owl:ObjectProperty rdf:ID="usesElement">
-    <rdfs:range rdf:resource="#Expression_Element"/>
+    <rdfs:range rdf:resource="#ExpressionElement"/>
     <rdfs:domain rdf:resource="#Expression"/>
   </owl:ObjectProperty>
   <owl:ObjectProperty rdf:ID="target">
     <rdfs:range>
       <owl:Class>
         <owl:unionOf rdf:parseType="Collection">
-          <owl:Class rdf:about="#Argument_Asset"/>
-          <owl:Class rdf:about="#Artifact_Asset"/>
+          <owl:Class rdf:about="#ArgumentAsset"/>
+          <owl:Class rdf:about="#ArtifactAsset"/>
         </owl:unionOf>
       </owl:Class>
     </rdfs:range>
     <rdfs:domain>
       <owl:Class>
         <owl:unionOf rdf:parseType="Collection">
-          <owl:Class rdf:about="#Asserted_Relationship"/>
-          <owl:Class rdf:about="#Artifact_Asset_Relationship"/>
+          <owl:Class rdf:about="#AssertedRelationship"/>
+          <owl:Class rdf:about="#ArtifactAssetRelationship"/>
         </owl:unionOf>
       </owl:Class>
     </rdfs:domain>
     <rdfs:subPropertyOf rdf:resource="PROV-S#wasDerivedFrom"/>
   </owl:ObjectProperty>
   <owl:ObjectProperty rdf:ID="usesTerminology">
-    <rdfs:range rdf:resource="#Terminology_Package"/>
-    <rdfs:domain rdf:resource="#Assurance_Case_Package"/>
+    <rdfs:range rdf:resource="#TerminologyPackage"/>
+    <rdfs:domain rdf:resource="#AssuranceCasePackage"/>
   </owl:ObjectProperty>
   <owl:DatatypeProperty rdf:ID="artifactVersion">
     <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
@@ -390,19 +401,19 @@
   </owl:DatatypeProperty>
   <owl:DatatypeProperty rdf:about="#gid">
     <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-    <rdfs:domain rdf:resource="#Sacm_Element"/>
+    <rdfs:domain rdf:resource="#SacmElement"/>
   </owl:DatatypeProperty>
   <owl:DatatypeProperty rdf:ID="startTime">
     <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-    <rdfs:domain rdf:resource="#Activity"/>
+    <rdfs:domain rdf:resource="#SacmActivity"/>
   </owl:DatatypeProperty>
   <owl:DatatypeProperty rdf:about="#lang">
     <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-    <rdfs:domain rdf:resource="#Lang_String"/>
+    <rdfs:domain rdf:resource="#LangString"/>
   </owl:DatatypeProperty>
   <owl:DatatypeProperty rdf:about="#isAbstract">
     <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-    <rdfs:domain rdf:resource="#Sacm_Element"/>
+    <rdfs:domain rdf:resource="#SacmElement"/>
   </owl:DatatypeProperty>
   <owl:DatatypeProperty rdf:ID="externalReference">
     <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
@@ -414,7 +425,7 @@
   </owl:DatatypeProperty>
   <owl:DatatypeProperty rdf:ID="endTime">
     <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-    <rdfs:domain rdf:resource="#Activity"/>
+    <rdfs:domain rdf:resource="#SacmActivity"/>
   </owl:DatatypeProperty>
   <owl:DatatypeProperty rdf:about="#uuid">
     <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
@@ -426,7 +437,7 @@
   </owl:DatatypeProperty>
   <owl:DatatypeProperty rdf:about="#contents">
     <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-    <rdfs:domain rdf:resource="#Lang_String"/>
+    <rdfs:domain rdf:resource="#LangString"/>
   </owl:DatatypeProperty>
   <owl:DatatypeProperty rdf:ID="assertionDeclaration">
     <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
@@ -434,14 +445,14 @@
   </owl:DatatypeProperty>
   <owl:DatatypeProperty rdf:about="#val">
     <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-    <rdfs:domain rdf:resource="#Expression_Element"/>
+    <rdfs:domain rdf:resource="#ExpressionElement"/>
   </owl:DatatypeProperty>
   <owl:DatatypeProperty rdf:about="#isCitation">
     <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-    <rdfs:domain rdf:resource="#Sacm_Element"/>
+    <rdfs:domain rdf:resource="#SacmElement"/>
   </owl:DatatypeProperty>
   <owl:DatatypeProperty rdf:ID="isCounter">
     <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-    <rdfs:domain rdf:resource="#Asserted_Relationship"/>
+    <rdfs:domain rdf:resource="#AssertedRelationship"/>
   </owl:DatatypeProperty>
 </rdf:RDF>

--- a/LM-Ontology/OwlModels/SACM.owl
+++ b/LM-Ontology/OwlModels/SACM.owl
@@ -1,12 +1,12 @@
 <rdf:RDF
     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-    xmlns:sadlbasemodel="http://sadl.org/sadlbasemodel"
-    xmlns:provs="http://arcos.rack/PROV-S"
+    xmlns:provs="http://arcos.rack/PROV-S#"
+    xmlns:builtinfunctions="http://sadl.org/builtinfunctions#"
     xmlns:owl="http://www.w3.org/2002/07/owl#"
     xmlns:sacm="http://arcos.rack/SACM#"
-    xmlns:sadlimplicitmodel="http://sadl.org/sadlimplicitmodel"
-    xmlns:builtinfunctions="http://sadl.org/builtinfunctions"
+    xmlns:sadlimplicitmodel="http://sadl.org/sadlimplicitmodel#"
     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:sadlbasemodel="http://sadl.org/sadlbasemodel#"
     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
   xml:base="http://arcos.rack/SACM">
   <owl:Ontology rdf:about="">
@@ -16,76 +16,37 @@
     <owl:imports rdf:resource="http://sadl.org/sadlbasemodel"/>
     <rdfs:comment xml:lang="en">This ontology was created from a SADL file 'SACM.sadl' and should not be directly edited.</rdfs:comment>
   </owl:Ontology>
-  <owl:Class rdf:ID="ARTIFACT_REFERENCE">
+  <owl:Class rdf:ID="Tagged_Value">
     <rdfs:subClassOf>
-      <owl:Class rdf:ID="ARGUMENT_ASSET"/>
+      <owl:Class rdf:ID="Utility_Element"/>
     </rdfs:subClassOf>
   </owl:Class>
-  <owl:Class rdf:ID="TERM">
+  <owl:Class rdf:ID="Terminology_Asset">
     <rdfs:subClassOf>
-      <owl:Class rdf:ID="EXPRESSION_ELEMENT"/>
+      <owl:Class rdf:ID="Terminology_Element"/>
     </rdfs:subClassOf>
   </owl:Class>
-  <owl:Class rdf:ID="TERMINOLOGY_ELEMENT">
+  <owl:Class rdf:ID="Resource">
     <rdfs:subClassOf>
-      <owl:Class rdf:ID="ARTIFACT_ELEMENT"/>
+      <owl:Class rdf:ID="Artifact_Asset"/>
     </rdfs:subClassOf>
   </owl:Class>
-  <owl:Class rdf:ID="TERMINOLOGY_ASSET">
-    <rdfs:subClassOf rdf:resource="#TERMINOLOGY_ELEMENT"/>
-  </owl:Class>
-  <owl:Class rdf:ID="CATEGORY">
-    <rdfs:subClassOf rdf:resource="#TERMINOLOGY_ASSET"/>
-  </owl:Class>
-  <owl:Class rdf:ID="CLAIM">
+  <owl:Class rdf:ID="Activity">
     <rdfs:subClassOf>
-      <owl:Class rdf:ID="ASSERTION"/>
+      <owl:Class rdf:about="#Artifact_Asset"/>
     </rdfs:subClassOf>
   </owl:Class>
-  <owl:Class rdf:ID="TERMINOLOGY_PACKAGE">
-    <rdfs:subClassOf rdf:resource="#TERMINOLOGY_ELEMENT"/>
-  </owl:Class>
-  <owl:Class rdf:ID="MULTI_LANG_STRING">
+  <owl:Class rdf:ID="Artifact">
     <rdfs:subClassOf>
-      <owl:Class rdf:ID="ELEMENT"/>
+      <owl:Class rdf:about="#Artifact_Asset"/>
     </rdfs:subClassOf>
   </owl:Class>
-  <owl:Class rdf:ID="ASSERTED_RELATIONSHIP">
+  <owl:Class rdf:ID="Term">
     <rdfs:subClassOf>
-      <owl:Class rdf:about="#ASSERTION"/>
+      <owl:Class rdf:ID="Expression_Element"/>
     </rdfs:subClassOf>
   </owl:Class>
-  <owl:Class rdf:ID="RESOURCE">
-    <rdfs:subClassOf>
-      <owl:Class rdf:ID="ARTIFACT_ASSET"/>
-    </rdfs:subClassOf>
-  </owl:Class>
-  <owl:Class rdf:ID="DESCRIPTION">
-    <rdfs:subClassOf>
-      <owl:Class rdf:ID="UTILITY_ELEMENT"/>
-    </rdfs:subClassOf>
-  </owl:Class>
-  <owl:Class rdf:ID="IMPLEMENTATION_CONSTRAINT">
-    <rdfs:subClassOf>
-      <owl:Class rdf:about="#UTILITY_ELEMENT"/>
-    </rdfs:subClassOf>
-  </owl:Class>
-  <owl:Class rdf:ID="ARTIFACT_ASSET_RELATIONSHIP">
-    <rdfs:subClassOf>
-      <owl:Class rdf:about="#ARTIFACT_ASSET"/>
-    </rdfs:subClassOf>
-  </owl:Class>
-  <owl:Class rdf:ID="PROPERTY">
-    <rdfs:subClassOf>
-      <owl:Class rdf:about="#ARTIFACT_ASSET"/>
-    </rdfs:subClassOf>
-  </owl:Class>
-  <owl:Class rdf:ID="NOTE">
-    <rdfs:subClassOf>
-      <owl:Class rdf:about="#UTILITY_ELEMENT"/>
-    </rdfs:subClassOf>
-  </owl:Class>
-  <owl:Class rdf:ID="LANG_STRING">
+  <owl:Class rdf:ID="Lang_String">
     <rdfs:subClassOf>
       <owl:Restriction>
         <owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
@@ -105,53 +66,123 @@
       </owl:Restriction>
     </rdfs:subClassOf>
     <rdfs:subClassOf>
-      <owl:Class rdf:about="#ELEMENT"/>
+      <owl:Class rdf:ID="Element"/>
     </rdfs:subClassOf>
   </owl:Class>
-  <owl:Class rdf:about="#ARGUMENT_ASSET">
+  <owl:Class rdf:ID="Assurance_Case_Package">
     <rdfs:subClassOf>
-      <owl:Class rdf:ID="ARGUMENTATION_ELEMENT"/>
+      <owl:Class rdf:ID="Artifact_Element"/>
     </rdfs:subClassOf>
   </owl:Class>
-  <owl:Class rdf:ID="ASSERTED_CONTEXT">
-    <rdfs:subClassOf rdf:resource="#ASSERTED_RELATIONSHIP"/>
-  </owl:Class>
-  <owl:Class rdf:about="#ASSERTION">
-    <rdfs:subClassOf rdf:resource="#ARGUMENT_ASSET"/>
-  </owl:Class>
-  <owl:Class rdf:ID="ARTIFACT">
+  <owl:Class rdf:about="#Artifact_Asset">
     <rdfs:subClassOf>
-      <owl:Class rdf:about="#ARTIFACT_ASSET"/>
+      <owl:Class rdf:about="#Artifact_Element"/>
     </rdfs:subClassOf>
   </owl:Class>
-  <owl:Class rdf:ID="ASSURANCE_CASE_PACKAGE">
+  <owl:Class rdf:ID="Participant">
+    <rdfs:subClassOf rdf:resource="#Artifact_Asset"/>
+  </owl:Class>
+  <owl:Class rdf:ID="Expression_Lang_String">
+    <rdfs:subClassOf rdf:resource="#Lang_String"/>
+  </owl:Class>
+  <owl:Class rdf:ID="Claim">
     <rdfs:subClassOf>
-      <owl:Class rdf:about="#ARTIFACT_ELEMENT"/>
+      <owl:Class rdf:ID="Assertion"/>
     </rdfs:subClassOf>
   </owl:Class>
-  <owl:Class rdf:about="#ARTIFACT_ASSET">
+  <owl:Class rdf:ID="Property">
+    <rdfs:subClassOf rdf:resource="#Artifact_Asset"/>
+  </owl:Class>
+  <owl:Class rdf:ID="Asserted_Evidence">
     <rdfs:subClassOf>
-      <owl:Class rdf:about="#ARTIFACT_ELEMENT"/>
+      <owl:Class rdf:ID="Asserted_Relationship"/>
     </rdfs:subClassOf>
   </owl:Class>
-  <owl:Class rdf:ID="ASSERTED_EVIDENCE">
-    <rdfs:subClassOf rdf:resource="#ASSERTED_RELATIONSHIP"/>
-  </owl:Class>
-  <owl:Class rdf:ID="EVENT">
-    <rdfs:subClassOf rdf:resource="#ARTIFACT_ASSET"/>
-  </owl:Class>
-  <owl:Class rdf:ID="TECHNIQUE">
-    <rdfs:subClassOf rdf:resource="#ARTIFACT_ASSET"/>
-  </owl:Class>
-  <owl:Class rdf:about="#UTILITY_ELEMENT">
+  <owl:Class rdf:ID="Model_Element">
     <rdfs:subClassOf>
-      <owl:Class rdf:ID="SACM_ELEMENT"/>
+      <owl:Class rdf:ID="Sacm_Element"/>
     </rdfs:subClassOf>
   </owl:Class>
-  <owl:Class rdf:ID="TAGGED_VALUE">
-    <rdfs:subClassOf rdf:resource="#UTILITY_ELEMENT"/>
+  <owl:Class rdf:ID="Argument_Reasoning">
+    <rdfs:subClassOf>
+      <owl:Class rdf:ID="Argument_Asset"/>
+    </rdfs:subClassOf>
   </owl:Class>
-  <owl:Class rdf:about="#SACM_ELEMENT">
+  <owl:Class rdf:ID="Technique">
+    <rdfs:subClassOf rdf:resource="#Artifact_Asset"/>
+  </owl:Class>
+  <owl:Class rdf:ID="Argument_Package">
+    <rdfs:subClassOf>
+      <owl:Class rdf:ID="Argumentation_Element"/>
+    </rdfs:subClassOf>
+  </owl:Class>
+  <owl:Class rdf:ID="Note">
+    <rdfs:subClassOf>
+      <owl:Class rdf:about="#Utility_Element"/>
+    </rdfs:subClassOf>
+  </owl:Class>
+  <owl:Class rdf:ID="Terminology_Group">
+    <rdfs:subClassOf>
+      <owl:Class rdf:about="#Terminology_Element"/>
+    </rdfs:subClassOf>
+  </owl:Class>
+  <owl:Class rdf:about="#Asserted_Relationship">
+    <rdfs:subClassOf>
+      <owl:Class rdf:about="#Assertion"/>
+    </rdfs:subClassOf>
+  </owl:Class>
+  <owl:Class rdf:about="#Artifact_Element">
+    <rdfs:subClassOf rdf:resource="#Model_Element"/>
+  </owl:Class>
+  <owl:Class rdf:about="#Argumentation_Element">
+    <rdfs:subClassOf rdf:resource="#Artifact_Element"/>
+  </owl:Class>
+  <owl:Class rdf:ID="Expression">
+    <rdfs:subClassOf>
+      <owl:Class rdf:about="#Expression_Element"/>
+    </rdfs:subClassOf>
+  </owl:Class>
+  <owl:Class rdf:ID="Artifact_Asset_Relationship">
+    <rdfs:subClassOf rdf:resource="#Artifact_Asset"/>
+  </owl:Class>
+  <owl:Class rdf:ID="Multi_Lang_String">
+    <rdfs:subClassOf>
+      <owl:Class rdf:about="#Element"/>
+    </rdfs:subClassOf>
+  </owl:Class>
+  <owl:Class rdf:about="#Element">
+    <rdfs:subClassOf>
+      <owl:Restriction>
+        <owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >1</owl:cardinality>
+        <owl:onProperty>
+          <owl:DatatypeProperty rdf:ID="uuid"/>
+        </owl:onProperty>
+      </owl:Restriction>
+    </rdfs:subClassOf>
+    <rdfs:subClassOf rdf:resource="PROV-S#ENTITY"/>
+  </owl:Class>
+  <owl:Class rdf:ID="Implementation_Constraint">
+    <rdfs:subClassOf>
+      <owl:Class rdf:about="#Utility_Element"/>
+    </rdfs:subClassOf>
+  </owl:Class>
+  <owl:Class rdf:ID="Asserted_Context">
+    <rdfs:subClassOf rdf:resource="#Asserted_Relationship"/>
+  </owl:Class>
+  <owl:Class rdf:about="#Argument_Asset">
+    <rdfs:subClassOf rdf:resource="#Argumentation_Element"/>
+  </owl:Class>
+  <owl:Class rdf:ID="Event">
+    <rdfs:subClassOf rdf:resource="#Artifact_Asset"/>
+  </owl:Class>
+  <owl:Class rdf:about="#Terminology_Element">
+    <rdfs:subClassOf rdf:resource="#Artifact_Element"/>
+  </owl:Class>
+  <owl:Class rdf:about="#Assertion">
+    <rdfs:subClassOf rdf:resource="#Argument_Asset"/>
+  </owl:Class>
+  <owl:Class rdf:about="#Sacm_Element">
     <rdfs:subClassOf>
       <owl:Restriction>
         <owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
@@ -179,17 +210,27 @@
         </owl:onProperty>
       </owl:Restriction>
     </rdfs:subClassOf>
-    <rdfs:subClassOf>
-      <owl:Class rdf:about="#ELEMENT"/>
-    </rdfs:subClassOf>
+    <rdfs:subClassOf rdf:resource="#Element"/>
   </owl:Class>
-  <owl:Class rdf:ID="ARGUMENT_REASONING">
-    <rdfs:subClassOf rdf:resource="#ARGUMENT_ASSET"/>
+  <owl:Class rdf:about="#Utility_Element">
+    <rdfs:subClassOf rdf:resource="#Sacm_Element"/>
   </owl:Class>
-  <owl:Class rdf:ID="TERMINOLOGY_GROUP">
-    <rdfs:subClassOf rdf:resource="#TERMINOLOGY_ELEMENT"/>
+  <owl:Class rdf:ID="Artifact_Reference">
+    <rdfs:subClassOf rdf:resource="#Argument_Asset"/>
   </owl:Class>
-  <owl:Class rdf:about="#EXPRESSION_ELEMENT">
+  <owl:Class rdf:ID="Category">
+    <rdfs:subClassOf rdf:resource="#Terminology_Asset"/>
+  </owl:Class>
+  <owl:Class rdf:ID="Description">
+    <rdfs:subClassOf rdf:resource="#Utility_Element"/>
+  </owl:Class>
+  <owl:Class rdf:ID="Artifact_Package">
+    <rdfs:subClassOf rdf:resource="#Artifact_Element"/>
+  </owl:Class>
+  <owl:Class rdf:ID="Terminology_Package">
+    <rdfs:subClassOf rdf:resource="#Terminology_Element"/>
+  </owl:Class>
+  <owl:Class rdf:about="#Expression_Element">
     <rdfs:subClassOf>
       <owl:Restriction>
         <owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
@@ -199,251 +240,208 @@
         </owl:onProperty>
       </owl:Restriction>
     </rdfs:subClassOf>
-    <rdfs:subClassOf rdf:resource="#TERMINOLOGY_ASSET"/>
-  </owl:Class>
-  <owl:Class rdf:about="#ARGUMENTATION_ELEMENT">
-    <rdfs:subClassOf>
-      <owl:Class rdf:about="#ARTIFACT_ELEMENT"/>
-    </rdfs:subClassOf>
-  </owl:Class>
-  <owl:Class rdf:ID="ARTIFACT_PACKAGE">
-    <rdfs:subClassOf>
-      <owl:Class rdf:about="#ARTIFACT_ELEMENT"/>
-    </rdfs:subClassOf>
-  </owl:Class>
-  <owl:Class rdf:ID="MODEL_ELEMENT">
-    <rdfs:subClassOf rdf:resource="#SACM_ELEMENT"/>
-  </owl:Class>
-  <owl:Class rdf:ID="SACM_ACTIVITY">
-    <rdfs:subClassOf rdf:resource="#ARTIFACT_ASSET"/>
-  </owl:Class>
-  <owl:Class rdf:ID="ARGUMENT_PACKAGE">
-    <rdfs:subClassOf rdf:resource="#ARGUMENTATION_ELEMENT"/>
-  </owl:Class>
-  <owl:Class rdf:about="#ELEMENT">
-    <rdfs:subClassOf>
-      <owl:Restriction>
-        <owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >1</owl:cardinality>
-        <owl:onProperty>
-          <owl:DatatypeProperty rdf:ID="uuid"/>
-        </owl:onProperty>
-      </owl:Restriction>
-    </rdfs:subClassOf>
-    <rdfs:subClassOf rdf:resource="PROV-S#ENTITY"/>
-  </owl:Class>
-  <owl:Class rdf:ID="EXPRESSION_LANG_STRING">
-    <rdfs:subClassOf rdf:resource="#LANG_STRING"/>
-  </owl:Class>
-  <owl:Class rdf:about="#ARTIFACT_ELEMENT">
-    <rdfs:subClassOf rdf:resource="#MODEL_ELEMENT"/>
-  </owl:Class>
-  <owl:Class rdf:ID="PARTICIPANT">
-    <rdfs:subClassOf rdf:resource="#ARTIFACT_ASSET"/>
-  </owl:Class>
-  <owl:Class rdf:ID="EXPRESSION">
-    <rdfs:subClassOf rdf:resource="#EXPRESSION_ELEMENT"/>
+    <rdfs:subClassOf rdf:resource="#Terminology_Asset"/>
   </owl:Class>
   <owl:ObjectProperty rdf:ID="hasImplementationConstraint">
-    <rdfs:range rdf:resource="#IMPLEMENTATION_CONSTRAINT"/>
-    <rdfs:domain rdf:resource="#MODEL_ELEMENT"/>
+    <rdfs:range rdf:resource="#Implementation_Constraint"/>
+    <rdfs:domain rdf:resource="#Model_Element"/>
   </owl:ObjectProperty>
   <owl:ObjectProperty rdf:ID="hasElement">
     <rdfs:subPropertyOf rdf:resource="PROV-S#wasDerivedFrom"/>
     <rdfs:range>
       <owl:Class>
         <owl:unionOf rdf:parseType="Collection">
-          <owl:Class rdf:about="#TERMINOLOGY_ELEMENT"/>
-          <owl:Class rdf:about="#ARGUMENTATION_ELEMENT"/>
+          <owl:Class rdf:about="#Terminology_Element"/>
+          <owl:Class rdf:about="#Argumentation_Element"/>
         </owl:unionOf>
       </owl:Class>
     </rdfs:range>
     <rdfs:domain>
       <owl:Class>
         <owl:unionOf rdf:parseType="Collection">
-          <owl:Class rdf:about="#TERMINOLOGY_PACKAGE"/>
-          <owl:Class rdf:about="#TERMINOLOGY_GROUP"/>
-          <owl:Class rdf:about="#ARGUMENT_PACKAGE"/>
+          <owl:Class rdf:about="#Terminology_Package"/>
+          <owl:Class rdf:about="#Terminology_Group"/>
+          <owl:Class rdf:about="#Argument_Package"/>
         </owl:unionOf>
       </owl:Class>
     </rdfs:domain>
   </owl:ObjectProperty>
   <owl:ObjectProperty rdf:ID="hasName">
-    <rdfs:range rdf:resource="#LANG_STRING"/>
-    <rdfs:domain rdf:resource="#MODEL_ELEMENT"/>
+    <rdfs:range rdf:resource="#Lang_String"/>
+    <rdfs:domain rdf:resource="#Model_Element"/>
   </owl:ObjectProperty>
   <owl:ObjectProperty rdf:ID="hasValue">
-    <rdfs:range rdf:resource="#LANG_STRING"/>
-    <rdfs:domain rdf:resource="#MULTI_LANG_STRING"/>
+    <rdfs:range rdf:resource="#Lang_String"/>
+    <rdfs:domain rdf:resource="#Multi_Lang_String"/>
   </owl:ObjectProperty>
   <owl:ObjectProperty rdf:ID="hasArgument">
-    <rdfs:range rdf:resource="#ARGUMENT_PACKAGE"/>
-    <rdfs:domain rdf:resource="#ASSURANCE_CASE_PACKAGE"/>
+    <rdfs:range rdf:resource="#Argument_Package"/>
+    <rdfs:domain rdf:resource="#Assurance_Case_Package"/>
   </owl:ObjectProperty>
   <owl:ObjectProperty rdf:ID="inCategory">
-    <rdfs:range rdf:resource="#CATEGORY"/>
-    <rdfs:domain rdf:resource="#EXPRESSION_ELEMENT"/>
+    <rdfs:range rdf:resource="#Category"/>
+    <rdfs:domain rdf:resource="#Expression_Element"/>
   </owl:ObjectProperty>
   <owl:ObjectProperty rdf:ID="references">
-    <rdfs:range rdf:resource="#ARTIFACT_ELEMENT"/>
-    <rdfs:domain rdf:resource="#ARTIFACT_REFERENCE"/>
+    <rdfs:range rdf:resource="#Artifact_Element"/>
+    <rdfs:domain rdf:resource="#Artifact_Reference"/>
   </owl:ObjectProperty>
   <owl:ObjectProperty rdf:ID="hasNote">
-    <rdfs:range rdf:resource="#NOTE"/>
-    <rdfs:domain rdf:resource="#MODEL_ELEMENT"/>
+    <rdfs:range rdf:resource="#Note"/>
+    <rdfs:domain rdf:resource="#Model_Element"/>
   </owl:ObjectProperty>
   <owl:ObjectProperty rdf:ID="source">
     <rdfs:range>
       <owl:Class>
         <owl:unionOf rdf:parseType="Collection">
-          <owl:Class rdf:about="#ARGUMENT_ASSET"/>
-          <owl:Class rdf:about="#ARTIFACT_ASSET"/>
+          <owl:Class rdf:about="#Argument_Asset"/>
+          <owl:Class rdf:about="#Artifact_Asset"/>
         </owl:unionOf>
       </owl:Class>
     </rdfs:range>
     <rdfs:domain>
       <owl:Class>
         <owl:unionOf rdf:parseType="Collection">
-          <owl:Class rdf:about="#ASSERTED_RELATIONSHIP"/>
-          <owl:Class rdf:about="#ARTIFACT_ASSET_RELATIONSHIP"/>
+          <owl:Class rdf:about="#Asserted_Relationship"/>
+          <owl:Class rdf:about="#Artifact_Asset_Relationship"/>
         </owl:unionOf>
       </owl:Class>
     </rdfs:domain>
     <rdfs:subPropertyOf rdf:resource="PROV-S#wasDerivedFrom"/>
   </owl:ObjectProperty>
   <owl:ObjectProperty rdf:ID="hasTaggedValue">
-    <rdfs:range rdf:resource="#TAGGED_VALUE"/>
-    <rdfs:domain rdf:resource="#MODEL_ELEMENT"/>
+    <rdfs:range rdf:resource="#Tagged_Value"/>
+    <rdfs:domain rdf:resource="#Model_Element"/>
   </owl:ObjectProperty>
   <owl:ObjectProperty rdf:ID="hasContent">
     <rdfs:domain>
       <owl:Class>
         <owl:unionOf rdf:parseType="Collection">
-          <owl:Class rdf:about="#UTILITY_ELEMENT"/>
-          <owl:Class rdf:about="#ARGUMENT_ASSET"/>
+          <owl:Class rdf:about="#Utility_Element"/>
+          <owl:Class rdf:about="#Argument_Asset"/>
         </owl:unionOf>
       </owl:Class>
     </rdfs:domain>
-    <rdfs:range rdf:resource="#MULTI_LANG_STRING"/>
+    <rdfs:range rdf:resource="#Multi_Lang_String"/>
   </owl:ObjectProperty>
   <owl:ObjectProperty rdf:ID="hasPackage">
-    <rdfs:range rdf:resource="#ASSURANCE_CASE_PACKAGE"/>
-    <rdfs:domain rdf:resource="#ASSURANCE_CASE_PACKAGE"/>
+    <rdfs:range rdf:resource="#Assurance_Case_Package"/>
+    <rdfs:domain rdf:resource="#Assurance_Case_Package"/>
   </owl:ObjectProperty>
   <owl:ObjectProperty rdf:ID="cites">
-    <rdfs:range rdf:resource="#SACM_ELEMENT"/>
-    <rdfs:domain rdf:resource="#SACM_ELEMENT"/>
+    <rdfs:range rdf:resource="#Sacm_Element"/>
+    <rdfs:domain rdf:resource="#Sacm_Element"/>
   </owl:ObjectProperty>
   <owl:ObjectProperty rdf:ID="implements">
-    <rdfs:range rdf:resource="#SACM_ELEMENT"/>
-    <rdfs:domain rdf:resource="#SACM_ELEMENT"/>
+    <rdfs:range rdf:resource="#Sacm_Element"/>
+    <rdfs:domain rdf:resource="#Sacm_Element"/>
   </owl:ObjectProperty>
   <owl:ObjectProperty rdf:ID="reasoning">
     <rdfs:subPropertyOf rdf:resource="PROV-S#wasDerivedFrom"/>
-    <rdfs:range rdf:resource="#ARGUMENT_REASONING"/>
-    <rdfs:domain rdf:resource="#ASSERTED_RELATIONSHIP"/>
+    <rdfs:range rdf:resource="#Argument_Reasoning"/>
+    <rdfs:domain rdf:resource="#Asserted_Relationship"/>
   </owl:ObjectProperty>
   <owl:ObjectProperty rdf:ID="expresses">
-    <rdfs:range rdf:resource="#EXPRESSION_ELEMENT"/>
-    <rdfs:domain rdf:resource="#EXPRESSION_LANG_STRING"/>
+    <rdfs:range rdf:resource="#Expression_Element"/>
+    <rdfs:domain rdf:resource="#Expression_Lang_String"/>
   </owl:ObjectProperty>
   <owl:ObjectProperty rdf:ID="hasDescription">
-    <rdfs:range rdf:resource="#DESCRIPTION"/>
-    <rdfs:domain rdf:resource="#MODEL_ELEMENT"/>
+    <rdfs:range rdf:resource="#Description"/>
+    <rdfs:domain rdf:resource="#Model_Element"/>
   </owl:ObjectProperty>
   <owl:ObjectProperty rdf:ID="hasOrigin">
-    <rdfs:range rdf:resource="#MODEL_ELEMENT"/>
-    <rdfs:domain rdf:resource="#TERM"/>
+    <rdfs:range rdf:resource="#Model_Element"/>
+    <rdfs:domain rdf:resource="#Term"/>
   </owl:ObjectProperty>
   <owl:ObjectProperty rdf:ID="hasKey">
-    <rdfs:range rdf:resource="#MULTI_LANG_STRING"/>
-    <rdfs:domain rdf:resource="#TAGGED_VALUE"/>
+    <rdfs:range rdf:resource="#Multi_Lang_String"/>
+    <rdfs:domain rdf:resource="#Tagged_Value"/>
   </owl:ObjectProperty>
   <owl:ObjectProperty rdf:ID="usesElement">
-    <rdfs:range rdf:resource="#EXPRESSION_ELEMENT"/>
-    <rdfs:domain rdf:resource="#EXPRESSION"/>
+    <rdfs:range rdf:resource="#Expression_Element"/>
+    <rdfs:domain rdf:resource="#Expression"/>
   </owl:ObjectProperty>
   <owl:ObjectProperty rdf:ID="target">
     <rdfs:range>
       <owl:Class>
         <owl:unionOf rdf:parseType="Collection">
-          <owl:Class rdf:about="#ARGUMENT_ASSET"/>
-          <owl:Class rdf:about="#ARTIFACT_ASSET"/>
+          <owl:Class rdf:about="#Argument_Asset"/>
+          <owl:Class rdf:about="#Artifact_Asset"/>
         </owl:unionOf>
       </owl:Class>
     </rdfs:range>
     <rdfs:domain>
       <owl:Class>
         <owl:unionOf rdf:parseType="Collection">
-          <owl:Class rdf:about="#ASSERTED_RELATIONSHIP"/>
-          <owl:Class rdf:about="#ARTIFACT_ASSET_RELATIONSHIP"/>
+          <owl:Class rdf:about="#Asserted_Relationship"/>
+          <owl:Class rdf:about="#Artifact_Asset_Relationship"/>
         </owl:unionOf>
       </owl:Class>
     </rdfs:domain>
     <rdfs:subPropertyOf rdf:resource="PROV-S#wasDerivedFrom"/>
   </owl:ObjectProperty>
   <owl:ObjectProperty rdf:ID="usesTerminology">
-    <rdfs:range rdf:resource="#TERMINOLOGY_PACKAGE"/>
-    <rdfs:domain rdf:resource="#ASSURANCE_CASE_PACKAGE"/>
+    <rdfs:range rdf:resource="#Terminology_Package"/>
+    <rdfs:domain rdf:resource="#Assurance_Case_Package"/>
   </owl:ObjectProperty>
   <owl:DatatypeProperty rdf:ID="artifactVersion">
     <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-    <rdfs:domain rdf:resource="#ARTIFACT"/>
+    <rdfs:domain rdf:resource="#Artifact"/>
   </owl:DatatypeProperty>
   <owl:DatatypeProperty rdf:about="#gid">
     <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-    <rdfs:domain rdf:resource="#SACM_ELEMENT"/>
+    <rdfs:domain rdf:resource="#Sacm_Element"/>
   </owl:DatatypeProperty>
   <owl:DatatypeProperty rdf:ID="startTime">
     <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-    <rdfs:domain rdf:resource="#SACM_ACTIVITY"/>
+    <rdfs:domain rdf:resource="#Activity"/>
   </owl:DatatypeProperty>
   <owl:DatatypeProperty rdf:about="#lang">
     <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-    <rdfs:domain rdf:resource="#LANG_STRING"/>
+    <rdfs:domain rdf:resource="#Lang_String"/>
   </owl:DatatypeProperty>
   <owl:DatatypeProperty rdf:about="#isAbstract">
     <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-    <rdfs:domain rdf:resource="#SACM_ELEMENT"/>
+    <rdfs:domain rdf:resource="#Sacm_Element"/>
   </owl:DatatypeProperty>
   <owl:DatatypeProperty rdf:ID="externalReference">
     <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-    <rdfs:domain rdf:resource="#TERM"/>
+    <rdfs:domain rdf:resource="#Term"/>
   </owl:DatatypeProperty>
   <owl:DatatypeProperty rdf:ID="occurence">
     <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-    <rdfs:domain rdf:resource="#EVENT"/>
+    <rdfs:domain rdf:resource="#Event"/>
   </owl:DatatypeProperty>
   <owl:DatatypeProperty rdf:ID="endTime">
     <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-    <rdfs:domain rdf:resource="#SACM_ACTIVITY"/>
+    <rdfs:domain rdf:resource="#Activity"/>
   </owl:DatatypeProperty>
   <owl:DatatypeProperty rdf:about="#uuid">
     <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-    <rdfs:domain rdf:resource="#ELEMENT"/>
+    <rdfs:domain rdf:resource="#Element"/>
   </owl:DatatypeProperty>
   <owl:DatatypeProperty rdf:ID="artifactDate">
     <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-    <rdfs:domain rdf:resource="#ARTIFACT"/>
+    <rdfs:domain rdf:resource="#Artifact"/>
   </owl:DatatypeProperty>
   <owl:DatatypeProperty rdf:about="#contents">
     <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-    <rdfs:domain rdf:resource="#LANG_STRING"/>
+    <rdfs:domain rdf:resource="#Lang_String"/>
   </owl:DatatypeProperty>
   <owl:DatatypeProperty rdf:ID="assertionDeclaration">
     <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-    <rdfs:domain rdf:resource="#ASSERTION"/>
+    <rdfs:domain rdf:resource="#Assertion"/>
   </owl:DatatypeProperty>
   <owl:DatatypeProperty rdf:about="#val">
     <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-    <rdfs:domain rdf:resource="#EXPRESSION_ELEMENT"/>
+    <rdfs:domain rdf:resource="#Expression_Element"/>
   </owl:DatatypeProperty>
   <owl:DatatypeProperty rdf:about="#isCitation">
     <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-    <rdfs:domain rdf:resource="#SACM_ELEMENT"/>
+    <rdfs:domain rdf:resource="#Sacm_Element"/>
   </owl:DatatypeProperty>
   <owl:DatatypeProperty rdf:ID="isCounter">
     <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-    <rdfs:domain rdf:resource="#ASSERTED_RELATIONSHIP"/>
+    <rdfs:domain rdf:resource="#Asserted_Relationship"/>
   </owl:DatatypeProperty>
 </rdf:RDF>

--- a/LM-Ontology/ontologies/SACM.sadl
+++ b/LM-Ontology/ontologies/SACM.sadl
@@ -6,186 +6,186 @@ import "http://arcos.rack/PROV-S".
 
 /* Base Classes. */
 
-ELEMENT is a type of ENTITY.
-        uuid describes ELEMENT with a single value of type string.
+Element is a type of ENTITY.
+        uuid describes Element with a single value of type string.
 
-MULTI_LANG_STRING
-    is a type of ELEMENT.
-        hasValue describes MULTI_LANG_STRING with values of type LANG_STRING.
+Multi_Lang_String
+    is a type of Element.
+        hasValue describes Multi_Lang_String with values of type Lang_String.
 
-LANG_STRING
-    is a type of ELEMENT.
-        lang describes LANG_STRING with values of type string.
-        lang of LANG_STRING has at most 1 value.
-        contents describes LANG_STRING with values of type string.
-        contents of LANG_STRING has at most 1 value.
+Lang_String
+    is a type of Element.
+        lang describes Lang_String with values of type string.
+        lang of Lang_String has at most 1 value.
+        contents describes Lang_String with values of type string.
+        contents of Lang_String has at most 1 value.
 
-EXPRESSION_LANG_STRING
-    is a type of LANG_STRING.
-        expresses describes EXPRESSION_LANG_STRING with values of type EXPRESSION_ELEMENT.
+Expression_Lang_String
+    is a type of Lang_String.
+        expresses describes Expression_Lang_String with values of type Expression_Element.
 
-SACM_ELEMENT
-    is a type of ELEMENT.
-        gid describes SACM_ELEMENT with values of type string.
-        gid of SACM_ELEMENT has at most 1 value.
-        isCitation describes SACM_ELEMENT with values of type boolean.
-        isCitation of SACM_ELEMENT has at most 1 value.
-        isAbstract describes SACM_ELEMENT with values of type boolean.
-        isAbstract of SACM_ELEMENT has at most 1 value.
-        cites describes SACM_ELEMENT with values of type SACM_ELEMENT.
-        implements describes SACM_ELEMENT with values of type SACM_ELEMENT.
+Sacm_Element
+    is a type of Element.
+        gid describes Sacm_Element with values of type string.
+        gid of Sacm_Element has at most 1 value.
+        isCitation describes Sacm_Element with values of type boolean.
+        isCitation of Sacm_Element has at most 1 value.
+        isAbstract describes Sacm_Element with values of type boolean.
+        isAbstract of Sacm_Element has at most 1 value.
+        cites describes Sacm_Element with values of type Sacm_Element.
+        implements describes Sacm_Element with values of type Sacm_Element.
 
-UTILITY_ELEMENT
-    is a type of SACM_ELEMENT.
-        hasContent describes UTILITY_ELEMENT with values of type MULTI_LANG_STRING.
+Utility_Element
+    is a type of Sacm_Element.
+        hasContent describes Utility_Element with values of type Multi_Lang_String.
 
-TAGGED_VALUE
-    is a type of UTILITY_ELEMENT.
-        hasKey describes TAGGED_VALUE with values of type MULTI_LANG_STRING.
+Tagged_Value
+    is a type of Utility_Element.
+        hasKey describes Tagged_Value with values of type Multi_Lang_String.
 
-NOTE
-    is a type of UTILITY_ELEMENT.
+Note
+    is a type of Utility_Element.
 
-IMPLEMENTATION_CONSTRAINT
-    is a type of UTILITY_ELEMENT.
+Implementation_Constraint
+    is a type of Utility_Element.
 
-DESCRIPTION
-    is a type of UTILITY_ELEMENT.
+Description
+    is a type of Utility_Element.
 
-MODEL_ELEMENT
-    is a type of SACM_ELEMENT.
-        hasTaggedValue describes MODEL_ELEMENT with values of type TAGGED_VALUE.
-        hasImplementationConstraint describes MODEL_ELEMENT with values of type IMPLEMENTATION_CONSTRAINT.
-        hasDescription describes MODEL_ELEMENT with values of type DESCRIPTION.
-        hasNote describes MODEL_ELEMENT with values of type NOTE.
-        hasName describes MODEL_ELEMENT with values of type LANG_STRING.
+Model_Element
+    is a type of Sacm_Element.
+        hasTaggedValue describes Model_Element with values of type Tagged_Value.
+        hasImplementationConstraint describes Model_Element with values of type Implementation_Constraint.
+        hasDescription describes Model_Element with values of type Description.
+        hasNote describes Model_Element with values of type Note.
+        hasName describes Model_Element with values of type Lang_String.
 
-ARTIFACT_ELEMENT
-    is a type of MODEL_ELEMENT.
+Artifact_Element
+    is a type of Model_Element.
 
 /* Assurance Case Package Classes. */
 
-ASSURANCE_CASE_PACKAGE
-    is a type of ARTIFACT_ELEMENT.
-        hasPackage describes ASSURANCE_CASE_PACKAGE with values of type ASSURANCE_CASE_PACKAGE.
-        usesTerminology describes ASSURANCE_CASE_PACKAGE with values of type TERMINOLOGY_PACKAGE.
-        hasArgument describes ASSURANCE_CASE_PACKAGE with values of type ARGUMENT_PACKAGE.
+Assurance_Case_Package
+    is a type of Artifact_Element.
+        hasPackage describes Assurance_Case_Package with values of type Assurance_Case_Package.
+        usesTerminology describes Assurance_Case_Package with values of type Terminology_Package.
+        hasArgument describes Assurance_Case_Package with values of type Argument_Package.
 
 /* TERMinology Classes. */
 
-TERMINOLOGY_ELEMENT
-    is a type of ARTIFACT_ELEMENT.
+Terminology_Element
+    is a type of Artifact_Element.
 
-TERMINOLOGY_PACKAGE
-    is a type of TERMINOLOGY_ELEMENT.
-        hasElement describes TERMINOLOGY_PACKAGE with values of type TERMINOLOGY_ELEMENT.
+Terminology_Package
+    is a type of Terminology_Element.
+        hasElement describes Terminology_Package with values of type Terminology_Element.
 
-TERMINOLOGY_GROUP
-    is a type of TERMINOLOGY_ELEMENT.
-        hasElement describes TERMINOLOGY_GROUP with values of type TERMINOLOGY_ELEMENT.
+Terminology_Group
+    is a type of Terminology_Element.
+        hasElement describes Terminology_Group with values of type Terminology_Element.
 
-TERMINOLOGY_ASSET
-    is a type of TERMINOLOGY_ELEMENT.
+Terminology_Asset
+    is a type of Terminology_Element.
 
-CATEGORY
-    is a type of TERMINOLOGY_ASSET.
+Category
+    is a type of Terminology_Asset.
 
-EXPRESSION_ELEMENT
-    is a type of TERMINOLOGY_ASSET.
-        val describes EXPRESSION_ELEMENT with values of type string.
-        val of EXPRESSION_ELEMENT has at most 1 value.
-        inCategory describes EXPRESSION_ELEMENT with values of type CATEGORY.
+Expression_Element
+    is a type of Terminology_Asset.
+        val describes Expression_Element with values of type string.
+        val of Expression_Element has at most 1 value.
+        inCategory describes Expression_Element with values of type Category.
 
-EXPRESSION
-    is a type of EXPRESSION_ELEMENT.
-        usesElement describes EXPRESSION with values of type EXPRESSION_ELEMENT.
+Expression
+    is a type of Expression_Element.
+        usesElement describes Expression with values of type Expression_Element.
 
-TERM
-    is a type of EXPRESSION_ELEMENT.
-        externalReference describes TERM with values of type string.
-        hasOrigin describes TERM with values of type MODEL_ELEMENT.
+Term
+    is a type of Expression_Element.
+        externalReference describes Term with values of type string.
+        hasOrigin describes Term with values of type Model_Element.
 
 /* Argumentation Classes. */
 
-ARGUMENTATION_ELEMENT
-    is a type of ARTIFACT_ELEMENT.
+Argumentation_Element
+    is a type of Artifact_Element.
 
-ARGUMENT_PACKAGE
-    is a type of ARGUMENTATION_ELEMENT.
-        hasElement describes ARGUMENT_PACKAGE with values of type ARGUMENTATION_ELEMENT.
+Argument_Package
+    is a type of Argumentation_Element.
+        hasElement describes Argument_Package with values of type Argumentation_Element.
         hasElement is a type of wasDerivedFrom.
 
-ARGUMENT_ASSET
-    is a type of ARGUMENTATION_ELEMENT.
-        hasContent describes ARGUMENT_ASSET with values of type MULTI_LANG_STRING.
+Argument_Asset
+    is a type of Argumentation_Element.
+        hasContent describes Argument_Asset with values of type Multi_Lang_String.
 
-ARGUMENT_REASONING
-    is a type of ARGUMENT_ASSET.
+Argument_Reasoning
+    is a type of Argument_Asset.
 
-ARTIFACT_REFERENCE
-    is a type of ARGUMENT_ASSET.
-        references describes ARTIFACT_REFERENCE with values of type ARTIFACT_ELEMENT.
+Artifact_Reference
+    is a type of Argument_Asset.
+        references describes Artifact_Reference with values of type Artifact_Element.
 
-ASSERTION
-    is a type of ARGUMENT_ASSET.
-        assertionDeclaration describes ASSERTION with values of type string.
+Assertion
+    is a type of Argument_Asset.
+        assertionDeclaration describes Assertion with values of type string.
 
-CLAIM
-    is a type of ASSERTION.
+Claim
+    is a type of Assertion.
 
-ASSERTED_RELATIONSHIP
-    is a type of ASSERTION.
-        isCounter describes ASSERTED_RELATIONSHIP with values of type boolean.
-        source describes ASSERTED_RELATIONSHIP with values of type ARGUMENT_ASSET.
+Asserted_Relationship
+    is a type of Assertion.
+        isCounter describes Asserted_Relationship with values of type boolean.
+        source describes Asserted_Relationship with values of type Argument_Asset.
         source is a type of wasDerivedFrom.
-        target describes ASSERTED_RELATIONSHIP with values of type ARGUMENT_ASSET.
+        target describes Asserted_Relationship with values of type Argument_Asset.
         target is a type of wasDerivedFrom.
-        reasoning describes ASSERTED_RELATIONSHIP with values of type ARGUMENT_REASONING.
+        reasoning describes Asserted_Relationship with values of type Argument_Reasoning.
         reasoning is a type of wasDerivedFrom.
 
-ASSERTED_CONTEXT
-    is a type of ASSERTED_RELATIONSHIP.
+Asserted_Context
+    is a type of Asserted_Relationship.
 
-ASSERTED_EVIDENCE
-    is a type of ASSERTED_RELATIONSHIP.
+Asserted_Evidence
+    is a type of Asserted_Relationship.
 
 /* Artifact Classes. */
 
-ARTIFACT_PACKAGE
-    is a type of ARTIFACT_ELEMENT.
+Artifact_Package
+    is a type of Artifact_Element.
 
-ARTIFACT_ASSET
-    is a type of ARTIFACT_ELEMENT.
+Artifact_Asset
+    is a type of Artifact_Element.
 
-PROPERTY
-    is a type of ARTIFACT_ASSET.
+Property
+    is a type of Artifact_Asset.
 
-ARTIFACT_ASSET_RELATIONSHIP
-    is a type of ARTIFACT_ASSET.
-        source describes ARTIFACT_ASSET_RELATIONSHIP with values of type ARTIFACT_ASSET.
+Artifact_Asset_Relationship
+    is a type of Artifact_Asset.
+        source describes Artifact_Asset_Relationship with values of type Artifact_Asset.
         source is a type of wasDerivedFrom.
-        target describes ARTIFACT_ASSET_RELATIONSHIP with values of type ARTIFACT_ASSET.
+        target describes Artifact_Asset_Relationship with values of type Artifact_Asset.
         target is a type of wasDerivedFrom.
 
-ARTIFACT
-    is a type of ARTIFACT_ASSET.
-        artifactVersion describes ARTIFACT with values of type string.
-        artifactDate describes ARTIFACT with values of type string.
+Artifact
+    is a type of Artifact_Asset.
+        artifactVersion describes Artifact with values of type string.
+        artifactDate describes Artifact with values of type string.
 
-SACM_ACTIVITY
-    is a type of ARTIFACT_ASSET.
-        startTime describes SACM_ACTIVITY with values of type string.
-        endTime describes SACM_ACTIVITY with values of type string.
+Activity
+    is a type of Artifact_Asset.
+        startTime describes Activity with values of type string.
+        endTime describes Activity with values of type string.
 
-EVENT
-    is a type of ARTIFACT_ASSET.
-        occurence describes EVENT with values of type string.
+Event
+    is a type of Artifact_Asset.
+        occurence describes Event with values of type string.
 
-PARTICIPANT
-    is a type of ARTIFACT_ASSET.
+Participant
+    is a type of Artifact_Asset.
 
-TECHNIQUE
-    is a type of ARTIFACT_ASSET.
+Technique
+    is a type of Artifact_Asset.
 
-RESOURCE
-    is a type of ARTIFACT_ASSET.
+Resource
+    is a type of Artifact_Asset.

--- a/LM-Ontology/ontologies/SACM.sadl
+++ b/LM-Ontology/ontologies/SACM.sadl
@@ -9,183 +9,183 @@ import "http://arcos.rack/PROV-S".
 Element is a type of ENTITY.
         uuid describes Element with a single value of type string.
 
-Multi_Lang_String
+MultiLangString
     is a type of Element.
-        hasValue describes Multi_Lang_String with values of type Lang_String.
+        hasValue describes MultiLangString with values of type LangString.
 
-Lang_String
+LangString
     is a type of Element.
-        lang describes Lang_String with values of type string.
-        lang of Lang_String has at most 1 value.
-        contents describes Lang_String with values of type string.
-        contents of Lang_String has at most 1 value.
+        lang describes LangString with values of type string.
+        lang of LangString has at most 1 value.
+        contents describes LangString with values of type string.
+        contents of LangString has at most 1 value.
 
-Expression_Lang_String
-    is a type of Lang_String.
-        expresses describes Expression_Lang_String with values of type Expression_Element.
+ExpressionLangString
+    is a type of LangString.
+        expresses describes ExpressionLangString with values of type ExpressionElement.
 
-Sacm_Element
+SacmElement
     is a type of Element.
-        gid describes Sacm_Element with values of type string.
-        gid of Sacm_Element has at most 1 value.
-        isCitation describes Sacm_Element with values of type boolean.
-        isCitation of Sacm_Element has at most 1 value.
-        isAbstract describes Sacm_Element with values of type boolean.
-        isAbstract of Sacm_Element has at most 1 value.
-        cites describes Sacm_Element with values of type Sacm_Element.
-        implements describes Sacm_Element with values of type Sacm_Element.
+        gid describes SacmElement with values of type string.
+        gid of SacmElement has at most 1 value.
+        isCitation describes SacmElement with values of type boolean.
+        isCitation of SacmElement has at most 1 value.
+        isAbstract describes SacmElement with values of type boolean.
+        isAbstract of SacmElement has at most 1 value.
+        cites describes SacmElement with values of type SacmElement.
+        implements describes SacmElement with values of type SacmElement.
 
-Utility_Element
-    is a type of Sacm_Element.
-        hasContent describes Utility_Element with values of type Multi_Lang_String.
+UtilityElement
+    is a type of SacmElement.
+        hasContent describes UtilityElement with values of type MultiLangString.
 
-Tagged_Value
-    is a type of Utility_Element.
-        hasKey describes Tagged_Value with values of type Multi_Lang_String.
+TaggedValue
+    is a type of UtilityElement.
+        hasKey describes TaggedValue with values of type MultiLangString.
 
 Note
-    is a type of Utility_Element.
+    is a type of UtilityElement.
 
-Implementation_Constraint
-    is a type of Utility_Element.
+ImplementationConstraint
+    is a type of UtilityElement.
 
 Description
-    is a type of Utility_Element.
+    is a type of UtilityElement.
 
-Model_Element
-    is a type of Sacm_Element.
-        hasTaggedValue describes Model_Element with values of type Tagged_Value.
-        hasImplementationConstraint describes Model_Element with values of type Implementation_Constraint.
-        hasDescription describes Model_Element with values of type Description.
-        hasNote describes Model_Element with values of type Note.
-        hasName describes Model_Element with values of type Lang_String.
+ModelElement
+    is a type of SacmElement.
+        hasTaggedValue describes ModelElement with values of type TaggedValue.
+        hasImplementationConstraint describes ModelElement with values of type ImplementationConstraint.
+        hasDescription describes ModelElement with values of type Description.
+        hasNote describes ModelElement with values of type Note.
+        hasName describes ModelElement with values of type LangString.
 
-Artifact_Element
-    is a type of Model_Element.
+ArtifactElement
+    is a type of ModelElement.
 
 /* Assurance Case Package Classes. */
 
-Assurance_Case_Package
-    is a type of Artifact_Element.
-        hasPackage describes Assurance_Case_Package with values of type Assurance_Case_Package.
-        usesTerminology describes Assurance_Case_Package with values of type Terminology_Package.
-        hasArgument describes Assurance_Case_Package with values of type Argument_Package.
+AssuranceCasePackage
+    is a type of ArtifactElement.
+        hasPackage describes AssuranceCasePackage with values of type AssuranceCasePackage.
+        usesTerminology describes AssuranceCasePackage with values of type TerminologyPackage.
+        hasArgument describes AssuranceCasePackage with values of type ArgumentPackage.
 
 /* TERMinology Classes. */
 
-Terminology_Element
-    is a type of Artifact_Element.
+TerminologyElement
+    is a type of ArtifactElement.
 
-Terminology_Package
-    is a type of Terminology_Element.
-        hasElement describes Terminology_Package with values of type Terminology_Element.
+TerminologyPackage
+    is a type of TerminologyElement.
+        hasElement describes TerminologyPackage with values of type TerminologyElement.
 
-Terminology_Group
-    is a type of Terminology_Element.
-        hasElement describes Terminology_Group with values of type Terminology_Element.
+TerminologyGroup
+    is a type of TerminologyElement.
+        hasElement describes TerminologyGroup with values of type TerminologyElement.
 
-Terminology_Asset
-    is a type of Terminology_Element.
+TerminologyAsset
+    is a type of TerminologyElement.
 
 Category
-    is a type of Terminology_Asset.
+    is a type of TerminologyAsset.
 
-Expression_Element
-    is a type of Terminology_Asset.
-        val describes Expression_Element with values of type string.
-        val of Expression_Element has at most 1 value.
-        inCategory describes Expression_Element with values of type Category.
+ExpressionElement
+    is a type of TerminologyAsset.
+        val describes ExpressionElement with values of type string.
+        val of ExpressionElement has at most 1 value.
+        inCategory describes ExpressionElement with values of type Category.
 
 Expression
-    is a type of Expression_Element.
-        usesElement describes Expression with values of type Expression_Element.
+    is a type of ExpressionElement.
+        usesElement describes Expression with values of type ExpressionElement.
 
 Term
-    is a type of Expression_Element.
+    is a type of ExpressionElement.
         externalReference describes Term with values of type string.
-        hasOrigin describes Term with values of type Model_Element.
+        hasOrigin describes Term with values of type ModelElement.
 
 /* Argumentation Classes. */
 
-Argumentation_Element
-    is a type of Artifact_Element.
+ArgumentationElement
+    is a type of ArtifactElement.
 
-Argument_Package
-    is a type of Argumentation_Element.
-        hasElement describes Argument_Package with values of type Argumentation_Element.
+ArgumentPackage
+    is a type of ArgumentationElement.
+        hasElement describes ArgumentPackage with values of type ArgumentationElement.
         hasElement is a type of wasDerivedFrom.
 
-Argument_Asset
-    is a type of Argumentation_Element.
-        hasContent describes Argument_Asset with values of type Multi_Lang_String.
+ArgumentAsset
+    is a type of ArgumentationElement.
+        hasContent describes ArgumentAsset with values of type MultiLangString.
 
-Argument_Reasoning
-    is a type of Argument_Asset.
+ArgumentReasoning
+    is a type of ArgumentAsset.
 
-Artifact_Reference
-    is a type of Argument_Asset.
-        references describes Artifact_Reference with values of type Artifact_Element.
+ArtifactReference
+    is a type of ArgumentAsset.
+        references describes ArtifactReference with values of type ArtifactElement.
 
 Assertion
-    is a type of Argument_Asset.
+    is a type of ArgumentAsset.
         assertionDeclaration describes Assertion with values of type string.
 
 Claim
     is a type of Assertion.
 
-Asserted_Relationship
+AssertedRelationship
     is a type of Assertion.
-        isCounter describes Asserted_Relationship with values of type boolean.
-        source describes Asserted_Relationship with values of type Argument_Asset.
+        isCounter describes AssertedRelationship with values of type boolean.
+        source describes AssertedRelationship with values of type ArgumentAsset.
         source is a type of wasDerivedFrom.
-        target describes Asserted_Relationship with values of type Argument_Asset.
+        target describes AssertedRelationship with values of type ArgumentAsset.
         target is a type of wasDerivedFrom.
-        reasoning describes Asserted_Relationship with values of type Argument_Reasoning.
+        reasoning describes AssertedRelationship with values of type ArgumentReasoning.
         reasoning is a type of wasDerivedFrom.
 
-Asserted_Context
-    is a type of Asserted_Relationship.
+AssertedContext
+    is a type of AssertedRelationship.
 
-Asserted_Evidence
-    is a type of Asserted_Relationship.
+AssertedEvidence
+    is a type of AssertedRelationship.
 
 /* Artifact Classes. */
 
-Artifact_Package
-    is a type of Artifact_Element.
+ArtifactPackage
+    is a type of ArtifactElement.
 
-Artifact_Asset
-    is a type of Artifact_Element.
+ArtifactAsset
+    is a type of ArtifactElement.
 
 Property
-    is a type of Artifact_Asset.
+    is a type of ArtifactAsset.
 
-Artifact_Asset_Relationship
-    is a type of Artifact_Asset.
-        source describes Artifact_Asset_Relationship with values of type Artifact_Asset.
+ArtifactAssetRelationship
+    is a type of ArtifactAsset.
+        source describes ArtifactAssetRelationship with values of type ArtifactAsset.
         source is a type of wasDerivedFrom.
-        target describes Artifact_Asset_Relationship with values of type Artifact_Asset.
+        target describes ArtifactAssetRelationship with values of type ArtifactAsset.
         target is a type of wasDerivedFrom.
 
 Artifact
-    is a type of Artifact_Asset.
+    is a type of ArtifactAsset.
         artifactVersion describes Artifact with values of type string.
         artifactDate describes Artifact with values of type string.
 
-Activity
-    is a type of Artifact_Asset.
-        startTime describes Activity with values of type string.
-        endTime describes Activity with values of type string.
+SacmActivity
+    is a type of ArtifactAsset.
+        startTime describes SacmActivity with values of type string.
+        endTime describes SacmActivity with values of type string.
 
 Event
-    is a type of Artifact_Asset.
+    is a type of ArtifactAsset.
         occurence describes Event with values of type string.
 
 Participant
-    is a type of Artifact_Asset.
+    is a type of ArtifactAsset.
 
 Technique
-    is a type of Artifact_Asset.
+    is a type of ArtifactAsset.
 
 Resource
-    is a type of Artifact_Asset.
+    is a type of ArtifactAsset.


### PR DESCRIPTION
I gave the LMCO team wrong advice about capitalization on Classes. All caps are only used on classes in the core ontology. This corrects the casing. Sorry about that!