### PR TITLE
migration: use types-colorama and wheel

### DIFF
--- a/migration/requirements-dev.txt
+++ b/migration/requirements-dev.txt
@@ -3,3 +3,5 @@ mypy~=0.812
 git+https://github.com/matangover/mypyls.git#egg=mypyls
 pylint
 rope
+types-colorama
+wheel

--- a/migration/typeshed/populate_typeshed.sh
+++ b/migration/typeshed/populate_typeshed.sh
@@ -1,5 +1,3 @@
 #!/usr/bin/env sh
 
-stubgen -p colorama -o .
-stubgen -p git -o .
 stubgen -p setuptools -o .


### PR DESCRIPTION
It turns out stubs for `colorama` are hosted, so we don't need to manually generate them ourselves.

I'm also adding `wheel` as a development requirement, since it makes `pip install` happier and is apparently a more modern approach.