### PR TITLE
Fix CI on pull requests from forks

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -91,7 +91,7 @@ jobs:
         path: RACK
 
     - name: Check out RACK wiki
-      if: steps.cache-files.outputs.cache-hit != 'true' && github.repository == 'ge-high-assurance/RACK'
+      if: steps.cache-files.outputs.cache-hit != 'true' && github.event.pull_request.head.repo.full_name == 'ge-high-assurance/RACK'
       uses: actions/checkout@v2
       with:
         repository: ge-high-assurance/RACK.wiki


### PR DESCRIPTION
We don't want continuous.yml to check out RACK wiki on pull requests
from forked repositories since forks can't use secrets.RACK_CI_PAT.
However, if condition doesn't work as expected.  Replace it with
another condition which should work better.