### PR TITLE
See if checkout on PR from fork works

### DIFF
--- a/.github/workflows/actions/download/action.yml
+++ b/.github/workflows/actions/download/action.yml
@@ -48,12 +48,8 @@ runs:
       shell: bash
       run: |
         sudo npm install -g github-wikito-converter markdown-to-html
-        # In case job couldn't check out RACK.wiki
-        mkdir -p RACK.wiki/
-        touch -a RACK.wiki/_Footer.md
         cp RACK.wiki/_Footer.md RACK.wiki/Copyright.md
         gwtc -t RACK-in-a-Box RACK.wiki
-        touch -a RACK.wiki/_Welcome.md
         markdown -t RACK-in-a-box -s style.css RACK.wiki/_Welcome.md > index.html
         sed -i -e 's/>NodeGroupService/ onclick="javascript:event.target.port=12058">NodeGroupService/' index.html
         mv documentation.html index.html RACK/rack-box/files

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -89,7 +89,7 @@ jobs:
         path: RACK
 
     - name: Check out RACK wiki
-      if: ${{ steps.cache-files.outputs.cache-hit != 'true' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == 'ge-high-assurance/RACK') }}
+      if: steps.cache-files.outputs.cache-hit != 'true'
       uses: actions/checkout@v2
       with:
         repository: ge-high-assurance/RACK.wiki


### PR DESCRIPTION
If CI jobs on branches don't need secrets.RACK_CI_PAT to check out
RACK.wiki, then CI jobs on pull requests from forked repositories
should be able to check out RACK.wiki too.  If so, simplify steps.