### PR TITLE
Improve rack-box build steps and instructions

### DIFF
--- a/.github/workflows/actions/download/action.yml
+++ b/.github/workflows/actions/download/action.yml
@@ -18,21 +18,31 @@ runs:
   using: 'composite'
 
   steps:
-    - name: Download Fuseki distribution
+    - name: Download Fuseki release
       shell: bash
       run: curl -LSfs https://archive.apache.org/dist/jena/binaries/apache-jena-fuseki-3.16.0.tar.gz -o RACK/rack-box/files/fuseki.tar.gz
 
-    - name: Download SemTK distribution
+    - name: Download SemTK release
       shell: bash
       run: curl -LSfs https://github.com/ge-semtk/semtk/releases/download/v2.3.0-20210526/semtk-opensource-v2.3.0-20210526-dist.tar.gz -o RACK/rack-box/files/semtk.tar.gz
 
-    - name: Download style spreadsheet
+    - name: Download CSS stylesheet
       shell: bash
       run: curl -LSfs https://github.com/KrauseFx/markdown-to-html-github-style/raw/master/style.css -o RACK/rack-box/files/style.css
 
     - name: Download systemctl script
       shell: bash
       run: curl -LSfs https://github.com/gdraheim/docker-systemctl-replacement/raw/v1.5.4505/files/docker/systemctl3.py -o RACK/rack-box/files/systemctl3.py
+
+    - name: Package RACK ontology and data
+      shell: bash
+      run: |
+        tar cfz RACK/rack-box/files/rack.tar.gz --exclude=.git --exclude=.github --exclude=assist --exclude=cli --exclude=rack-box --exclude=tests --exclude=tools RACK
+
+    - name: Package RACK ASSIST
+      shell: bash
+      run: |
+        tar cfz RACK/rack-box/files/rack-assist.tar.gz RACK/assist
 
     - name: Package RACK CLI
       shell: bash
@@ -44,11 +54,6 @@ runs:
         cd ${{ github.workspace }}
         tar cfz RACK/rack-box/files/rack-cli.tar.gz RACK/cli/{setup-rack.sh,wheels}
 
-    - name: Package RACK ASSIST
-      shell: bash
-      run: |
-        tar cfz RACK/rack-box/files/rack-assist.tar.gz RACK/assist
-
     - name: Package RACK documentation
       shell: bash
       run: |
@@ -58,7 +63,3 @@ runs:
         markdown -t RACK-in-a-box -s style.css RACK.wiki/_Welcome.md > index.html
         sed -i -e 's/>NodeGroupService/ onclick="javascript:event.target.port=12058">NodeGroupService/' index.html
         mv documentation.html index.html RACK/rack-box/files
-
-    - name: Package RACK ontology and data
-      shell: bash
-      run: tar cfz RACK/rack-box/files/rack.tar.gz --exclude=.git --exclude=.github --exclude=assist --exclude=cli --exclude=rack-box --exclude=tests --exclude=tools RACK

--- a/rack-box/README.md
+++ b/rack-box/README.md
@@ -3,12 +3,16 @@
 # RACK-box
 
 This README is for RACK developers and RACK-in-a-Box power users who
-want to know how to build rack-box images.  Normally we let our RACK
-repository's GitHub Actions workflow build rack-box images and push or
-upload them to our [Docker
-Hub](https://hub.docker.com/repository/docker/gehighassurance/rack-box) or
-[GitHub Releases](https://github.com/ge-high-assurance/RACK/releases)
-pages automatically.
+want to build their own rack-box images instead of downloading
+already-built images from our [Docker
+Hub](https://hub.docker.com/repository/docker/gehighassurance/rack-box)
+or [GitHub
+Releases](https://github.com/ge-high-assurance/RACK/releases) pages.
+Note that these already-built images were built automatically by our
+RACK repository's continuous integration and release workflows.
+Please see these [workflows](../.github/workflows) for the most up to
+date way to build rack-box images since this README may be out of
+date.
 
 ## Environment variables needed before building
 
@@ -26,113 +30,100 @@ variables explicitly in your packer build command like this:
 
 ## Files needed before building
 
-You will need to copy the following files into the `files`
-subdirectory before building your rack-box images:
+You will need to download 9 files into the `files` subdirectory before
+building your rack-box images.  Please see the
+[commands](../.github/workflows/actions/download/action.yml) used by
+our workflows for the most up to date way to download these files,
+although we will mention each file here as well:
 
-- `files/fuseki.tar.gz`: latest Fuseki release (download tarball from
-  <https://jena.apache.org/download/> and rename it)
+- `files/fuseki.tar.gz`: Download latest Fuseki release tarball from
+  <https://jena.apache.org/download/> and rename it (note we still are
+  using version 3.16.0, not the latest release, though)
 
-- `files/rack-cli.tar.gz`: A binary distribution of the RACK CLI, see
-  [Build the RACK CLI](#Build-the-RACK-CLI).
+- `files/semtk.tar.gz`: Download latest SemTK release tarball from
+  <https://github.com/ge-semtk/semtk/releases> and rename it
 
-- `files/rack.tar.gz`: A copy of the RACK ontology and data (clone
-  this repo and run `tar cfz RACK/rack-box/files/rack.tar.gz
-  --exclude=.git --exclude=.github --exclude=assist --exclude=cli
-  --exclude=rack-box --exclude=tests --exclude=tools RACK`)
-
-- `files/documentation.html`: RACK documentation (clone RACK.wiki, run
-  `gwtc -t RACK-in-a-Box RACK.wiki/` using [Github Wikito
-  Converter](https://github.com/yakivmospan/github-wikito-converter),
-  and copy `documentation.html`)
-
-- `files/index.html`: RACK box welcome page (clone RACK.wiki, run
-  `markdown -t RACK-in-a-box -s style.css RACK.wiki/Welcome.md >
-  index.html` using
-  [markdown-to-html](https://github.com/cwjohan/markdown-to-html), and
-  copy `index.html`)
-
-- `files/semtk.tar.gz`: latest SemTK binary distribution (download
-  tarball from <https://github.com/ge-semtk/semtk/releases> and rename
-  it)
-
-- `files/style.css`: stylesheet for index.html (visit
+- `files/style.css`: Download latest CSS stylesheet (`style.css`) for
+  rendering markdown from
   [markdown-to-html-github-style](https://github.com/KrauseFx/markdown-to-html-github-style)
-  and download `style.css` under the MIT License)
 
-- `files/systemctl3.py`: entrypoint and init daemon (visit
+- `files/systemctl3.py`: Download latest systemctl script
+  (`files/docker/systemctl3.py`) from
   [docker-systemd-replacement](https://github.com/gdraheim/docker-systemctl-replacement)
-  and download `files/docker/systemctl3.py` under the European Union
-  Public Licence)
 
-Our GitHub Actions workflow automatically downloads these files into
-the GitHub runner's RACK/rack-box/files directory.
+- `files/rack.tar.gz`: Package the RACK ontology and data (`tar cfz
+  RACK/rack-box/files/rack.tar.gz --exclude=.git --exclude=.github
+  --exclude=assist --exclude=cli --exclude=rack-box --exclude=tests
+  --exclude=tools RACK`)
+
+- `files/rack-assist.tar.gz`: Package the RACK ASSIST (`tar cfz
+  RACK/rack-box/files/rack-assist.tar.gz RACK/assist`)
+
+- `files/rack-cli.tar.gz`: Package the RACK CLI (`tar cfz
+  RACK/rack-box/files/rack-cli.tar.gz
+  RACK/cli/{setup-rack.sh,wheels}`), see [Build the RACK
+  CLI](#Build-the-RACK-CLI) for build instructions first
+
+- `files/{documentation.html,index.html}`: Package the RACK
+  documentation, see [Package RACK
+  documentation](#Package-RACK-documentation) for commands
+
+Once you have downloaded these files, skip to [Build the rack-box
+images](#Build-the-rack-box-images) for the next step.
 
 ## Build the RACK CLI
 
-The RACK team has written a RACK [command-line
-interface](https://github.com/ge-high-assurance/RACK/tree/master/cli)
-and a setup-rack.sh script which will build the latest RACK database
-using that command-line interface.  To build a binary distribution of
-the RACK CLI, clone the RACK git repository in your home directory
-($HOME) and run the following commands:
+You will need to install these packages before building the RACK CLI:
 
-<!--
-Note for documentation authors: These instructions should be kept in sync with
-the Github Actions workflows.
--->
+    sudo apt install python3-pip
+    python3 -m pip install --upgrade pip setuptools wheel
 
-```shell
-sudo apt update
-sudo apt install python3-pip
-cd $HOME
-git clone git@github.com:ge-high-assurance/RACK.git
-cd RACK/cli
-python3 -m pip install --upgrade pip setuptools wheel
-pip3 wheel --wheel-dir=wheels -r requirements.txt
-pip3 wheel --wheel-dir=wheels .
-# If you want to install the RACK CLI on your machine...
-#python3 -m pip install wheels/*.whl
-cd $HOME
-tar cfz RACK/rack-box/files/rack-cli.tar.gz RACK/cli/{setup-rack.sh,wheels}
-```
+In the cli directory of your checkout of the RACK repository, run
+these commands to build the RACK CLI:
 
-## ASSIST
+    pip3 wheel --wheel-dir=wheels -r requirements.txt
+    pip3 wheel --wheel-dir=wheels .
 
-The RACK distribution also includes a number of ASSIST tools to
-analyze and verify the RACK data and collect and ingest information
-during the build process.
+## Package RACK documentation
 
-```shell
-sudo add-apt-repository ppa:swi-prolog/stable
-sudo apt-get update
-sudo apt-get install swi-prolog
-cd $HOME
-tar cvz RACK/rack-box/files/rack-assist.tar.gz RACK/assist
-```
+You will need to install two programs, the [Github Wikito
+Converter](https://github.com/yakivmospan/github-wikito-converter) and
+the [markdown-to-html](https://github.com/cwjohan/markdown-to-html):
+
+    sudo npm install -g github-wikito-converter markdown-to-html
+
+In the directory above your checkouts of the RACK and RACK.wiki
+repositories, run these commands:
+
+    cp RACK.wiki/_Footer.md RACK.wiki/Copyright.md
+    gwtc -t RACK-in-a-Box RACK.wiki
+    rm RACK.wiki/Copyright.md
+    markdown -t RACK-in-a-box -s style.css RACK.wiki/_Welcome.md > index.html
+    sed -i -e 's/>NodeGroupService/ onclick="javascript:event.target.port=12058">NodeGroupService/' index.html
+    mv documentation.html index.html RACK/rack-box/files
 
 ## Build the rack-box images
 
 You will need to install [Packer](https://www.packer.io/) if you don't
 have it.  Packer will read instructions from the rack-box JSON files
 and use files in the `files`, `http`, and `scripts` directories to
-build each rack-box image.  The following Packer commands will build
+build the rack-box images.  The following Packer commands will build
 Docker, Hyper-V, and VirtualBox rack-box images:
 
-```shell
-packer build rack-box-docker.json
-packer build rack-box-hyperv.json
-packer build rack-box-virtualbox.json
-```
+    packer build rack-box-docker.json
+    packer build rack-box-hyperv.json
+    packer build rack-box-virtualbox.json
 
-Following these commands, the Docker rack-box image will be added to
-your local Docker images and the Hyper-V & VirtualBox rack-box images
-will be exported to output-hyperv-iso and output-virtualbox-iso
-subdirectories.  You can directly import these subdirectories into new
-virtual machines in your Hyper-V and VirtualBox GUI windows.
+When Packer finishes these build commands, it will save the Docker
+rack-box image in your local Docker image cache and save the Hyper-V &
+VirtualBox rack-box images to new subdirectories called
+`output-hyperv-iso` and `output-virtualbox-iso`.  Your Hyper-V and
+VirtualBox GUI program can import these subdirectories directly into
+newly created virtual machines.
 
 ## Release process
 
-To make a new release, we will need to perform the following steps:
+When it is time to make a new release, perform the following steps:
 
 1. Update version numbers in some files (see the next section).
 2. Tag the RACK wiki with the version tag name since our GitHub
@@ -145,8 +136,8 @@ To make a new release, we will need to perform the following steps:
 
 ## Update documentation pages
 
-Before making a new release, we will need to update version numbers or
-instructions in the following places:
+Before making a new release, update version numbers or instructions in
+the following places:
 
 ### RACK Box
 
@@ -166,19 +157,23 @@ since its pages must go into the rack-box image too.
 
 ## Using `act` to Run CI Locally
 
-The [`act`][act] tool can be used to run (an
+The [act](https://github.com/nektos/act) tool can be used to run (an
 approximation of) the Github Actions workflow locally:
 
-- Download a binary release of Packer for Ubuntu, and place the `packer`
-  executable in the `rack-box/` directory.
+- Download a binary release of Packer for Ubuntu, and place the
+  `packer` executable in the `rack-box/` directory
 - Install `act`
-- Generate a Github [personal access token][PAT] (PAT)
-- Create a `.secrets` file containing `GITHUB_TOKEN=<your-github-PAT-here>`
-- Run `act --secret-file .secrets -P ubuntu-latest=nektos/act-environments-ubuntu:18.04`
+- Generate a Github [personal access
+  token](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token)
+- Create a `.secrets` file containing
+  `GITHUB_TOKEN=<your-github-PAT-here>`
+- Run `act --secret-file .secrets -P
+  ubuntu-latest=nektos/act-environments-ubuntu:18.04`
 
 The Docker image `nektos/act-environments-ubuntu:18.04` is quite large
-(approximately 18GB), so (1) you'll need enough free disk space to store it and
-(2) the first execution of `act` takes a while because it downloads this image.
+(approximately 18GB), so (1) you'll need enough free disk space to
+store it and (2) the first execution of `act` takes a while because it
+downloads this image.
 
 Unfortunately, `act` [does not yet support Ubuntu
 20.04](https://github.com/nektos/act-environments/issues/4).
@@ -189,17 +184,13 @@ Unfortunately, `act` [does not yet support Ubuntu
 
 If you see a message like this:
 
-```text
-Error: Error response from daemon: remove act-Build-Lint-shell-scripts-and-the-RACK-CLI: volume is in use
-```
+    Error: Error response from daemon: remove act-Build-Lint-shell-scripts-and-the-RACK-CLI: volume is in use
 
 You can forcibly stop and remove the `act` Docker containers and their volumes:
 
-```bash
-docker stop $(docker ps -a | grep "nektos/act-environments-ubuntu:18.04" | awk '{print $1}')
-docker rm $(docker ps -a | grep "nektos/act-environments-ubuntu:18.04" | awk '{print $1}')
-docker volume rm $(docker volume ls --filter dangling=true | grep -o -E "act-.+$")
-```
+    docker stop $(docker ps -a | grep "nektos/act-environments-ubuntu:18.04" | awk '{print $1}')
+    docker rm $(docker ps -a | grep "nektos/act-environments-ubuntu:18.04" | awk '{print $1}')
+    docker volume rm $(docker volume ls --filter dangling=true | grep -o -E "act-.+$")
 
 There may also be a more precise solution to this issue, but the above works.
 
@@ -207,9 +198,6 @@ There may also be a more precise solution to this issue, but the above works.
 
 `act` needs to be run with enough privileges to run Docker containers. Try
 `sudo -g docker act ...` (or an equivalent invocation for your OS/distro).
-
-[act]: (https://github.com/nektos/act)
-[PAT]: https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token
 
 ---
 Copyright (c) 2021, General Electric Company, Galois, Inc.

--- a/rack-box/http/user-data
+++ b/rack-box/http/user-data
@@ -11,6 +11,10 @@ autoinstall:
   storage:
     layout:
       name: direct
+  apt:
+    sources:
+      swi-prolog:
+        source: "ppa:swi-prolog/stable"
   ssh:
     install-server: true
   packages:
@@ -19,6 +23,7 @@ autoinstall:
     - nginx-light
     - python3
     - python3-pip
+    - swi-prolog
     - unzip
   late-commands:
     - echo 'ubuntu ALL=(ALL) NOPASSWD:ALL' > /target/etc/sudoers.d/ubuntu

--- a/rack-box/scripts/clean.sh
+++ b/rack-box/scripts/clean.sh
@@ -19,16 +19,14 @@ if [ "${PACKER_BUILDER_TYPE}" == "hyperv-iso" ]; then
     cd /usr/libexec/hypervkvpd
     ln -s /usr/sbin/hv_get_dhcp_info .
     ln -s /usr/sbin/hv_get_dns_info .
-else
+elif dpkg -l | grep -q linux-cloud-tools-virtual; then
     apt-get remove -yqq linux-cloud-tools-virtual
     apt-get autoremove -yqq # remaining linux-cloud-tools packages
 fi
 
-# Upgrade all packages, also install swi-prolog
+# Upgrade all packages
 
-add-apt-repository ppa:swi-prolog/stable
 apt-get update -yqq
-apt-get install -yqq swi-prolog
 apt-get upgrade -yqq
 
 # Clean apt cache and temporary files

--- a/rack-box/scripts/install.sh
+++ b/rack-box/scripts/install.sh
@@ -10,13 +10,27 @@ cd /tmp/files
 
 if [ "${PACKER_BUILDER_TYPE}" == "docker" ]; then
 
-    # Install necessary packages
+    # Install necessary packages non-interactively
 
     export DEBIAN_FRONTEND=noninteractive
     export DEBCONF_NONINTERACTIVE_SEEN=true
-
     apt-get update -yqq
-    apt-get install -yqq curl default-jre gettext-base nano nginx-light python3 python3-pip software-properties-common unzip
+    apt-get install -yqq software-properties-common
+    add-apt-repository -yu ppa:swi-prolog/stable
+
+    # If you change this, change packages in rack-box/http/user-data too
+    # Note VM image already has curl, gettext-base, nano, etc.
+
+    apt-get install -yqq \
+            curl \
+            default-jre \
+            gettext-base \
+            nano \
+            nginx-light \
+            python3 \
+            python3-pip \
+            swi-prolog \
+            unzip
 
     # Install docker-systemctl-replaement
 
@@ -38,10 +52,10 @@ rm fuseki.tar.gz
 mv /opt/apache-jena-fuseki-* /opt/fuseki
 tar xfzC rack.tar.gz "/home/${USER}"
 rm rack.tar.gz
-tar xfzC rack-cli.tar.gz "/home/${USER}"
-rm rack-cli.tar.gz
 tar xfzC rack-assist.tar.gz "/home/${USER}"
 rm rack-assist.tar.gz
+tar xfzC rack-cli.tar.gz "/home/${USER}"
+rm rack-cli.tar.gz
 tar xfzC semtk.tar.gz "/home/${USER}"
 rm semtk.tar.gz
 mv ENV_OVERRIDE "/home/${USER}/semtk-opensource"


### PR DESCRIPTION
action.yml: Reorder some steps to be consistent with instructions in
README.md.

README.md: Update instructions for downloading all files
needed to build rack-box image and make them clearer, especially how
to package the RACK documentation.

user-data: Add ppa:swi-prolog/stable to apt sources and install
swi-prolog in VM images.

clean.sh: Turn else branch into an elif branch in case
linux-cloud-tools-virtual isn't installed.  Remove commands to install
swi-prolog (they should be in user-data and install.sh, not here).

install.sh: Add ppa:swi-prolog/stable to apt sources and install
swi-prolog in Docker images.  Add comment for maintainers to keep
package lists consistent between user-data and install.sh (that is,
between VM and Docker images).