### PR TITLE
assist: write_ontology now exports RDF assertions

### DIFF
--- a/assist/bin/rack/model.pl
+++ b/assist/bin/rack/model.pl
@@ -43,6 +43,8 @@ description DSL into instances in the model.
               property/3,
               property_target/5,
               rack_instance/2,
+              rack_instance_assert/2,
+              rack_property_assert/3,
               rack_entity_instance/1,
               rack_entity_instance/3,
               rack_ontology_node/3,
@@ -484,6 +486,12 @@ rack_instance(OntologyClassName, InstanceURL) :-
     rack_ref(OntologyClassName, Ref),
     rdf(InstanceURL, rdf:type, Ref).
 
+rack_instance_assert(OntologyClassName, InstanceURL) :-
+    rack_ref(OntologyClassName, Ref),
+    add_triple(InstanceURL, rdf:type, Ref).
+
+rack_property_assert(Source, Property, Target) :-
+    add_triple(Source, Property, Target).
 
 %! rack_entity_instance(-InstanceURL:atom) is nondet
 %

--- a/assist/bin/rack/write_ontology.pl
+++ b/assist/bin/rack/write_ontology.pl
@@ -161,7 +161,8 @@ write_exports(Handle, Indent, Classes, Properties) :-
 
 %! class_query_declaration(+Namespace, +Class, -Declaration) is det.
 %
-%    Computes the text declaration for a given class in some namespace.
+%    Computes the text declaration for the RDF query of a given class in some
+%    namespace.
 class_query_declaration(Namespace, Class, Declaration) :-
     string_lower(Class, Predicate),
     atomic_list_concat(
@@ -172,7 +173,8 @@ class_query_declaration(Namespace, Class, Declaration) :-
 
 %! class_assert_declaration(+Namespace, +Class, -Declaration) is det.
 %
-%    Computes the text declaration for a given class in some namespace.
+%    Computes the text declaration for the RDF assertion of a given class in
+%    some namespace.
 class_assert_declaration(Namespace, Class, Declaration) :-
     string_lower(Class, PredicateSuffix),
     atomic_list_concat(['assert_', PredicateSuffix], Predicate),
@@ -184,7 +186,8 @@ class_assert_declaration(Namespace, Class, Declaration) :-
 
 %! write_class_query(+Handle, +Namespace, +Class) is det.
 %
-%    Writes the text declaration for a given class in some namespace.
+%    Writes the text declaration for the RDF query of a given class in some
+%    namespace.
 write_class_query(Handle, Namespace, Class) :-
     class_query_declaration(Namespace, Class, Declaration),
     writeln(Handle, Declaration).
@@ -192,7 +195,8 @@ write_class_query(Handle, Namespace, Class) :-
 
 %! write_class_assert(+Handle, +Namespace, +Class) is det.
 %
-%    Writes the text declaration for a given class in some namespace.
+%    Writes the text declaration for the RDF query of a given class in some
+%    namespace.
 write_class_assert(Handle, Namespace, Class) :-
     class_assert_declaration(Namespace, Class, Declaration),
     writeln(Handle, Declaration).
@@ -283,12 +287,16 @@ write_ontology_file(Namespace, Classes, Properties) :-
     writeln(Handle, '    ]'),
     writeln(Handle, ').'),
     nl(Handle),
+    writeln(Handle, '% Assert RACK classes: always succeeds, adding to the database.'),
     forall(member(Class, Classes), write_class_assert(Handle, Namespace, Class)),
     nl(Handle),
+    writeln(Handle, '% Query RACK classes: returns existing instances in the database, if any.'),
     forall(member(Class, Classes), write_class_query(Handle, Namespace, Class)),
     nl(Handle),
+    writeln(Handle, '% Assert RACK properties: always succeeds, adding to the database.'),
     forall(member(Property, Properties), write_property_assert(Handle, Namespace, Property)),
     nl(Handle),
+    writeln(Handle, '% Query RACK properties: returns existing instances in the database, if any.'),
     forall(member(Property, Properties), write_property_query(Handle, Namespace, Property)),
     close(Handle),
     % let the user know which files are being written


### PR DESCRIPTION
The previous write_ontology exported what I refer to as RDF queries for each
class and property, that is, a Prolog predicate that allows one to retrieve
instances of a class of property that are registered within the database.

This adds a notion of RDF assertions for each class and property, allowing one
to register new data in the database.  As usual, this was already doable via
the ASSIST tooling, this commit just adds convenience operators for
RACK-specific data.