### PR TITLE
assist: fix write_ontology handling of dashes in modules

### DIFF
--- a/assist/bin/rack/write_ontology.pl
+++ b/assist/bin/rack/write_ontology.pl
@@ -168,6 +168,16 @@ write_property(Handle, Namespace, Property) :-
     property_declaration(Namespace, Property, Declaration),
     writeln(Handle, Declaration).
 
+
+%! use_quotes_if_contains_dashes(+In, -Out) is det.
+%
+%    Adds single quotes around input string if it contains dashes.
+use_quotes_if_contains_dashes(Good, Good) :-
+    \+ sub_string(Good, _, 1, _, '-').
+use_quotes_if_contains_dashes(Bad, Good) :-
+    sub_string(Bad, _, 1, _, '-'), atomic_list_concat(['\'', Bad, '\''], Good).
+
+
 %! write_ontolofy_file(+Handle, +Namespace, +Things, +Properties) is det.
 %
 %    Writes the ontology file for a given namespace, list of ontology things,
@@ -175,7 +185,13 @@ write_property(Handle, Namespace, Property) :-
 write_ontology_file(Namespace, Things, Properties) :-
     ontology_file_path(Namespace, FilePath),
     open(FilePath, write, Handle),
-    string_lower(Namespace, Module),
+    % trick for "function composition"
+    foldl(
+        call,
+        [string_lower, use_quotes_if_contains_dashes],
+        Namespace,
+        Module
+    ),
     writeln(Handle, '% THIS FILE WAS AUTOMATICALLY GENERATED, SEE README'),
     nl(Handle),
     writeln(Handle, ':- module('),


### PR DESCRIPTION
Prolog modules must declare their name as a Prolog atom.  Unfortunately, dashes
in atoms have a special meaning, and so atoms whose name must contain dashes
have to be properly quoted.

write_ontology was generating such a module named prov-s for PROV-S.owl, and so
the generated Prolog file was incorrect.  This changes makes sure that we add
quotes around such names when they contain dashes, thus generating 'prov-s'
which is a correct atom.