### PR TITLE
[ASSIST-DV] Skip various background data instances.

### DIFF
--- a/assist/bin/rack/check.pl
+++ b/assist/bin/rack/check.pl
@@ -179,7 +179,12 @@ actual_val(V,VT,Val) :-
     Val = VN^^VT.
 
 has_interesting_prefix(I) :-
-    member(Pfx, [ 'http://sadl.org/' ]),
+    member(Pfx, [ 'http://sadl.org/',
+                  'http://com.ge.research/',
+                  'http://demo/',
+                  'http://research.ge.com/',
+                  'http://semtk.research.ge.com/'
+                ]),
     atom_concat(Pfx, _Local, I), !, fail.
 has_interesting_prefix(_).
 


### PR DESCRIPTION
These seem to be generated from SemTK and/or SADL builtins.
This is a workaround for issue #424.
