### PR TITLE
migration: include v7.0 tag

### DIFF
--- a/migration/rack/commits/__init__.py
+++ b/migration/rack/commits/__init__.py
@@ -19,13 +19,16 @@ from rack.commits import (
     commit0a89f70ff929380269a79fe2fc82f5dde346ed8c,
     commit10da69db606ebdc721fd3f8e003ef2099a5fdc43,
     commit13ed266ba5730cebe75c0c48f6ba83af69429122,
+    commit183dbba72623c2585a0451a19ac1ddb30f8a0ea6,
     commit2e079bb2a32b3cc1b3153d44ad0c21e27507937f,
     commit389424cb974164f552b6b6bf8aab504d23bf079b,
     commit44393cc30bb0ba7482acd21b2e68576b577179f9,
     commit44da44c6877c881240c418d084ecb17de9443373,
     commit4f60f85168ff8ef2513fa0e2f144c2ea5c3f87a3,
     commit4f9fce78e36a6dc75f1702ab50da6a4ac801dd5e,
+    commit5329c949815afea87d8bae3768bf132258aad9a0,
     commit581f1820855eee2445d9e8bfdbb639e169e9391e,
+    commit620b89db747b9834013502061040f179da67f123,
     commit643839e7d8036731ba1da767942c8e74c2876e2e,
     commit7202dbdb81274e521b0e2cdd3afedeb2a6204567,
     commit76de25ee930683871febc1b4cc1e4386aca16d42,
@@ -37,9 +40,11 @@ from rack.commits import (
     commita95a46dec5162e65979d96ba140559dfb3013d23,
     commitae0a7660b0afdd53ff334577fbdea7749abe6cf6,
     commitb25d07626e4693cd370a2070e17f6baa825a1d43,
+    commitb6796936abe054edc9c4f9657c34bb0eadf0757a,
     commitb721c16f0f7420a8ccd92bda0d98a96c16dc62b8,
     commitbdfef3d7ea9b3c9fc085defa8e26256f646097d9,
     commitc6692fed3e150e7df53d4a2a8f8c84f760087420,
+    commitcafce30763b5332106340cc8cbeb8fdac3b8132d,
     commitd48e208669c589d070c7c5fb7e3129ababbb9193,
     commitd8271d216704351cf0007a04abac47f4abc993ad,
     commite18de6ebaa298881aab7e8e69580905ffb97e0c4,
@@ -106,6 +111,13 @@ commits_in_chronological_order: List[Commit] = [
     commit4f60f85168ff8ef2513fa0e2f144c2ea5c3f87a3.commit, # v5.9
 
     commit76de25ee930683871febc1b4cc1e4386aca16d42.commit, # v6.0
+
+    commit183dbba72623c2585a0451a19ac1ddb30f8a0ea6.commit, # 2021 May 21
+    commit5329c949815afea87d8bae3768bf132258aad9a0.commit, # 2021 May 21
+    commit620b89db747b9834013502061040f179da67f123.commit, # 2021 May 25
+    commitb6796936abe054edc9c4f9657c34bb0eadf0757a.commit, # 2021 May 26
+
+    commitcafce30763b5332106340cc8cbeb8fdac3b8132d.commit, # v7.0
 
     # most recent (in history)
 ]

--- a/migration/rack/commits/commit183dbba72623c2585a0451a19ac1ddb30f8a0ea6.py
+++ b/migration/rack/commits/commit183dbba72623c2585a0451a19ac1ddb30f8a0ea6.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2021, Galois, Inc.
+#
+# All Rights Reserved
+#
+# This material is based upon work supported by the Defense Advanced Research
+# Projects Agency (DARPA) under Contract No. FA8750-20-C-0203.
+#
+# Any opinions, findings and conclusions or recommendations expressed in this
+# material are those of the author(s) and do not necessarily reflect the views
+# of the Defense Advanced Research Projects Agency (DARPA).
+
+from migration_helpers.name_space import rack
+from ontology_changes import ChangePropertyRange, Commit, RenameProperty
+
+FILE = rack("FILE")
+PROV_S = rack("PROV-S")
+
+commit = Commit(
+    number="183dbba72623c2585a0451a19ac1ddb30f8a0ea6",
+    changes=[
+        RenameProperty(
+            from_name_space=FILE,
+            from_class="THING",
+            from_name="definedIn",
+            to_name_space=PROV_S,
+            to_class="ENTITY",
+            to_name="definedIn",
+        ),
+        ChangePropertyRange(
+            prop_name_space=FILE,
+            prop_name="definedIn",
+            from_name_space=FILE,
+            from_range="FILE",
+            to_name_space=PROV_S,
+            to_range="ENTITY",
+        ),
+    ],
+)

--- a/migration/rack/commits/commit5329c949815afea87d8bae3768bf132258aad9a0.py
+++ b/migration/rack/commits/commit5329c949815afea87d8bae3768bf132258aad9a0.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2021, Galois, Inc.
+#
+# All Rights Reserved
+#
+# This material is based upon work supported by the Defense Advanced Research
+# Projects Agency (DARPA) under Contract No. FA8750-20-C-0203.
+#
+# Any opinions, findings and conclusions or recommendations expressed in this
+# material are those of the author(s) and do not necessarily reflect the views
+# of the Defense Advanced Research Projects Agency (DARPA).
+
+from ontology_changes import Commit
+
+commit = Commit(
+    number="5329c949815afea87d8bae3768bf132258aad9a0",
+    changes=[
+        # Nothing: note changed
+    ],
+)

--- a/migration/rack/commits/commit620b89db747b9834013502061040f179da67f123.py
+++ b/migration/rack/commits/commit620b89db747b9834013502061040f179da67f123.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2021, Galois, Inc.
+#
+# All Rights Reserved
+#
+# This material is based upon work supported by the Defense Advanced Research
+# Projects Agency (DARPA) under Contract No. FA8750-20-C-0203.
+#
+# Any opinions, findings and conclusions or recommendations expressed in this
+# material are those of the author(s) and do not necessarily reflect the views
+# of the Defense Advanced Research Projects Agency (DARPA).
+
+from migration_helpers.name_space import rack
+from ontology_changes import ChangePropertyRange, Commit, RenameProperty
+
+FILE = rack("FILE")
+PROV_S = rack("PROV-S")
+
+commit = Commit(
+    number="620b89db747b9834013502061040f179da67f123",
+    changes=[
+        RenameProperty(
+            from_name_space=PROV_S,
+            from_class="ENTITY",
+            from_name="definedIn",
+            to_name_space=FILE,
+            to_class="THING",
+            to_name="definedIn",
+        ),
+        ChangePropertyRange(
+            prop_name_space=FILE,
+            prop_name="definedIn",
+            from_name_space=PROV_S,
+            from_range="ENTITY",
+            to_name_space=FILE,
+            to_range="FILE",
+        ),
+    ],
+)

--- a/migration/rack/commits/commitb6796936abe054edc9c4f9657c34bb0eadf0757a.py
+++ b/migration/rack/commits/commitb6796936abe054edc9c4f9657c34bb0eadf0757a.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2021, Galois, Inc.
+#
+# All Rights Reserved
+#
+# This material is based upon work supported by the Defense Advanced Research
+# Projects Agency (DARPA) under Contract No. FA8750-20-C-0203.
+#
+# Any opinions, findings and conclusions or recommendations expressed in this
+# material are those of the author(s) and do not necessarily reflect the views
+# of the Defense Advanced Research Projects Agency (DARPA).
+
+from ontology_changes import Commit
+
+commit = Commit(
+    number="b6796936abe054edc9c4f9657c34bb0eadf0757a",
+    changes=[
+        # Nothing: changes to ARP-4754A
+    ],
+)

--- a/migration/rack/commits/commitcafce30763b5332106340cc8cbeb8fdac3b8132d.py
+++ b/migration/rack/commits/commitcafce30763b5332106340cc8cbeb8fdac3b8132d.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2021, Galois, Inc.
+#
+# All Rights Reserved
+#
+# This material is based upon work supported by the Defense Advanced Research
+# Projects Agency (DARPA) under Contract No. FA8750-20-C-0203.
+#
+# Any opinions, findings and conclusions or recommendations expressed in this
+# material are those of the author(s) and do not necessarily reflect the views
+# of the Defense Advanced Research Projects Agency (DARPA).
+
+from ontology_changes import Commit
+
+commit = Commit(
+    number="76de25ee930683871febc1b4cc1e4386aca16d42",
+    tag="v7.0",
+    changes=[
+        # no ontology change, just here for the tag
+    ],
+)

--- a/migration/rack_crawl/crawler.py
+++ b/migration/rack_crawl/crawler.py
@@ -86,7 +86,7 @@ def add_commit_to_list_of_all_commits(commits_file: str, commit_id: str) -> None
         if "<CHANGE_CRAWLER_IMPORTS>" in line:
             sys.stdout.write(f"    commit{commit_id},\n")
         if "<CHANGE_CRAWLER_COMMITS>" in line:
-            sys.stdout.write(f"    commit{commit_id}.commit,  # FIXME: ORGANIZE ME\n")
+            sys.stdout.write(f"    commit{commit_id}.commit, # FIXME: ORGANIZE ME\n")
 
 
 def is_ontology_file(file: str) -> bool:


### PR DESCRIPTION
I had prepared this but was waiting to see the `v7.0` tag and then didn't end up pushing it.

This adds the migration steps for `v7.0` (fortunately, they're effectively a no-op).