### PR TITLE
prolog: update listing of files for documentation purposes

### DIFF
--- a/assist/bin/documentation/serve.pl
+++ b/assist/bin/documentation/serve.pl
@@ -14,22 +14,30 @@
 :- doc_server(4040).
 :- portray_text(true).
 
-:- load_files(checks(bdu)).
-
-:- load_files(ontology(hazard)).
-:- load_files(ontology(requirements)).
-:- load_files(ontology(testing)).
-
-:- load_files(queries(hazard_structure)).
+% Documentation for ontology generated files, if any.
+:-
+    paths_dir(Paths),
+    directory_file_path(Paths, 'ontology', OntologyDir),
+    directory_files(OntologyDir, Files),
+    forall(
+        (
+            member(OntologyFile, Files),
+            sub_atom(OntologyFile, DotPosition, _, _, '.pl'),
+            sub_atom(OntologyFile, 0, DotPosition, _, ModuleName)
+        ),
+        load_files(ontology(ModuleName))
+    ).
 
 :- load_files(rack(analyze)).
 :- load_files(rack(check)).
-:- load_files(rack(write_ontology)).
 :- load_files(rack(model)).
+:- load_files(rack(write_ontology)).
 
+:- load_files(utils(float_equality)).
 :- load_files(utils(transitive_closure)).
 :- load_files(utils(zip_by_key)).
 
-:- load_files(visualization(my_dot_arc)).
-:- load_files(visualization(my_dot_node)).
-:- load_files(visualization(view_neighbors)).
+% These are currently not maintained, so rather not advertised.
+% :- load_files(visualization(my_dot_arc)).
+% :- load_files(visualization(my_dot_node)).
+% :- load_files(visualization(view_neighbors)).


### PR DESCRIPTION
The Prolog documentation was assuming that ontology files were generated, and
was also quite outdated.  This commit makes it so that only existing generated
files are listed, and removes from the listing files that were only part of
exploratory work but are no longer relevant or maintained.

This almost fixes #472 , there is just another stupid Prolog detail covered by my next PR.