### PR TITLE
add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.owl -diff -merge
+nodegroups/ingestion/*/ingest_*.json -diff -merge
+nodegroups/queries/*/query*.json -diff -merge


### PR DESCRIPTION
Proposal: a `.gitattributes` file allows one to mark some files as "should not display diff" and/or "should not use usual merge techniques".

Advantages:

- Much less noise in reviewing commits.

Drawbacks:

- Need to curate the list of what is considered not human-friendly.
- git-based tools assume that these flags are used for binary files, so they will display messages such as "Binary files differ" when the files are, technically, not binary files.

Open to discussion as to whether this is a good idea, and what files ought to be hidden or displayed.
For instance, I'm currently leaving the ingestion CSVs (are those what are referred to as CDRs?), since they are somewhat human-readable and fairly short, but I'm open to also hiding them as they are derived from an authoritative human-readable source.

Note that this change does not address the issue of keeping these files up to date.