### PR TITLE
Assist test results

### DIFF
--- a/Turnstile-Ontology/02-Software/03-Implementation/Makefile
+++ b/Turnstile-Ontology/02-Software/03-Implementation/Makefile
@@ -31,7 +31,7 @@ $(TESTEXE): test.c test.h $(EXE)
 
 .PHONY: test
 test: $(TESTEXE)
-	./$(TESTEXE)
+	rack_capture ./$(TESTEXE)
 
 .PHONY: clean
 clean:

--- a/Turnstile-Ontology/02-Software/turnstile-ingest.rack
+++ b/Turnstile-Ontology/02-Software/turnstile-ingest.rack
@@ -4,13 +4,16 @@
 
 :- multifile data_instance/4, data_get/4.
 
+turnstile_ns(Elem, URI) :-
+    atom_concat('http://arcos.turnstile/GE/', Elem, URI).
+
 % The DevelopmentPlan specifies that SOFTWARE#CODE_DEVELOPMENT
 % references the plan-defined SoftwareStandard.  This is an
 % abstract/documentation linkage that is established by this rule.
 
-data_get('SOFTWARE#CODE_DEVELOPMENT', 'SOFTWARE#referenced',
-         sw_devel(_,_,_),
-         'http://Turnstile/DevelopmentPlanData#SoftwareStandard').
+data_get('SOFTWARE#CODE_DEVELOPMENT', 'SOFTWARE#referenced', sw_devel(_,_,_),
+         Value) :-
+    turnstile_ns('DevelopmentPlanData#SoftwareStandard', Value).
 
 
 % The DevelopmentPlan creates a SoftwareIntegration as an instance of
@@ -29,10 +32,10 @@ data_get('SOFTWARE#COMPILE', 'PROV-S#identifier', uid(Instance,_,_), Identifier)
 % Explicit links between software files and documented requirements.
 % These cannot be automatically discovered and are project specific.
 
-data_get('FILE#FILE', 'FILE#satisfies', sw_file_data(_,_,'output.h'),
-         'http://Turnstile/CounterApplicationDesignDescription#OUT-LLR-1').
-data_get('FILE#FILE', 'FILE#satisfies', sw_file_data(_,_,'output.h'),
-         'http://Turnstile/CounterApplicationDesignDescription#OUT-LLR-2').
+data_get('FILE#FILE', 'FILE#satisfies', sw_file_data(_,_,'output.h'), Value) :-
+    turnstile_ns('CounterApplicationDesignDescription#OUT-LLR-1', Value).
+data_get('FILE#FILE', 'FILE#satisfies', sw_file_data(_,_,'output.h'), Value) :-
+    turnstile_ns('CounterApplicationDesignDescription#OUT-LLR-2', Value).
 
 data_get(_, 'SOFTWARE#definedIn', func_decl(_, FileName), FileRef) :-
     build_inputs(Nonce, InpSources),
@@ -40,25 +43,25 @@ data_get(_, 'SOFTWARE#definedIn', func_decl(_, FileName), FileRef) :-
     member(FileName, InpSources),
     file_instance(Nonce, Dir, FileName, FileRef).
 
-data_get('FILE#FILE', 'FILE#satisfies', sw_file_data(_,_,'hw.h'),
-         'http://Turnstile/CounterApplicationDesignDescription#IN-LLR-1').
-data_get('FILE#FILE', 'FILE#satisfies', sw_file_data(_,_,'hw.h'),
-         'http://Turnstile/CounterApplicationDesignDescription#IN-LLR-2').
-data_get('FILE#FILE', 'FILE#satisfies', sw_file_data(_,_,'hw.h'),
-         'http://Turnstile/CounterApplicationDesignDescription#IN-LLR-3').
-data_get('FILE#FILE', 'FILE#satisfies', sw_file_data(_,_,'hw.h'),
-         'http://Turnstile/CounterApplicationDesignDescription#IN-LLR-4').
-data_get('FILE#FILE', 'FILE#satisfies', sw_file_data(_,_,'hw.h'),
-         'http://Turnstile/CounterApplicationDesignDescription#IN-LLR-5').
-data_get('FILE#FILE', 'FILE#satisfies', sw_file_data(_,_,'hw.h'),
-         'http://Turnstile/CounterApplicationDesignDescription#IN-LLR-6').
+data_get('FILE#FILE', 'FILE#satisfies', sw_file_data(_,_,'hw.h'), Value) :-
+    turnstile_ns('CounterApplicationDesignDescription#IN-LLR-1', Value).
+data_get('FILE#FILE', 'FILE#satisfies', sw_file_data(_,_,'hw.h'), Value) :-
+    turnstile_ns('CounterApplicationDesignDescription#IN-LLR-2', Value).
+data_get('FILE#FILE', 'FILE#satisfies', sw_file_data(_,_,'hw.h'), Value) :-
+    turnstile_ns('CounterApplicationDesignDescription#IN-LLR-3', Value).
+data_get('FILE#FILE', 'FILE#satisfies', sw_file_data(_,_,'hw.h'), Value) :-
+    turnstile_ns('CounterApplicationDesignDescription#IN-LLR-4', Value).
+data_get('FILE#FILE', 'FILE#satisfies', sw_file_data(_,_,'hw.h'), Value) :-
+    turnstile_ns('CounterApplicationDesignDescription#IN-LLR-5', Value).
+data_get('FILE#FILE', 'FILE#satisfies', sw_file_data(_,_,'hw.h'), Value) :-
+    turnstile_ns('CounterApplicationDesignDescription#IN-LLR-6', Value).
 
-data_get('FILE#FILE', 'FILE#satisfies', sw_file_data(_,_,'counter.h'),
-         'http://Turnstile/CounterApplicationDesignDescription#EXE-LLR-1').
-data_get('FILE#FILE', 'FILE#satisfies', sw_file_data(_,_,'counter.h'),
-         'http://Turnstile/CounterApplicationDesignDescription#EXE-LLR-2').
-data_get('FILE#FILE', 'FILE#satisfies', sw_file_data(_,_,'counter.h'),
-         'http://Turnstile/CounterApplicationDesignDescription#EXE-LLR-3').
+data_get('FILE#FILE', 'FILE#satisfies', sw_file_data(_,_,'counter.h'), V) :-
+    turnstile_ns('CounterApplicationDesignDescription#EXE-LLR-1', V).
+data_get('FILE#FILE', 'FILE#satisfies', sw_file_data(_,_,'counter.h'), V) :-
+    turnstile_ns('CounterApplicationDesignDescription#EXE-LLR-2', V).
+data_get('FILE#FILE', 'FILE#satisfies', sw_file_data(_,_,'counter.h'), V) :-
+    turnstile_ns('CounterApplicationDesignDescription#EXE-LLR-3', V).
 
 % Generate explicit links between the automatically-recognized input
 % files and the corresponding software functions and data declared in

--- a/Turnstile-Ontology/02-Software/turnstile-ingest.rack
+++ b/Turnstile-Ontology/02-Software/turnstile-ingest.rack
@@ -22,12 +22,18 @@ data_get('SOFTWARE#CODE_DEVELOPMENT', 'SOFTWARE#referenced', sw_devel(_,_,_),
 % explicit using predicates not normally needed for data recognizers.
 % If the DevelopmentPlan simply specified a SOFTWARE#COMPILE, then
 % this data_get recognizer could be removed.
-data_get('SOFTWARE#COMPILE', 'PROV-S#identifier', uid(Instance,_,_), Identifier) :-
-    rack_namespace(NS),
-    ns_ref(NS, Instance, RDFInstance),
-    atom_string(Instance, Identifier),
-    add_triple(RDFInstance, rdf:type,
-               'http://Turnstile/DevelopmentPlan#SoftwareIntegration').
+
+data_instance('DevelopmentPlan#SoftwareIntegration', load_data, Instance,
+              [ uid(Instance, Title, Descr),
+                activity_data(BW,BS,BF) ]) :-
+    BW = build_with(Nonce, compile, _ToolName, _ToolPath, _ToolArgs),
+    BS = build_start(Nonce, _StartTime),
+    BF = build_finished(Nonce, _FinishTime, _ExitVal),
+    BW, BS, BF,
+    activity_instance(Nonce, compile, Instance),
+    Title = "compilation",
+    Descr = "Execution of the compiler".
+
 
 % Explicit links between software files and documented requirements.
 % These cannot be automatically discovered and are project specific.

--- a/Turnstile-Ontology/02-Software/turnstile-ingest.rack
+++ b/Turnstile-Ontology/02-Software/turnstile-ingest.rack
@@ -109,7 +109,10 @@ data_instance('FILE#FORMAT', load_data, 'JSONFile',
 % The test process runs in an explicit rack_capture.  The output from
 % the countertest.exe tool is lines of the form "UTC-1-1: PASS", where
 % the first part is the name of the test and the second is the test
-% result.  The name of the Test is also unique to
+% result.  The name of the Test is also unique to the current test run
+% to ensure that test results are associated with the instance of the
+% source tested and that source changes get unique test results
+% instead of overwriting previous results.
 
 data_instance('TESTING#TEST_EXECUTION', load_data, Instance,
               [ uid(Instance, Title, Descr), activity_data(BW,BS,BF) ]) :-

--- a/Turnstile-Ontology/02-Software/turnstile-ingest.rack
+++ b/Turnstile-Ontology/02-Software/turnstile-ingest.rack
@@ -2,10 +2,15 @@
 % automatically-generated assist databin information to the
 % user-specified abstract/documentation information.
 
-:- multifile data_instance/4, data_get/4.
+:- multifile data_instance/4, data_get/4, data_load/3.
+:- use_module(library(dcg/basics)).
 
 turnstile_ns(Elem, URI) :-
     atom_concat('http://arcos.turnstile/GE/', Elem, URI).
+turnstile_ns_ref(NS, Elem, URI) :-
+    atom_concat(NS, '#', P),
+    atom_concat(P, Elem, Q),
+    turnstile_ns(Q, URI).
 
 % The DevelopmentPlan specifies that SOFTWARE#CODE_DEVELOPMENT
 % references the plan-defined SoftwareStandard.  This is an
@@ -100,3 +105,44 @@ data_get('FILE#FILE', 'FILE#fileFormat', sw_file_data(_,_,'conf.json'),
 data_instance('FILE#FORMAT', load_data, 'JSONFile',
               [ uid('JSONFile', 'JSONFile', 'JSONFileFormat'),
                 fmt('JSONFile')]).
+
+% The test process runs in an explicit rack_capture.  The output from
+% the countertest.exe tool is lines of the form "UTC-1-1: PASS", where
+% the first part is the name of the test and the second is the test
+% result.  The name of the Test is also unique to
+
+data_instance('TESTING#TEST_EXECUTION', load_data, Instance,
+              [ uid(Instance, Title, Descr), activity_data(BW,BS,BF) ]) :-
+    BW = build_with(Nonce, ToolType, 'countertest.exe', _ToolPath, _ToolArgs),
+    BS = build_start(Nonce, _StartTime),
+    BF = build_finished(Nonce, _FinishTime, _ExitVal),
+    BW, BS, BF,
+    activity_instance(Nonce, ToolType, Instance),
+    atom_string(ToolType, Title),
+    string_concat(Title, " testing", Descr).
+
+data_instance('TESTING#TEST_RESULT', load_data, Instance,
+              test_res(TestGenInstance, TestName, TestRes)) :-
+    build_with(Nonce, ToolType, 'countertest.exe', _ToolPath, _ToolArgs),
+    tool_output(Nonce, 'countertest.exe', Output),
+    string_lines(Output, OutLines),
+    member(OutLine, OutLines),
+    string_codes(OutLine, OutLineCodes),
+    phrase(test_result(TestNameCodes, TestRes), OutLineCodes, _Rem),
+    atom_codes(TestName, TestNameCodes),
+    append_fld(Nonce, 'Result', NR),
+    append_fld(NR, TestName, Instance),
+    activity_instance(Nonce, ToolType, TestGenInstance).
+
+test_result(TestName, 'Passed') -->
+    string(TestName), ":", blanks, "PASS", !, remainder(_) .
+test_result(TestName, 'Failed') -->
+    string(TestName), ":", blanks, "FAIL", !, remainder(_) .
+
+data_get('TESTING#TEST_RESULT', 'TESTING#result', test_res(_,_,R), V) :-
+    atom_concat('TESTING#', R, Result),
+    rack_ref(Result, V).
+
+data_get('TESTING#TEST_RESULT', 'TESTING#executedBy', test_res(V,_,_), V).
+data_get('TESTING#TEST_RESULT', 'TESTING#confirms', test_res(_,N,_), V) :-
+    turnstile_ns_ref('CounterApplicationSoftwareUnitTesting', N, V).

--- a/Turnstile-Ontology/03-Verification/03-UnitTesting/CounterApplicationUnitTesting.sadl
+++ b/Turnstile-Ontology/03-Verification/03-UnitTesting/CounterApplicationUnitTesting.sadl
@@ -36,37 +36,6 @@ UTC-1-4 is a SoftwareUnitTest
 	has verifies IN-LLR-1
 	has tst:producedBy UnitTestDevelopment.
 
-UTR-1-1-1 is a SoftwareUnitTestResult
-	has identifier "UTR-1-1-1",
-	has confirms UTC-1-1,
-	has generatedAtTime "2017-03-23 10:03:16 UTC"
-	has tst:result tst:Passed,
-	has executedBy SoftwareUnitTestRun1.
-
-UTR-1-2-1 is a SoftwareUnitTestResult
-	has identifier "UTR-1-2-1",
-	has confirms UTC-1-2,
-	has tst:result tst:Passed,
-	has executedBy SoftwareUnitTestRun1.
-
-UTR-1-3-1 is a SoftwareUnitTestResult
-	has identifier "UTR-1-3-1",
-	has confirms UTC-1-3,
-	has tst:result tst:Passed,
-	has executedBy SoftwareUnitTestRun1.
-
-UTR-1-4-1 is a SoftwareUnitTestResult
-	has identifier "UTR-1-4-1",
-	has confirms UTC-1-4,
-	has tst:result tst:Failed,
-	has executedBy SoftwareUnitTestRun1.
-	
-TestStation1 is an AGENT
-	has identifier "TestStation1".
-SoftwareUnitTestRun1 is a SoftwareUnitTestExecution
-	has identifier "SoftwareUnitTestRun1"
-	has executedOn TestStation1.
-
 UTR-1-1-2 is a SoftwareUnitTestResult
 	has identifier "UTR-1-1-2",
 	has confirms UTC-1-1,

--- a/Turnstile-Ontology/OwlModels/CounterApplicationUnitTesting.owl
+++ b/Turnstile-Ontology/OwlModels/CounterApplicationUnitTesting.owl
@@ -45,50 +45,11 @@
     </j.2:confirms>
     <j.0:identifier>UTR-1-4-2</j.0:identifier>
   </j.1:SoftwareUnitTestResult>
-  <j.1:SoftwareUnitTestResult rdf:ID="UTR-1-4-1">
-    <j.2:executedBy>
-      <j.1:SoftwareUnitTestExecution rdf:ID="SoftwareUnitTestRun1">
-        <j.2:executedOn>
-          <j.0:AGENT rdf:ID="TestStation1">
-            <j.0:identifier>TestStation1</j.0:identifier>
-          </j.0:AGENT>
-        </j.2:executedOn>
-        <j.0:identifier>SoftwareUnitTestRun1</j.0:identifier>
-      </j.1:SoftwareUnitTestExecution>
-    </j.2:executedBy>
-    <j.2:result rdf:resource="http://arcos.rack/TESTING#Failed"/>
-    <j.2:confirms rdf:resource="#UTC-1-4"/>
-    <j.0:identifier>UTR-1-4-1</j.0:identifier>
-  </j.1:SoftwareUnitTestResult>
-  <j.1:SoftwareUnitTestResult rdf:ID="UTR-1-2-1">
-    <j.2:executedBy rdf:resource="#SoftwareUnitTestRun1"/>
-    <j.2:result rdf:resource="http://arcos.rack/TESTING#Passed"/>
-    <j.2:confirms>
-      <j.1:SoftwareUnitTest rdf:ID="UTC-1-2">
-        <j.2:producedBy rdf:resource="#UnitTestDevelopment"/>
-        <j.2:verifies rdf:resource="CounterApplicationDesignDescription#IN-LLR-1"/>
-        <j.0:identifier>UTC-1-2</j.0:identifier>
-      </j.1:SoftwareUnitTest>
-    </j.2:confirms>
-    <j.0:identifier>UTR-1-2-1</j.0:identifier>
-  </j.1:SoftwareUnitTestResult>
   <j.1:SoftwareUnitTestResult rdf:ID="UTR-1-2-2">
     <j.2:executedBy rdf:resource="#SoftwareUnitTestRun2"/>
     <j.2:result rdf:resource="http://arcos.rack/TESTING#Passed"/>
     <j.2:confirms rdf:resource="#UTC-1-2"/>
     <j.0:identifier>UTR-1-2-2</j.0:identifier>
-  </j.1:SoftwareUnitTestResult>
-  <j.1:SoftwareUnitTestResult rdf:ID="UTR-1-3-1">
-    <j.2:executedBy rdf:resource="#SoftwareUnitTestRun1"/>
-    <j.2:result rdf:resource="http://arcos.rack/TESTING#Passed"/>
-    <j.2:confirms>
-      <j.1:SoftwareUnitTest rdf:ID="UTC-1-3">
-        <j.2:producedBy rdf:resource="#UnitTestDevelopment"/>
-        <j.2:verifies rdf:resource="CounterApplicationDesignDescription#IN-LLR-1"/>
-        <j.0:identifier>UTC-1-3</j.0:identifier>
-      </j.1:SoftwareUnitTest>
-    </j.2:confirms>
-    <j.0:identifier>UTR-1-3-1</j.0:identifier>
   </j.1:SoftwareUnitTestResult>
   <j.1:SoftwareUnitTestResult rdf:ID="UTR-1-1-2">
     <j.2:executedBy rdf:resource="#SoftwareUnitTestRun2"/>
@@ -107,13 +68,5 @@
     <j.2:result rdf:resource="http://arcos.rack/TESTING#Passed"/>
     <j.2:confirms rdf:resource="#UTC-1-3"/>
     <j.0:identifier>UTR-1-3-2</j.0:identifier>
-  </j.1:SoftwareUnitTestResult>
-  <j.1:SoftwareUnitTestResult rdf:ID="UTR-1-1-1">
-    <j.2:executedBy rdf:resource="#SoftwareUnitTestRun1"/>
-    <j.2:result rdf:resource="http://arcos.rack/TESTING#Passed"/>
-    <j.0:generatedAtTime rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime"
-    >2017-03-23T06:03:16-04:00</j.0:generatedAtTime>
-    <j.2:confirms rdf:resource="#UTC-1-1"/>
-    <j.0:identifier>UTR-1-1-1</j.0:identifier>
   </j.1:SoftwareUnitTestResult>
 </rdf:RDF>

--- a/assist/bin/README.md
+++ b/assist/bin/README.md
@@ -56,14 +56,14 @@ Prolog modules in this directory:
 
   ```shell
   ingest_data -h
-  ingest_data http://TurnstileSystem/CounterApplication models/TurnstileSystem/src
+  ingest_data -O Turnstile-Ontology/OwlModels http://rack001/turnstiledata Turnstile-Ontology/02-Software
   ```
 
   The above would ingest all build/test datafiles generated during
   the build process in the `Turnstile-Ontology/02-Software/03-Implementation` directory.
   The results would be loaded into the RACK database being served at
   `http://localhost:3030` as instance data in the
-  `http://TurnstileSystem/CounterApplication` namespace.
+  `http://rack001/turnstiledata` namespace.
 
   The typical usage is to:
 

--- a/assist/bin/ingest_data
+++ b/assist/bin/ingest_data
@@ -4,7 +4,7 @@
 
 usage_exit() {
     # shellcheck disable=SC2046
-    echo Usage: $(basename "$0") '[-o OwlFile]' '[-a]' '[-r RecognizerFile]' DATA_NAMESPACE DATA_DIR
+    echo Usage: $(basename "$0") '[-o OwlFile]' '[-a]' '[-O overlay-ontology-path]' '[-r RecognizerFile]' DATA_NAMESPACE DATA_DIR
     echo ""
     echo "  Reads RACK ontology and creates instances from DATA_DIR data"
     echo "  under the specified namespace.  The created instances are then"
@@ -29,10 +29,11 @@ loads=(
 
 mode="upload"
 
-while getopts "ao:r:" opt ; do
+while getopts "ao:r:O:" opt ; do
     case $opt in
         a) mode="analyze";;
         o) mode="$OPTARG";;
+        O) loads+=(-g "load_local_model('${OPTARG}')");;
         r) loads+=(-g "load_recognizer('${OPTARG}')");;
         ?) echo "Unrecognized option argument: $opt" >&2
            usage_exit >&2;;

--- a/assist/bin/rack/analyze.pl
+++ b/assist/bin/rack/analyze.pl
@@ -143,7 +143,7 @@ parent_path(E, [R|RS]) :-
     rdf(E, rdfs:subClassOf, LR),
     % Some nodes have multiple parent classes; the additional classes
     % are blank nodes with (for example) cardinality restrictions.
-    \+ rdf_bnode(LR),
+    \+ rdf_is_bnode(LR),
     prefix_shorten(LR, R),
     parent_path(LR, RS).
 parent_path(E, []) :-
@@ -152,7 +152,7 @@ parent_path(E, []) :-
     % base class to the _::file in which it was defined).
     rdf_subject(E),
     has_no_regular_parent(E).
-has_no_regular_parent(E) :- rdf(E, rdfs:subClassOf, P), \+ rdf_bnode(P), !, fail.
+has_no_regular_parent(E) :- rdf(E, rdfs:subClassOf, P), \+ rdf_is_bnode(P), !, fail.
 has_no_regular_parent(_E).
 
 % ----------------------------------------------------------------------
@@ -207,7 +207,7 @@ instance_prefixes(Prefixes) :-
               rdf_reachable(T, rdfs:subClassOf, owl:'Class'),
               rdf(I, rdf:type, E),
               \+ rack_ontology_node(I, _, _),
-              \+ rdf_bnode(I),
+              \+ rdf_is_bnode(I),
               rdf_split_url(PL, L, I),
               atomic_list_concat([PB|_],'#',PL),
               atom_concat(PB,'#',P)
@@ -223,7 +223,7 @@ report_instance_prefix(Prefix) :-
     findall(I, (rdf(I, rdf:type, E),
                 rdf(E, rdf:type, T),
                 rdf_reachable(T, rdfs:subClassOf, owl:'Class'),
-                \+ rdf_bnode(I),
+                \+ rdf_is_bnode(I),
                 atom_concat(Prefix, _, I)
                ), IS),
     length(IS, N),
@@ -233,7 +233,7 @@ report_instances_in(Pfx) :-
     findall(I, (rdf(I, rdf:type, E),
                 rdf(E, rdf:type, T),
                 rdf_reachable(T, rdfs:subClassOf, owl:'Class'),
-                \+ rdf_bnode(I),
+                \+ rdf_is_bnode(I),
                 atom_concat(Pfx, _, I)
                ), IS),
     length(IS, N),
@@ -300,7 +300,7 @@ instances_in_summary(Pfx, T) :-
     sort(Leaves, SL),
     member(T, SL),
     findall(I, (rdf(I, rdf:type, T),
-                \+ rdf_bnode(I),
+                \+ rdf_is_bnode(I),
                 atom_concat(Pfx, _, I)
                ), IS),
     length(IS, ISLen),

--- a/assist/bin/rack/model.pl
+++ b/assist/bin/rack/model.pl
@@ -578,11 +578,10 @@ realize_loaded_data :-
     findall(Instance, rdf_dataref(_RDFClass3, load_data_finish, Instance), FiInstances),
     append(StInstances, LdInstances, StLdInstances),
     append(StLdInstances, FiInstances, PrimaryInstances),
-    rack_namespace(NS),
-    findall(Instance, (member(PIRef, PrimaryInstances),
-                       ns_ref(NS, PI, PIRef),
+    findall(Instance, (member(iad(_,PI,_), PrimaryInstances),
                        rdf_dataref(_RDFClass4, generated_from(PI), Instance)), GenInstances),
     append(PrimaryInstances, GenInstances, Instances),
+    rdf_datagen(Instances),
     length(Instances, Count),
     rack_namespace(Namespace),
     print_message(informational, loaded_data_instances(Namespace, Count)).

--- a/assist/bin/rack/model.pl
+++ b/assist/bin/rack/model.pl
@@ -426,6 +426,7 @@ property(Class, Property, shared) :-
 property_target(Class, Property, PropUsage, Target, Restrictions) :-
     property(Class, Property, PropUsage),
     rdf(Property, rdfs:range, Target),
+    \+ rdf_is_bnode(Target),
     property_extra(Class, Property, Target, Restrictions).
 property_target(Class, Property, PropUsage, Target, Restrictions) :-
     rdf(Class, rdfs:subClassOf, Parent),

--- a/assist/bin/rack/model.pl
+++ b/assist/bin/rack/model.pl
@@ -52,7 +52,7 @@ description DSL into instances in the model.
 
               % Importing user data into the model
               load_data/2,
-              rdf_dataref/3,
+              rdf_dataref/2,
               load_recognizer/1
           ]).
 
@@ -777,7 +777,7 @@ add_atom_newref(DataRef, Property, Value) :-
 % Used to load a set of Data recognizers from a file.  This can be
 % used with multiple files to aggregate recognizers.
 %
-% Data recognizers are invoked by the load_data/2 and rdf_dataref/3
+% Data recognizers are invoked by the load_data/2 and rdf_dataref/2
 % process to recognize the relationship between information in the
 % input =.rack= data files and specific ontology elements.
 %

--- a/assist/bin/rack/model.pl
+++ b/assist/bin/rack/model.pl
@@ -725,29 +725,33 @@ rdf_datagen_inst(iad(RDFClass, InstanceSuffix, InstanceData)) :-
     rack_namespace(NS),
     ns_ref(NS, InstanceSuffix, Instance),
     add_triple(Instance, rdf:type, RDFClass),
+    rack_inheritance_chain(RDFClass, AClass),
+    rdf_datagen_instclass(AClass, Instance, InstanceData).
+
+rdf_datagen_instclass(InstClass, Instance, InstanceData) :-
     % Use InstanceData to drive data_get property relation definitions
     (is_list(InstanceData),
-     add_each_rdfdata(RDFClass, RDFClass, Instance, InstanceData);
+     add_each_rdfdata(InstClass, InstClass, Instance, InstanceData);
      \+ is_list(InstanceData),
-     add_rdfdata(RDFClass, RDFClass, Instance, InstanceData);
+     add_rdfdata(InstClass, InstClass, Instance, InstanceData);
      true  % OK if there are no elements for this instance
     ).
 
-add_each_rdfdata(RDFClass, Class, DataRef, DataList) :-
+add_each_rdfdata(InstClass, Class, DataRef, DataList) :-
     member(Data, DataList),
-    add_rdfdata(RDFClass, Class, DataRef, Data).
+    add_rdfdata(InstClass, Class, DataRef, Data).
 
-add_rdfdata(RDFClass, Class, DataRef, Data) :-
+add_rdfdata(InstClass, Class, DataRef, Data) :-
     rdf(Class, rdfs:subClassOf, Parent),
-    add_rdfdata(RDFClass, Parent, DataRef, Data).
+    add_rdfdata(InstClass, Parent, DataRef, Data).
 
-add_rdfdata(RDFClass, Class, DataRef, Data) :-
+add_rdfdata(InstClass, Class, DataRef, Data) :-
     property(Class, Property, _),
-    rack_ref(ShortC, RDFClass),
+    rack_ref(ShortC, InstClass),
     rack_ref(ShortP, Property),
-    add_rdfproperty(ShortC, ShortP, RDFClass, Property, DataRef, Data).
+    add_rdfproperty(ShortC, ShortP, Property, DataRef, Data).
 
-add_rdfproperty(ShortC, ShortP, _RDFClass, Property, DataRef, Data) :-
+add_rdfproperty(ShortC, ShortP, Property, DataRef, Data) :-
     data_get(ShortC, ShortP, Data, Value),
     (
         % If this is an atom, it might be existing or might need to be created.

--- a/assist/databin/ar
+++ b/assist/databin/ar
@@ -39,25 +39,19 @@ if (( creating )) ; then
         export IFS=","
         shift $archive_file_idx
         shift 1
-        echo ":- multifile build_with/5, build_from/2, build_inputs/2, build_outputs/2,
-                           build_start/2, build_finished/3, file_sha1/3."
-        # shellcheck disable=SC2086
-        echo "build_with(${nonce@Q}, ar," ${tool@Q}, ${realtool@Q}", [] )."
-        echo "build_from(${nonce@Q}, '"$(top_rel_curdir)"')."
+        rack_info_pre "ar"
         echo "build_inputs(${nonce@Q}, [ ${*@Q} ])."
         echo "build_outputs(${nonce@Q}, [ ${outf@Q} ])."
-        echo "build_start(${nonce@Q}, $(date +'date_time(%Y,%m,%d,%H,%M,%S,%z)'))."
     ) > "${rackf}"
 
     update_make_steps
 
     when_done() {
-        rval=$?
+        rack_info_post >> "${rackf}"
         for F in "${files[@]}" "$realtool" ; do
             read sum f < <(sha1sum "$F")
             echo "file_sha1(${f@Q}, ${sum@Q}, ${nonce@Q})." >> "${rackf}"
         done
-        echo "build_finished(${nonce@Q}, $(date +'date_time(%Y,%m,%d,%H,%M,%S,%z)'), $rval)." >> "${rackf}"
     }
     trap when_done EXIT
 

--- a/assist/databin/databin.rack
+++ b/assist/databin/databin.rack
@@ -18,6 +18,7 @@ databin_name(MyName) :-
                  build_outputs/2,
                  build_from/2,
                  build_start/2,
+                 build_on/2,
                  build_finished/3,
                  build_user/2,
                  file_sha1/3,

--- a/assist/databin/databin.rack
+++ b/assist/databin/databin.rack
@@ -219,7 +219,7 @@ output_of(Tool, Dir, F, BuildNonce) :-
 output_of(_, _, _, _) :- false.  % base case for checkout output_of
 
 data_get('FILE#FILE', 'FILE#fileFormat',
-         sw_file_data(Nonce, _, F), 'ElfFile') :-
+         sw_file_data(_, _, F), 'ElfFile') :-
     build_outputs(Nonce, FS),
     member(F, FS),
     build_with(Nonce, compile, _, _, _).

--- a/assist/databin/databin.rack
+++ b/assist/databin/databin.rack
@@ -144,6 +144,13 @@ data_get('SOFTWARE#BUILD', 'SOFTWARE#step',
     tar_start(N, _, _),
     activity_instance(N, tar, V).
 
+%% -------------------- TEST GENERAL HANDLING
+
+data_get('TESTING#TEST_EXECUTION', 'TESTING#executedOn',
+         activity_data(_, _, build_finished(Nonce, _, _)),
+         Value) :-
+    build_on(Nonce, Name), atom_string(Name, Value).
+
 
 %% -------------------- MISC FILES
 

--- a/assist/databin/databin.rack
+++ b/assist/databin/databin.rack
@@ -309,7 +309,15 @@ data_instance('AGENTS#TOOL', load_data, Name, [toolSpec(Name, ToolPath, UserInst
     userForToolUsage(Nonce, UserInstance),
     toolName(Nonce, ToolName, ToolPath, Name).
 
-data_get('AGENTS#TOOL', 'FILE#definedIn', toolSpec(_Name, ToolPath, _User), ToolPath).
+data_get('AGENTS#TOOL', 'FILE#definedIn',
+         toolSpec(_Name, ToolPath, _User), ToolRef) :-
+    (pre_existing_file(ToolPath), !, ToolRef = ToolPath
+    ;
+    build_outputs(Nonce, OutFiles),
+    member(ToolPath, OutFiles),
+    build_from(Nonce, Dir),
+    file_instance(Nonce, Dir, ToolPath, ToolRef)).
+
 data_get('AGENTS#TOOL', 'PROV-S#actedOnBehalfOf', toolSpec(_Name, _ToolPath, User), User).
 
 userForToolUsage(Nonce, UserInstance) :-

--- a/assist/databin/databin.rack
+++ b/assist/databin/databin.rack
@@ -172,13 +172,27 @@ data_instance('FILE#FILE', load_data, Instance, InstanceData) :-
     InstanceData = [uid(Instance, Title, Descr),
                     sw_file_data(Nonce, Dir, Output)].
 
-data_instance('FILE#FILE', load_data, ToolPath,
+data_instance('FILE#FILE', load_data, ToolInst,
               [uid(UID, Title, Descr),
-               sw_file_data(Nonce, '/tmp', ToolPath)]) :-
+               sw_file_data(Nonce, Dir, ToolInst)]) :-
     build_with(Nonce, _ToolType, _ToolName, ToolPath, _ToolArgs),
+
+    % make sure this isn't already declared as the output file of a
+    % previous stage, because then there's already a FILE#FILE
+    % instance that we don't want to duplicate
+    pre_existing_file(ToolPath),
+
     UID = ToolPath,
+    build_from(Nonce, Dir),
     atom_string(ToolPath, Title),
-    string_concat(Title, " file", Descr).
+    string_concat(Title, " file", Descr),
+    file_base_name(ToolPath, ToolFile),
+    (file_directory_name(ToolPath, '.'), !, ToolInst = ToolFile;
+     ToolInst = ToolPath).
+
+pre_existing_file(File) :-
+    build_outputs(_, OutFiles), member(File, OutFiles), !, fail.
+pre_existing_file(_).
 
 data_get('FILE#FILE', 'FILE#fileFormat',
          sw_file_data(Nonce, _, F), 'C') :-

--- a/assist/databin/databin.rack
+++ b/assist/databin/databin.rack
@@ -416,8 +416,6 @@ data_instance('PROV-S#ACTIVITY', load_data, Instance,
     BS = build_start(Nonce, _StartTime),
     BF = build_finished(Nonce, _FinishTime, _ExitVal),
     BW, BS, BF,
-    ToolType \= compile,
-    ToolType \= make,
     activity_instance(Nonce, ToolType, Instance),
     atom_string(ToolType, Title),
     string_concat(Title, " tool invocation", Descr).

--- a/assist/databin/gcc
+++ b/assist/databin/gcc
@@ -70,17 +70,11 @@ nonce="n$(date +%s)-$$"
 
 (
     export IFS=","
-    echo ":- multifile build_with/5, build_from/2, build_inputs/2, build_outputs/2,
-                       build_start/2, build_finished/3, build_user/2, file_sha1/3,
-                       file_committer/2."
-    # shellcheck disable=SC2086
-    echo "build_with(${nonce@Q}, compile," ${tool@Q}, ${realtool@Q}, [ "${opts[*]@Q}" ] ")."
-    # shellcheck disable=SC2086,SC2027,SC2046
-    echo "build_from(${nonce@Q}, '"$(top_rel_curdir)"')."
+    rack_info_pre "compile" "${opts[@]}"
+    echo ":- multifile file_committer/2."
+    echo ":- discontiguous file_committer/2."
     echo "build_inputs(${nonce@Q}, [ ${inf[*]@Q} ])."
     echo "build_outputs(${nonce@Q}, [ ${outf@Q} ])."
-    echo "build_start(${nonce@Q}, $(date +'date_time(%Y,%m,%d,%H,%M,%S,%z)'))."
-    echo "build_user(${nonce@Q}, '$(whoami)')."
     for inp in ${inf[*]} ; do
         git log -n 1 --pretty=format:"file_committer(${inp@Q}, '%al').%n" "$inp" 2>/dev/null
     done
@@ -104,7 +98,7 @@ nonce="n$(date +%s)-$$"
 update_make_steps
 
 when_done() {
-    rval=$?
+    rack_info_post >> "${rackf}"
     if [ ! -z "$inclf" -a -r "$inclf" ] ; then
         read -a fl < <(cat "$inclf")
         if [ ${#fl[*]} -gt 1 ] ; then
@@ -123,7 +117,6 @@ when_done() {
         read sum f < <(sha1sum "$F")
         echo "file_sha1(${f@Q}, ${sum@Q}, ${nonce@Q})." >> "${rackf}"
     done
-    echo "build_finished(${nonce@Q}, $(date +'date_time(%Y,%m,%d,%H,%M,%S,%z)'), $rval)." >> "${rackf}"
 }
 trap when_done EXIT
 

--- a/assist/databin/make
+++ b/assist/databin/make
@@ -14,19 +14,10 @@ nonce="n$(date +%s)-$$"
 # invoked by make to link those commands to this make process.
 export MAKE_DATABIN="${outf}@${nonce}:${MAKE_DATABIN}"
 
-(
-    echo ":- multifile build_with/5, build_from/2, build_inputs/2, build_outputs/2, build_start/2, build_finished/3, build_step/2, build_user/2."
-    # shellcheck disable=SC2086
-    echo "build_with(${nonce@Q}, make," ${tool@Q}, ${realtool@Q}, [ "${*@Q}" ] ")."
-    # shellcheck disable=SC2027,SC2046
-    echo "build_from(${nonce@Q}, '"$(top_rel_curdir)"')."
-    echo "build_start(${nonce@Q}, $(date +'date_time(%Y,%m,%d,%H,%M,%S,%z)'))."
-    echo "build_user(${nonce@Q}, '$(whoami)')."
-) > "${outf}"
+rack_info_pre "make" "${@}" > "${outf}"
 
 when_done() {
-    rval=$?
-    echo "build_finished(${nonce@Q}, $(date +'date_time(%Y,%m,%d,%H,%M,%S,%z)'), $rval)." >> "${outf}"
+    rack_info_post >> "${outf}"
 }
 trap when_done EXIT
 

--- a/assist/databin/rack_capture
+++ b/assist/databin/rack_capture
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2184,SC2027,SC2046,SC2162,SC1090
+#
+# Generic wrapper that will collect basic information for RACK about
+# the tool (first argument) which is run with the remaining arguments
+# on the ocmmand line.  The output of the tool is captured as well for
+# RACK analysis.
+#
+# Copyright (c) 2020, General Electric Company and Galois, Inc.
+
+. $(dirname "$0")/rackfuncs.sh
+
+tool=$(basename "$1")
+realtool=$(find_in_path_excluding "$1")
+nonce="n$(date +%s)-$$"
+outf=$(pwd)/.${tool}.capture.rack
+
+rack_info_pre "${tool}" > "${outf}"
+echo 'tool_output("' >> "${outf}"
+
+update_make_steps
+
+when_done() {
+    echo '").' >> "${outf}"
+    rack_info_post >> "${outf}"
+}
+trap when_done EXIT
+
+"${@}" | tee -a "${outf}"

--- a/assist/databin/rack_capture
+++ b/assist/databin/rack_capture
@@ -3,7 +3,7 @@
 #
 # Generic wrapper that will collect basic information for RACK about
 # the tool (first argument) which is run with the remaining arguments
-# on the ocmmand line.  The output of the tool is captured as well for
+# on the command line.  The output of the tool is captured as well for
 # RACK analysis.
 #
 # Copyright (c) 2020, General Electric Company and Galois, Inc.

--- a/assist/databin/rack_capture
+++ b/assist/databin/rack_capture
@@ -16,7 +16,8 @@ nonce="n$(date +%s)-$$"
 outf=$(pwd)/.${tool}.capture.rack
 
 rack_info_pre "${tool}" > "${outf}"
-echo 'tool_output("' >> "${outf}"
+echo ":- multifile tool_output/3." >> "${outf}"
+echo "tool_output(${nonce@Q}, ${tool@Q}," '"' >> "${outf}"
 
 update_make_steps
 

--- a/assist/databin/rackfuncs.sh
+++ b/assist/databin/rackfuncs.sh
@@ -72,11 +72,12 @@ update_make_steps() {  # assumes nonce is set
 rack_info_pre() {
     what=${1}
     shift 1
-    echo ":- multifile build_with/5, build_from/2, build_inputs/2, build_outputs/2, build_start/2, build_finished/3, build_step/2, build_user/2, file_sha1/3."
+    echo ":- multifile build_with/5, build_from/2, build_inputs/2, build_outputs/2, build_start/2, build_finished/3, build_step/2, build_user/2, build_on/2, file_sha1/3."
     # shellcheck disable=SC2086
     echo "build_with(${nonce@Q}, ${what@Q}," ${tool@Q}, ${realtool@Q}, [ "${*@Q}" ] ")."
     # shellcheck disable=SC2027,SC2046
     echo "build_from(${nonce@Q}, '"$(top_rel_curdir)"')."
+    echo "build_on(${nonce@Q}, '"$(hostname --fqdn)"')."
     echo "build_start(${nonce@Q}, $(date +'date_time(%Y,%m,%d,%H,%M,%S,%z)'))."
     echo "build_user(${nonce@Q}, '$(whoami)')."
     IFS=' ' read sum f < <(sha1sum "$realtool")

--- a/assist/databin/rackfuncs.sh
+++ b/assist/databin/rackfuncs.sh
@@ -11,8 +11,11 @@ find_in_path_remainder() { # $1 = name of executable
 
 find_in_path_excluding() { # $1 = name of executable, $2.. = exclusion paths
     exe="$1"; shift 1
-    # shellcheck disable=SC2046
-    (PATH=$(echo $(IFS=:
+    if [ "${exe:0:2}" == "./" ] ;
+    then echo $(basename "${exe}")
+    else
+        # shellcheck disable=SC2046
+        (PATH=$(echo $(IFS=:
                    for P in $PATH; do
                        for excl; do
                            if [[ "$excl" == "$P" ]] ; then
@@ -22,7 +25,8 @@ find_in_path_excluding() { # $1 = name of executable, $2.. = exclusion paths
                        # shellcheck disable=SC2086
                        echo $P
                    done
-                ) | tr ' ' :) type -p "$exe")
+                    ) | tr ' ' :) type -p "$exe")
+    fi
 }
 
 top_rel_curdir() {

--- a/assist/databin/rackfuncs.sh
+++ b/assist/databin/rackfuncs.sh
@@ -12,7 +12,7 @@ find_in_path_remainder() { # $1 = name of executable
 find_in_path_excluding() { # $1 = name of executable, $2.. = exclusion paths
     exe="$1"; shift 1
     if [ "${exe:0:2}" == "./" ] ;
-    then echo $(basename "${exe}")
+    then basename "${exe}"
     else
         # shellcheck disable=SC2046
         (PATH=$(echo $(IFS=:
@@ -73,13 +73,15 @@ rack_info_pre() {
     what=${1}
     shift 1
     echo ":- multifile build_with/5, build_from/2, build_inputs/2, build_outputs/2, build_start/2, build_finished/3, build_step/2, build_user/2, build_on/2, file_sha1/3."
-    # shellcheck disable=SC2086
+    # shellcheck disable=SC2086,SC2154
     echo "build_with(${nonce@Q}, ${what@Q}," ${tool@Q}, ${realtool@Q}, [ "${*@Q}" ] ")."
     # shellcheck disable=SC2027,SC2046
     echo "build_from(${nonce@Q}, '"$(top_rel_curdir)"')."
+    # shellcheck disable=SC2027,SC2046
     echo "build_on(${nonce@Q}, '"$(hostname --fqdn)"')."
     echo "build_start(${nonce@Q}, $(date +'date_time(%Y,%m,%d,%H,%M,%S,%z)'))."
     echo "build_user(${nonce@Q}, '$(whoami)')."
+    # shellcheck disable=SC2162,SC2034
     IFS=' ' read sum f < <(sha1sum "$realtool")
     echo "file_sha1(${tool@Q}, ${sum@Q}, ${nonce@Q})."
 }

--- a/assist/databin/rackfuncs.sh
+++ b/assist/databin/rackfuncs.sh
@@ -52,3 +52,37 @@ update_make_steps() {  # assumes nonce is set
     done
 )
 }
+
+# Run this prior to running a specific operation to capture the
+# information about the start of that operation.
+#
+# Arguments:
+#    $1 - tool generic name
+#    $* - command-line arguments
+#
+# shell variables referenced:
+#    nonce - the nonce value for this operation
+#    tool - the tool base name (this wrapper)
+#    realtool - the full path of the underlying tool being invoked
+
+rack_info_pre() {
+    what=${1}
+    shift 1
+    echo ":- multifile build_with/5, build_from/2, build_inputs/2, build_outputs/2, build_start/2, build_finished/3, build_step/2, build_user/2, file_sha1/3."
+    # shellcheck disable=SC2086
+    echo "build_with(${nonce@Q}, ${what@Q}," ${tool@Q}, ${realtool@Q}, [ "${*@Q}" ] ")."
+    # shellcheck disable=SC2027,SC2046
+    echo "build_from(${nonce@Q}, '"$(top_rel_curdir)"')."
+    echo "build_start(${nonce@Q}, $(date +'date_time(%Y,%m,%d,%H,%M,%S,%z)'))."
+    echo "build_user(${nonce@Q}, '$(whoami)')."
+    IFS=' ' read sum f < <(sha1sum "$realtool")
+    echo "file_sha1(${tool@Q}, ${sum@Q}, ${nonce@Q})."
+}
+
+# Run this on completion of a specific operation to capture the
+# completion information of the operation for ASSIST.
+
+rack_info_post() {
+    rval=$?
+    echo "build_finished(${nonce@Q}, $(date +'date_time(%Y,%m,%d,%H,%M,%S,%z)'), $rval)."
+}


### PR DESCRIPTION
Updates ASSIST-DC to collect Turnstile unit testing results from the build process.

Also contains updates to load information from overlay ontologies as well as the core RACK ontology.
