### PR TITLE
migration: use setup.cfg

### DIFF
--- a/migration/README.md
+++ b/migration/README.md
@@ -26,15 +26,15 @@ The rest of the procedure uses `pip`, which is added to your `PATH` by the
 virtual environment activation command.  If you open a new shell, make sure to
 run `source` again to reopen the virtual environment!
 
-In a shell where the environment is activated, you ought to be able to:
+In a shell where the environment is activated, you can install the development
+environment tools via:
 
 ```
+# still from the migration directory
 pip install -r requirements.txt
-# or, if you intend to work on the tool:
-pip install -e -r requirements.txt -r requirements-dev.txt
 ```
 
-And finally build and set up the tool with:
+In order to build the migration tools, you can run:
 
 ```
 # still from the migration directory

--- a/migration/requirements-dev.txt
+++ b/migration/requirements-dev.txt
@@ -1,7 +1,0 @@
-black
-mypy~=0.812
-git+https://github.com/matangover/mypyls.git#egg=mypyls
-pylint
-rope
-types-colorama
-wheel

--- a/migration/requirements.txt
+++ b/migration/requirements.txt
@@ -1,3 +1,2 @@
-colorama
-pydantic
-typing-extensions
+-e .
+-e .[dev]

--- a/migration/setup.cfg
+++ b/migration/setup.cfg
@@ -1,0 +1,26 @@
+[metadata]
+name = RACK migration tool suite
+version = 0.1
+description = Helps capturing changes to the RACK ontology
+author = Valentin Robert
+author_email = val@galois.com
+
+[options]
+install_requires =
+    colorama
+    pydantic
+    typing-extensions
+packages = find:
+scripts =
+    rack_crawl/rack_crawl
+    rack_migrate/rack_migrate
+
+[options.extras_require]
+dev:
+    black
+    mypy ~= 0.812
+    mypyls @ git+https://github.com/matangover/mypyls.git#egg=mypyls
+    pylint
+    rope
+    types-colorama
+    wheel

--- a/migration/setup.py
+++ b/migration/setup.py
@@ -1,10 +1,6 @@
-from setuptools import setup, find_packages
+#!/usr/bin/env python3
 
-setup(
-    name="RACK migration tool suite",
-    scripts=[
-        "rack_crawl/rack_crawl",
-        "rack_migrate/rack_migrate",
-    ],
-    packages=find_packages(),
-)
+from setuptools import setup
+
+if __name__ == "__main__":
+    setup()

--- a/migration/shell.nix
+++ b/migration/shell.nix
@@ -17,7 +17,6 @@ nixpkgs.mkShell {
   postVenvCreation = ''
     export SOURCE_DATE_EPOCH=315532800
     pip install -r ${./requirements.txt}
-    pip install -r ${./requirements-dev.txt}
   '';
 
   venvDir = ".venv";


### PR DESCRIPTION
Recommended setup these days is to use the more declarative `setup.cfg` with a minimal `setup.py`.

`requirements.txt` can be inferred from the same file, and there's a trick to also include development dependencies.

This makes it so that one place summarizes everything we need for both development environments, and for setuptools to package.