### PR TITLE
data_shape: use setup.cfg

### DIFF
--- a/tools/data_shape/setup.cfg
+++ b/tools/data_shape/setup.cfg
@@ -1,0 +1,21 @@
+[metadata]
+name = data_shape
+version = 0.1
+description = RACK data shape
+author = Eric Mertens
+author_email = emertens@galois.com
+
+[options]
+install_requires =
+    SPARQLWrapper
+    graphviz
+package_dir =
+    = bin
+packages = find:
+scripts =
+    bin/data_shape
+    bin/collaboration
+zip_safe = False
+
+[options.packages.find]
+where = bin

--- a/tools/data_shape/setup.py
+++ b/tools/data_shape/setup.py
@@ -2,17 +2,5 @@
 
 from setuptools import setup
 
-setup(name='data_shape',
-      version='0.1',
-      description='RACK data shape',
-      author='Eric Mertens',
-      author_email='emertens@galois.com',
-      packages=['data_shape'],
-      scripts=[
-            'bin/data_shape',
-            'bin/collaboration'],
-      install_requires=[
-            'SPARQLWrapper',
-            'graphviz'
-      ],
-      zip_safe=False)
+if __name__ == "__main__":
+    setup()


### PR DESCRIPTION
I had trouble setting up the environment with the given setup.py.  I went to
read the documentation for setuptools, found out they recommended using
setup.cfg nowadays, switched the configuration for testing purposes, and it
worked.

It's very similar but makes the configuration a proper data file rather than
some constants in a piece of code.  If everyone is happy switching to
that, here is how we could go about it.