### PR TITLE
migration: relax required constraints in SemTK JSON schema

### DIFF
--- a/migration/ontology_changes/change_property_range.py
+++ b/migration/ontology_changes/change_property_range.py
@@ -104,6 +104,7 @@ class MigrationVisitor(semtk.DefaultSemTKVisitor):
 
             # cleanup
             for sparqlID in node.SnodeSparqlIDs:
+                if json.importSpec is None: continue
                 for index, importSpecNode in enumerate(json.importSpec.nodes):
                     if importSpecNode.sparqlID == sparqlID:
                         importSpecNode.type = self.rename(

--- a/migration/ontology_changes/delete_property.py
+++ b/migration/ontology_changes/delete_property.py
@@ -61,6 +61,7 @@ class MigrationVisitor(semtk.DefaultSemTKVisitor):
 
                 # cleanup
                 for sparqlID in node.SnodeSparqlIDs:
+                    if json.importSpec is None: continue
                     for index, importSpecNode in enumerate(json.importSpec.nodes):
                         if importSpecNode.sparqlID == sparqlID:
                             field = stylize_json("sparqlID")

--- a/migration/semtk/__init__.py
+++ b/migration/semtk/__init__.py
@@ -153,7 +153,7 @@ class ImportSpecProp(BaseModel):
 class ImportSpecNode(BaseModel):
     sparqlID: str
     type: str
-    URILookupMode: str
+    URILookupMode: Optional[str]
     mapping: List[Mapping]
     props: List[ImportSpecProp]
 

--- a/migration/semtk/__init__.py
+++ b/migration/semtk/__init__.py
@@ -80,7 +80,7 @@ class SNodeProp(BaseModel):
     relationship: str
     UriRelationship: str
     Constraints: str
-    fullURIName: str
+    fullURIName: Optional[str]
     SparqlID: str
     isReturned: bool
     optMinus: int
@@ -139,7 +139,7 @@ class SNodeGroup(BaseModel):
 
 
 class Mapping(BaseModel):
-    colId: str
+    colId: Optional[str]
     colName: Optional[str]
     transformList: Optional[List[str]]
 

--- a/migration/semtk/__init__.py
+++ b/migration/semtk/__init__.py
@@ -54,7 +54,8 @@ class DefaultSemTKVisitor(SemTKVisitor):
         pass
 
     def visit_SemTKJSON(self, json: SemTKJSON) -> None:
-        self.visit_ImportSpec(json, "importSpec", json.importSpec)
+        if json.importSpec is not None:
+            self.visit_ImportSpec(json, "importSpec", json.importSpec)
         self.visit_SNodeGroup(json, "sNodeGroup", json.sNodeGroup)
         self.visit_SparqlConn(json, "sparqlConn", json.sparqlConn)
 
@@ -199,7 +200,7 @@ class SemTKJSON(BaseModel):
     version: Optional[int]
     sparqlConn: SparqlConn
     sNodeGroup: SNodeGroup
-    importSpec: ImportSpec
+    importSpec: Optional[ImportSpec]
 
     def accept(self, visitor: SemTKVisitor) -> None:
         visitor.visit_SemTKJSON(self)


### PR DESCRIPTION
Should fix #538

@cuddihyge do these seem reasonable?

I was a bit surprised by missing `colId` on `mappings`.