### PR TITLE
RACK CLI: Use utf-8-sig

### DIFF
--- a/cli/rack/__init__.py
+++ b/cli/rack/__init__.py
@@ -274,7 +274,7 @@ def ingest_csv(conn: Connection, nodegroup: str, csv_name: Path) -> None:
 
     @with_status(f'Loading {str_highlight(nodegroup)}', suffix)
     def go() -> dict:
-        with open(csv_name, 'r', encoding='utf-8') as csv_file:
+        with open(csv_name, mode='r', encoding='utf-8-sig') as csv_file:
             csv = csv_file.read()
 
         return semtk3.ingest_by_id(nodegroup, csv, conn)
@@ -290,7 +290,7 @@ def ingest_owl(conn: Connection, owl_file: Path) -> None:
 
 def ingest_data_driver(config_path: Path, base_url: Url, data_graphs: Optional[List[Url]], triple_store: Optional[Url], clear: bool) -> None:
     """Use an import.yaml file to ingest multiple CSV files into the data graph."""
-    with open(config_path, 'r', encoding='utf-8') as config_file:
+    with open(config_path, mode='r', encoding='utf-8-sig') as config_file:
         config = yaml.safe_load(config_file)
         validate(config, INGEST_CSV_CONFIG_SCHEMA)
 
@@ -333,7 +333,7 @@ def ingest_data_driver(config_path: Path, base_url: Url, data_graphs: Optional[L
 
 def ingest_owl_driver(config_path: Path, base_url: Url, triple_store: Optional[Url], clear: bool) -> None:
     """Use an import.yaml file to ingest multiple OWL files into the model graph."""
-    with open(config_path, 'r', encoding='utf-8') as config_file:
+    with open(config_path, mode='r', encoding='utf-8-sig') as config_file:
         config = yaml.safe_load(config_file)
         validate(config, INGEST_OWL_CONFIG_SCHEMA)
 


### PR DESCRIPTION
This change makes our tools tolerant of the signature Microsoft tools like to add to CSV files without requiring that signature.