### PR TITLE
[ARP-4754A] fixed typos in .sadl, ARP-4754A.yaml, and in .sh comments

### DIFF
--- a/GE-Ontology/setup-GE.sh
+++ b/GE-Ontology/setup-GE.sh
@@ -29,7 +29,7 @@ rack model import "$BASEDIR"/../SRI-Ontology/OwlModels/import.yaml
 
 
 ### Applicable Standards ### copy any of these to the instance data load script and use when applicable
-# rack data import --clear ../RACK-Ontology/OwlModels/ARP-4754A.yaml     # from datagraph http://rack001/arp-475a
+# rack data import --clear ../RACK-Ontology/OwlModels/ARP-4754A.yaml     # from datagraph http://rack001/arp-4754a
 # rack data import --clear ../RACK-Ontology/OwlModels/DO-330.yaml        # from datagraph http://rack001/do-330
 rack data import --clear "$BASEDIR"/../RACK-Ontology/OwlModels/DO-178C.yaml         # from datagraph http://rack001/do-178c
 # rack data import --clear ../RACK-Ontology/OwlModels/MIL-STD-881D.yaml  # from datagraph http://rack001/mil-std-881d

--- a/RACK-Ontology/OwlModels/ARP-4754A.owl
+++ b/RACK-Ontology/OwlModels/ARP-4754A.owl
@@ -23,15 +23,39 @@
     <j.0:content>
       <D:SECTION rdf:ID="ARP-4754A-AppendixA">
         <j.0:content>
-          <Pr:OBJECTIVE rdf:ID="ARP-4786-7.1">
-            <j.0:description>Assurance is obtained that necessary plans are developed and maintained for all aspects of system certification.</j.0:description>
-            <j.0:identifier>ARP-4786-7.1</j.0:identifier>
+          <Pr:OBJECTIVE rdf:ID="ARP-4754-8.1">
+            <j.0:description>Compliance substantiation is provided.</j.0:description>
+            <j.0:identifier>ARP-4754-8.1</j.0:identifier>
           </Pr:OBJECTIVE>
         </j.0:content>
         <j.0:content>
-          <Pr:OBJECTIVE rdf:ID="ARP-4756-2.1">
-            <j.0:description>Aircraft-level functions, functional requirements, functional interfaces and assumptions are defined</j.0:description>
-            <j.0:identifier>ARP-4756-2.1</j.0:identifier>
+          <Pr:OBJECTIVE rdf:ID="ARP-4754-6.3">
+            <j.0:description>Problem reporting , change control, change review, and configuration status accounting are established.</j.0:description>
+            <j.0:identifier>ARP-4754-6.3</j.0:identifier>
+          </Pr:OBJECTIVE>
+        </j.0:content>
+        <j.0:content>
+          <Pr:OBJECTIVE rdf:ID="ARP-4754-2.5">
+            <j.0:description>System architecture is defined.</j.0:description>
+            <j.0:identifier>ARP-4754-2.5</j.0:identifier>
+          </Pr:OBJECTIVE>
+        </j.0:content>
+        <j.0:content>
+          <Pr:OBJECTIVE rdf:ID="ARP-4754-5.4">
+            <j.0:description>Safety requirements are verified.</j.0:description>
+            <j.0:identifier>ARP-4754-5.4</j.0:identifier>
+          </Pr:OBJECTIVE>
+        </j.0:content>
+        <j.0:content>
+          <Pr:OBJECTIVE rdf:ID="ARP-4754-3.1">
+            <j.0:description>The aircraft/system functional hazard assessment is performed.</j.0:description>
+            <j.0:identifier>ARP-4754-3.1</j.0:identifier>
+          </Pr:OBJECTIVE>
+        </j.0:content>
+        <j.0:content>
+          <Pr:OBJECTIVE rdf:ID="ARP-4754-2.6">
+            <j.0:description>System requirements are allocated to items.</j.0:description>
+            <j.0:identifier>ARP-4754-2.6</j.0:identifier>
           </Pr:OBJECTIVE>
         </j.0:content>
         <j.0:content>
@@ -41,196 +65,172 @@
           </Pr:OBJECTIVE>
         </j.0:content>
         <j.0:content>
-          <Pr:OBJECTIVE rdf:ID="ARP-4787-7.2">
-            <j.0:description>Development activities and processes are conducted in accordance with those plans.</j.0:description>
-            <j.0:identifier>ARP-4787-7.2</j.0:identifier>
-          </Pr:OBJECTIVE>
-        </j.0:content>
-        <j.0:content>
-          <Pr:OBJECTIVE rdf:ID="ARP-4776-5.1">
+          <Pr:OBJECTIVE rdf:ID="ARP-4754-5.1">
             <j.0:description>Test or demonstration procedures are correct.</j.0:description>
-            <j.0:identifier>ARP-4776-5.1</j.0:identifier>
+            <j.0:identifier>ARP-4754-5.1</j.0:identifier>
           </Pr:OBJECTIVE>
         </j.0:content>
         <j.0:content>
-          <Pr:OBJECTIVE rdf:ID="ARP-4769-3.7">
-            <j.0:description>Independence requirements in functions, systems and items are captured.</j.0:description>
-            <j.0:identifier>ARP-4769-3.7</j.0:identifier>
+          <Pr:OBJECTIVE rdf:ID="ARP-4754-2.3">
+            <j.0:description>System requirements including assumptions and system interfaces are defined.</j.0:description>
+            <j.0:identifier>ARP-4754-2.3</j.0:identifier>
           </Pr:OBJECTIVE>
         </j.0:content>
         <j.0:content>
-          <Pr:OBJECTIVE rdf:ID="ARP-4768-3.6">
-            <j.0:description>The system safety assessment is performed.</j.0:description>
-            <j.0:identifier>ARP-4768-3.6</j.0:identifier>
+          <Pr:OBJECTIVE rdf:ID="ARP-4754-2.7">
+            <j.0:description>Appropriate item, system and aircraft integrations are performed.</j.0:description>
+            <j.0:identifier>ARP-4754-2.7</j.0:identifier>
           </Pr:OBJECTIVE>
         </j.0:content>
         <j.0:content>
-          <Pr:OBJECTIVE rdf:ID="ARP-4766-3.4">
-            <j.0:description>The common cause analyses are performed.</j.0:description>
-            <j.0:identifier>ARP-4766-3.4</j.0:identifier>
+          <Pr:OBJECTIVE rdf:ID="ARP-4754-4.6">
+            <j.0:description>Validation compliance substantiation is provided.</j.0:description>
+            <j.0:identifier>ARP-4754-4.6</j.0:identifier>
           </Pr:OBJECTIVE>
         </j.0:content>
         <j.0:title>PROCESS OBJECTIVES DATA</j.0:title>
         <j.0:content>
-          <Pr:OBJECTIVE rdf:ID="ARP-4781-5.6">
-            <j.0:description>Assessment of deficiencies and their related impact on safety is identified.</j.0:description>
-            <j.0:identifier>ARP-4781-5.6</j.0:identifier>
+          <Pr:OBJECTIVE rdf:ID="ARP-4754-3.7">
+            <j.0:description>Independence requirements in functions, systems and items are captured.</j.0:description>
+            <j.0:identifier>ARP-4754-3.7</j.0:identifier>
           </Pr:OBJECTIVE>
         </j.0:content>
         <j.0:content>
-          <Pr:OBJECTIVE rdf:ID="ARP-4788-8.1">
-            <j.0:description>Compliance substantiation is provided.</j.0:description>
-            <j.0:identifier>ARP-4788-8.1</j.0:identifier>
-          </Pr:OBJECTIVE>
-        </j.0:content>
-        <j.0:content>
-          <Pr:OBJECTIVE rdf:ID="ARP-4767-3.5">
-            <j.0:description>The aircraft safety assessment is performed.</j.0:description>
-            <j.0:identifier>ARP-4767-3.5</j.0:identifier>
-          </Pr:OBJECTIVE>
-        </j.0:content>
-        <j.0:content>
-          <Pr:OBJECTIVE rdf:ID="ARP-4759-2.4">
+          <Pr:OBJECTIVE rdf:ID="ARP-4754-2.4">
             <j.0:description>System derived requirements (including derived safety-related requirements) are defined and rationale explained</j.0:description>
-            <j.0:identifier>ARP-4759-2.4</j.0:identifier>
+            <j.0:identifier>ARP-4754-2.4</j.0:identifier>
           </Pr:OBJECTIVE>
         </j.0:content>
         <j.0:content>
-          <Pr:OBJECTIVE rdf:ID="ARP-4780-5.5">
-            <j.0:description>Verification compliance substantiation is included.</j.0:description>
-            <j.0:identifier>ARP-4780-5.5</j.0:identifier>
-          </Pr:OBJECTIVE>
-        </j.0:content>
-        <j.0:content>
-          <Pr:OBJECTIVE rdf:ID="ARP-4758-2.3">
-            <j.0:description>System requirements including assumptions and system interfaces are defined.</j.0:description>
-            <j.0:identifier>ARP-4758-2.3</j.0:identifier>
-          </Pr:OBJECTIVE>
-        </j.0:content>
-        <j.0:content>
-          <Pr:OBJECTIVE rdf:ID="ARP-4762-2.7">
-            <j.0:description>Appropriate item, system and aircraft integrations are performed.</j.0:description>
-            <j.0:identifier>ARP-4762-2.7</j.0:identifier>
-          </Pr:OBJECTIVE>
-        </j.0:content>
-        <j.0:content>
-          <Pr:OBJECTIVE rdf:ID="ARP-4772-4.3">
+          <Pr:OBJECTIVE rdf:ID="ARP-4754-4.3">
             <j.0:description>Derived requirements are justified and validated.</j.0:description>
-            <j.0:identifier>ARP-4772-4.3</j.0:identifier>
+            <j.0:identifier>ARP-4754-4.3</j.0:identifier>
           </Pr:OBJECTIVE>
         </j.0:content>
         <j.0:content>
-          <Pr:OBJECTIVE rdf:ID="ARP-4783-6.2">
-            <j.0:description>Configuration baseline and derivatives are established.</j.0:description>
-            <j.0:identifier>ARP-4783-6.2</j.0:identifier>
-          </Pr:OBJECTIVE>
-        </j.0:content>
-        <j.0:content>
-          <Pr:OBJECTIVE rdf:ID="ARP-4775-4.6">
-            <j.0:description>Validation compliance substantiation is provided.</j.0:description>
-            <j.0:identifier>ARP-4775-4.6</j.0:identifier>
-          </Pr:OBJECTIVE>
-        </j.0:content>
-        <j.0:content>
-          <Pr:OBJECTIVE rdf:ID="ARP-4773-4.4">
-            <j.0:description>Requirements are traceable.</j.0:description>
-            <j.0:identifier>ARP-4773-4.4</j.0:identifier>
-          </Pr:OBJECTIVE>
-        </j.0:content>
-        <j.0:content>
-          <Pr:OBJECTIVE rdf:ID="ARP-4784-6.3">
-            <j.0:description>Problem reporting , change control, change review, and configuration status accounting are established.</j.0:description>
-            <j.0:identifier>ARP-4784-6.3</j.0:identifier>
-          </Pr:OBJECTIVE>
-        </j.0:content>
-        <j.0:content>
-          <Pr:OBJECTIVE rdf:ID="ARP-4779-5.4">
-            <j.0:description>Safety requirements are verified.</j.0:description>
-            <j.0:identifier>ARP-4779-5.4</j.0:identifier>
-          </Pr:OBJECTIVE>
-        </j.0:content>
-        <j.0:content>
-          <Pr:OBJECTIVE rdf:ID="ARP-4757-2.2">
+          <Pr:OBJECTIVE rdf:ID="ARP-4754-2.2">
             <j.0:description>Aircraft functions are allocated to systems</j.0:description>
-            <j.0:identifier>ARP-4757-2.2</j.0:identifier>
+            <j.0:identifier>ARP-4754-2.2</j.0:identifier>
           </Pr:OBJECTIVE>
         </j.0:content>
         <j.0:content>
-          <Pr:OBJECTIVE rdf:ID="ARP-4761-2.6">
-            <j.0:description>System requirements are allocated to items.</j.0:description>
-            <j.0:identifier>ARP-4761-2.6</j.0:identifier>
+          <Pr:OBJECTIVE rdf:ID="ARP-4754-4.4">
+            <j.0:description>Requirements are traceable.</j.0:description>
+            <j.0:identifier>ARP-4754-4.4</j.0:identifier>
           </Pr:OBJECTIVE>
         </j.0:content>
         <j.0:content>
-          <Pr:OBJECTIVE rdf:ID="ARP-4774-4.5">
+          <Pr:OBJECTIVE rdf:ID="ARP-4754-7.1">
+            <j.0:description>Assurance is obtained that necessary plans are developed and maintained for all aspects of system certification.</j.0:description>
+            <j.0:identifier>ARP-4754-7.1</j.0:identifier>
+          </Pr:OBJECTIVE>
+        </j.0:content>
+        <j.0:content>
+          <Pr:OBJECTIVE rdf:ID="ARP-4754-3.4">
+            <j.0:description>The common cause analyses are performed.</j.0:description>
+            <j.0:identifier>ARP-4754-3.4</j.0:identifier>
+          </Pr:OBJECTIVE>
+        </j.0:content>
+        <j.0:content>
+          <Pr:OBJECTIVE rdf:ID="ARP-4754-7.2">
+            <j.0:description>Development activities and processes are conducted in accordance with those plans.</j.0:description>
+            <j.0:identifier>ARP-4754-7.2</j.0:identifier>
+          </Pr:OBJECTIVE>
+        </j.0:content>
+        <j.0:content>
+          <Pr:OBJECTIVE rdf:ID="ARP-4754-4.5">
             <j.0:description></j.0:description>
-            <j.0:identifier>ARP-4774-4.5</j.0:identifier>
+            <j.0:identifier>ARP-4754-4.5</j.0:identifier>
           </Pr:OBJECTIVE>
         </j.0:content>
         <j.0:content>
-          <Pr:OBJECTIVE rdf:ID="ARP-4785-6.4">
+          <Pr:OBJECTIVE rdf:ID="ARP-4754-3.5">
+            <j.0:description>The aircraft safety assessment is performed.</j.0:description>
+            <j.0:identifier>ARP-4754-3.5</j.0:identifier>
+          </Pr:OBJECTIVE>
+        </j.0:content>
+        <j.0:content>
+          <Pr:OBJECTIVE rdf:ID="ARP-4754-2.1">
+            <j.0:description>Aircraft-level functions, functional requirements, functional interfaces and assumptions are defined</j.0:description>
+            <j.0:identifier>ARP-4754-2.1</j.0:identifier>
+          </Pr:OBJECTIVE>
+        </j.0:content>
+        <j.0:content>
+          <Pr:OBJECTIVE rdf:ID="ARP-4754-3.6">
+            <j.0:description>The system safety assessment is performed.</j.0:description>
+            <j.0:identifier>ARP-4754-3.6</j.0:identifier>
+          </Pr:OBJECTIVE>
+        </j.0:content>
+        <j.0:content>
+          <Pr:OBJECTIVE rdf:ID="ARP-4754-6.4">
             <j.0:description>Archive and retrieval are established.</j.0:description>
-            <j.0:identifier>ARP-4785-6.4</j.0:identifier>
+            <j.0:identifier>ARP-4754-6.4</j.0:identifier>
           </Pr:OBJECTIVE>
         </j.0:content>
         <j.0:content>
-          <Pr:OBJECTIVE rdf:ID="ARP-4782-6.1">
-            <j.0:description>Configuration items are identified</j.0:description>
-            <j.0:identifier>ARP-4782-6.1</j.0:identifier>
-          </Pr:OBJECTIVE>
-        </j.0:content>
-        <j.0:content>
-          <Pr:OBJECTIVE rdf:ID="ARP-4771-4.2">
-            <j.0:description>Assumptions are justified and validated.</j.0:description>
-            <j.0:identifier>ARP-4771-4.2</j.0:identifier>
-          </Pr:OBJECTIVE>
-        </j.0:content>
-        <j.0:content>
-          <Pr:OBJECTIVE rdf:ID="ARP-4778-5.3">
-            <j.0:description>Product implementation complies with aircraft, and system requirements.</j.0:description>
-            <j.0:identifier>ARP-4778-5.3</j.0:identifier>
-          </Pr:OBJECTIVE>
-        </j.0:content>
-        <j.0:content>
-          <Pr:OBJECTIVE rdf:ID="ARP-4777-5.2">
-            <j.0:description>Verification demonstrates intended function and confidence of no unintended function impacts to safety.</j.0:description>
-            <j.0:identifier>ARP-4777-5.2</j.0:identifier>
-          </Pr:OBJECTIVE>
-        </j.0:content>
-        <j.0:content>
-          <Pr:OBJECTIVE rdf:ID="ARP-4765-3.3">
-            <j.0:description>The preliminary system safety assessment is performed.</j.0:description>
-            <j.0:identifier>ARP-4765-3.3</j.0:identifier>
-          </Pr:OBJECTIVE>
-        </j.0:content>
-        <j.0:content>
-          <Pr:OBJECTIVE rdf:ID="ARP-4770-4.1">
+          <Pr:OBJECTIVE rdf:ID="ARP-4754-4.1">
             <j.0:description>Aircraft, system, items requirements are complete and correct.</j.0:description>
-            <j.0:identifier>ARP-4770-4.1</j.0:identifier>
+            <j.0:identifier>ARP-4754-4.1</j.0:identifier>
           </Pr:OBJECTIVE>
         </j.0:content>
         <j.0:content>
-          <Pr:OBJECTIVE rdf:ID="ARP-4755-1.2">
-            <j.0:description>Transition criteria and inter-relationship among processes are defined</j.0:description>
-            <j.0:identifier>ARP-4755-1.2</j.0:identifier>
+          <Pr:OBJECTIVE rdf:ID="ARP-4754-5.5">
+            <j.0:description>Verification compliance substantiation is included.</j.0:description>
+            <j.0:identifier>ARP-4754-5.5</j.0:identifier>
           </Pr:OBJECTIVE>
         </j.0:content>
         <j.0:content>
-          <Pr:OBJECTIVE rdf:ID="ARP-4764-3.2">
+          <Pr:OBJECTIVE rdf:ID="ARP-4754-4.2">
+            <j.0:description>Assumptions are justified and validated.</j.0:description>
+            <j.0:identifier>ARP-4754-4.2</j.0:identifier>
+          </Pr:OBJECTIVE>
+        </j.0:content>
+        <j.0:content>
+          <Pr:OBJECTIVE rdf:ID="ARP-4754-3.2">
             <j.0:description>The preliminary aircraft safety assessment is performed.</j.0:description>
-            <j.0:identifier>ARP-4764-3.2</j.0:identifier>
+            <j.0:identifier>ARP-4754-3.2</j.0:identifier>
           </Pr:OBJECTIVE>
         </j.0:content>
         <j.0:content>
-          <Pr:OBJECTIVE rdf:ID="ARP-4760-2.5">
-            <j.0:description>System architecture is defined.</j.0:description>
-            <j.0:identifier>ARP-4760-2.5</j.0:identifier>
+          <Pr:OBJECTIVE rdf:ID="ARP-4754-1.2">
+            <j.0:description>Transition criteria and inter-relationship among processes are defined</j.0:description>
+            <j.0:identifier>ARP-4754-1.2</j.0:identifier>
           </Pr:OBJECTIVE>
         </j.0:content>
         <j.0:content>
-          <Pr:OBJECTIVE rdf:ID="ARP-4763-3.1">
-            <j.0:description>The aircraft/system functional hazard assessment is performed.</j.0:description>
-            <j.0:identifier>ARP-4763-3.1</j.0:identifier>
+          <Pr:OBJECTIVE rdf:ID="ARP-4754-5.2">
+            <j.0:description>Verification demonstrates intended function and confidence of no unintended function impacts to safety.</j.0:description>
+            <j.0:identifier>ARP-4754-5.2</j.0:identifier>
+          </Pr:OBJECTIVE>
+        </j.0:content>
+        <j.0:content>
+          <Pr:OBJECTIVE rdf:ID="ARP-4754-6.1">
+            <j.0:description>Configuration items are identified</j.0:description>
+            <j.0:identifier>ARP-4754-6.1</j.0:identifier>
+          </Pr:OBJECTIVE>
+        </j.0:content>
+        <j.0:content>
+          <Pr:OBJECTIVE rdf:ID="ARP-4754-5.3">
+            <j.0:description>Product implementation complies with aircraft, and system requirements.</j.0:description>
+            <j.0:identifier>ARP-4754-5.3</j.0:identifier>
+          </Pr:OBJECTIVE>
+        </j.0:content>
+        <j.0:content>
+          <Pr:OBJECTIVE rdf:ID="ARP-4754-5.6">
+            <j.0:description>Assessment of deficiencies and their related impact on safety is identified.</j.0:description>
+            <j.0:identifier>ARP-4754-5.6</j.0:identifier>
+          </Pr:OBJECTIVE>
+        </j.0:content>
+        <j.0:content>
+          <Pr:OBJECTIVE rdf:ID="ARP-4754-6.2">
+            <j.0:description>Configuration baseline and derivatives are established.</j.0:description>
+            <j.0:identifier>ARP-4754-6.2</j.0:identifier>
+          </Pr:OBJECTIVE>
+        </j.0:content>
+        <j.0:content>
+          <Pr:OBJECTIVE rdf:ID="ARP-4754-3.3">
+            <j.0:description>The preliminary system safety assessment is performed.</j.0:description>
+            <j.0:identifier>ARP-4754-3.3</j.0:identifier>
           </Pr:OBJECTIVE>
         </j.0:content>
       </D:SECTION>

--- a/RACK-Ontology/OwlModels/ARP-4754A.yaml
+++ b/RACK-Ontology/OwlModels/ARP-4754A.yaml
@@ -1,6 +1,6 @@
 # This file is intended to be used with the rack CLI script found in RACK/cli/
 #
 # Script documentation is available in RACK/cli/README.md
-data-graph: "http://rack001/arp-475a"
+data-graph: "http://rack001/arp-4754a"
 ingestion-steps:
 - { owl: "ARP-4754A.owl"}

--- a/RACK-Ontology/ontology/ARP-4754A/ARP-4754A.sadl
+++ b/RACK-Ontology/ontology/ARP-4754A/ARP-4754A.sadl
@@ -17,179 +17,179 @@ import "http://arcos.rack/DOCUMENT".
 ARP-4754A-AppendixA is a SECTION,
 	has title "PROCESS OBJECTIVES DATA",
      has content ARP-4754-1.1,
-     has content ARP-4755-1.2,
-     has content ARP-4756-2.1,
-     has content ARP-4757-2.2,
-     has content ARP-4758-2.3,
-     has content ARP-4759-2.4,
-     has content ARP-4760-2.5,
-     has content ARP-4761-2.6,
-     has content ARP-4762-2.7,
-     has content ARP-4763-3.1,
-     has content ARP-4764-3.2,
-     has content ARP-4765-3.3,
-     has content ARP-4766-3.4,
-     has content ARP-4767-3.5,
-     has content ARP-4768-3.6,
-     has content ARP-4769-3.7,
-     has content ARP-4770-4.1,
-     has content ARP-4771-4.2,
-     has content ARP-4772-4.3,
-     has content ARP-4773-4.4,
-     has content ARP-4774-4.5,
-     has content ARP-4775-4.6,
-     has content ARP-4776-5.1,
-     has content ARP-4777-5.2,
-     has content ARP-4778-5.3,
-     has content ARP-4779-5.4,
-     has content ARP-4780-5.5,
-     has content ARP-4781-5.6,
-     has content ARP-4782-6.1,
-     has content ARP-4783-6.2,
-     has content ARP-4784-6.3,
-     has content ARP-4785-6.4,
-     has content ARP-4786-7.1,
-     has content ARP-4787-7.2,
-     has content ARP-4788-8.1.
+     has content ARP-4754-1.2,
+     has content ARP-4754-2.1,
+     has content ARP-4754-2.2,
+     has content ARP-4754-2.3,
+     has content ARP-4754-2.4,
+     has content ARP-4754-2.5,
+     has content ARP-4754-2.6,
+     has content ARP-4754-2.7,
+     has content ARP-4754-3.1,
+     has content ARP-4754-3.2,
+     has content ARP-4754-3.3,
+     has content ARP-4754-3.4,
+     has content ARP-4754-3.5,
+     has content ARP-4754-3.6,
+     has content ARP-4754-3.7,
+     has content ARP-4754-4.1,
+     has content ARP-4754-4.2,
+     has content ARP-4754-4.3,
+     has content ARP-4754-4.4,
+     has content ARP-4754-4.5,
+     has content ARP-4754-4.6,
+     has content ARP-4754-5.1,
+     has content ARP-4754-5.2,
+     has content ARP-4754-5.3,
+     has content ARP-4754-5.4,
+     has content ARP-4754-5.5,
+     has content ARP-4754-5.6,
+     has content ARP-4754-6.1,
+     has content ARP-4754-6.2,
+     has content ARP-4754-6.3,
+     has content ARP-4754-6.4,
+     has content ARP-4754-7.1,
+     has content ARP-4754-7.2,
+     has content ARP-4754-8.1.
 
 ARP-4754-1.1 is a OBJECTIVE,
     has identifier "ARP-4754-1.1"
     has description "System development and integral process activities are defined".
 
-ARP-4755-1.2 is a OBJECTIVE,
-    has identifier "ARP-4755-1.2"
+ARP-4754-1.2 is a OBJECTIVE,
+    has identifier "ARP-4754-1.2"
     has description "Transition criteria and inter-relationship among processes are defined".
 
-ARP-4756-2.1 is a OBJECTIVE,
-    has identifier "ARP-4756-2.1"
+ARP-4754-2.1 is a OBJECTIVE,
+    has identifier "ARP-4754-2.1"
     has description "Aircraft-level functions, functional requirements, functional interfaces and assumptions are defined".
 
-ARP-4757-2.2 is a OBJECTIVE,
-    has identifier "ARP-4757-2.2"
+ARP-4754-2.2 is a OBJECTIVE,
+    has identifier "ARP-4754-2.2"
     has description "Aircraft functions are allocated to systems".
 
-ARP-4758-2.3 is a OBJECTIVE,
-    has identifier "ARP-4758-2.3"
+ARP-4754-2.3 is a OBJECTIVE,
+    has identifier "ARP-4754-2.3"
     has description "System requirements including assumptions and system interfaces are defined.".
 
-ARP-4759-2.4 is a OBJECTIVE,
-    has identifier "ARP-4759-2.4"
+ARP-4754-2.4 is a OBJECTIVE,
+    has identifier "ARP-4754-2.4"
     has description "System derived requirements (including derived safety-related requirements) are defined and rationale explained".
 
-ARP-4760-2.5 is a OBJECTIVE,
-    has identifier "ARP-4760-2.5"
+ARP-4754-2.5 is a OBJECTIVE,
+    has identifier "ARP-4754-2.5"
     has description "System architecture is defined.".
 
-ARP-4761-2.6 is a OBJECTIVE,
-    has identifier "ARP-4761-2.6"
+ARP-4754-2.6 is a OBJECTIVE,
+    has identifier "ARP-4754-2.6"
     has description "System requirements are allocated to items.".
 
-ARP-4762-2.7 is a OBJECTIVE,
-    has identifier "ARP-4762-2.7"
+ARP-4754-2.7 is a OBJECTIVE,
+    has identifier "ARP-4754-2.7"
     has description "Appropriate item, system and aircraft integrations are performed.".
 
-ARP-4763-3.1 is a OBJECTIVE,
-    has identifier "ARP-4763-3.1"
+ARP-4754-3.1 is a OBJECTIVE,
+    has identifier "ARP-4754-3.1"
     has description "The aircraft/system functional hazard assessment is performed.".
 
-ARP-4764-3.2 is a OBJECTIVE,
-    has identifier "ARP-4764-3.2"
+ARP-4754-3.2 is a OBJECTIVE,
+    has identifier "ARP-4754-3.2"
     has description "The preliminary aircraft safety assessment is performed.".
 
-ARP-4765-3.3 is a OBJECTIVE,
-    has identifier "ARP-4765-3.3"
+ARP-4754-3.3 is a OBJECTIVE,
+    has identifier "ARP-4754-3.3"
     has description "The preliminary system safety assessment is performed.".
 
-ARP-4766-3.4 is a OBJECTIVE,
-    has identifier "ARP-4766-3.4"
+ARP-4754-3.4 is a OBJECTIVE,
+    has identifier "ARP-4754-3.4"
     has description "The common cause analyses are performed.".
 
-ARP-4767-3.5 is a OBJECTIVE,
-    has identifier "ARP-4767-3.5"
+ARP-4754-3.5 is a OBJECTIVE,
+    has identifier "ARP-4754-3.5"
     has description "The aircraft safety assessment is performed.".
 
-ARP-4768-3.6 is a OBJECTIVE,
-    has identifier "ARP-4768-3.6"
+ARP-4754-3.6 is a OBJECTIVE,
+    has identifier "ARP-4754-3.6"
     has description "The system safety assessment is performed.".
 
-ARP-4769-3.7 is a OBJECTIVE,
-    has identifier "ARP-4769-3.7"
+ARP-4754-3.7 is a OBJECTIVE,
+    has identifier "ARP-4754-3.7"
     has description "Independence requirements in functions, systems and items are captured.".
 
-ARP-4770-4.1 is a OBJECTIVE,
-    has identifier "ARP-4770-4.1"
+ARP-4754-4.1 is a OBJECTIVE,
+    has identifier "ARP-4754-4.1"
     has description "Aircraft, system, items requirements are complete and correct.".
 
-ARP-4771-4.2 is a OBJECTIVE,
-    has identifier "ARP-4771-4.2"
+ARP-4754-4.2 is a OBJECTIVE,
+    has identifier "ARP-4754-4.2"
     has description "Assumptions are justified and validated.".
 
-ARP-4772-4.3 is a OBJECTIVE,
-    has identifier "ARP-4772-4.3"
+ARP-4754-4.3 is a OBJECTIVE,
+    has identifier "ARP-4754-4.3"
     has description "Derived requirements are justified and validated.".
 
-ARP-4773-4.4 is a OBJECTIVE,
-    has identifier "ARP-4773-4.4"
+ARP-4754-4.4 is a OBJECTIVE,
+    has identifier "ARP-4754-4.4"
     has description "Requirements are traceable.".
 
-ARP-4774-4.5 is a OBJECTIVE,
-    has identifier "ARP-4774-4.5"
+ARP-4754-4.5 is a OBJECTIVE,
+    has identifier "ARP-4754-4.5"
     has description "".
 
-ARP-4775-4.6 is a OBJECTIVE,
-    has identifier "ARP-4775-4.6"
+ARP-4754-4.6 is a OBJECTIVE,
+    has identifier "ARP-4754-4.6"
     has description "Validation compliance substantiation is provided.".
 
-ARP-4776-5.1 is a OBJECTIVE,
-    has identifier "ARP-4776-5.1"
+ARP-4754-5.1 is a OBJECTIVE,
+    has identifier "ARP-4754-5.1"
     has description "Test or demonstration procedures are correct.".
 
-ARP-4777-5.2 is a OBJECTIVE,
-    has identifier "ARP-4777-5.2"
+ARP-4754-5.2 is a OBJECTIVE,
+    has identifier "ARP-4754-5.2"
     has description "Verification demonstrates intended function and confidence of no unintended function impacts to safety.".
 
-ARP-4778-5.3 is a OBJECTIVE,
-    has identifier "ARP-4778-5.3"
+ARP-4754-5.3 is a OBJECTIVE,
+    has identifier "ARP-4754-5.3"
     has description "Product implementation complies with aircraft, and system requirements.".
 
-ARP-4779-5.4 is a OBJECTIVE,
-    has identifier "ARP-4779-5.4"
+ARP-4754-5.4 is a OBJECTIVE,
+    has identifier "ARP-4754-5.4"
     has description "Safety requirements are verified.".
 
-ARP-4780-5.5 is a OBJECTIVE,
-    has identifier "ARP-4780-5.5"
+ARP-4754-5.5 is a OBJECTIVE,
+    has identifier "ARP-4754-5.5"
     has description "Verification compliance substantiation is included.".
 
-ARP-4781-5.6 is a OBJECTIVE,
-    has identifier "ARP-4781-5.6"
+ARP-4754-5.6 is a OBJECTIVE,
+    has identifier "ARP-4754-5.6"
     has description "Assessment of deficiencies and their related impact on safety is identified.".
 
-ARP-4782-6.1 is a OBJECTIVE,
-    has identifier "ARP-4782-6.1"
+ARP-4754-6.1 is a OBJECTIVE,
+    has identifier "ARP-4754-6.1"
     has description "Configuration items are identified".
 
-ARP-4783-6.2 is a OBJECTIVE,
-    has identifier "ARP-4783-6.2"
+ARP-4754-6.2 is a OBJECTIVE,
+    has identifier "ARP-4754-6.2"
     has description "Configuration baseline and derivatives are established.".
 
-ARP-4784-6.3 is a OBJECTIVE,
-    has identifier "ARP-4784-6.3"
+ARP-4754-6.3 is a OBJECTIVE,
+    has identifier "ARP-4754-6.3"
     has description "Problem reporting , change control, change review, and configuration status accounting are established.".
 
-ARP-4785-6.4 is a OBJECTIVE,
-    has identifier "ARP-4785-6.4"
+ARP-4754-6.4 is a OBJECTIVE,
+    has identifier "ARP-4754-6.4"
     has description "Archive and retrieval are established.".
 
-ARP-4786-7.1 is a OBJECTIVE,
-    has identifier "ARP-4786-7.1"
+ARP-4754-7.1 is a OBJECTIVE,
+    has identifier "ARP-4754-7.1"
     has description "Assurance is obtained that necessary plans are developed and maintained for all aspects of system certification.".
 
-ARP-4787-7.2 is a OBJECTIVE,
-    has identifier "ARP-4787-7.2"
+ARP-4754-7.2 is a OBJECTIVE,
+    has identifier "ARP-4754-7.2"
     has description "Development activities and processes are conducted in accordance with those plans.".
 
-ARP-4788-8.1 is a OBJECTIVE,
-    has identifier "ARP-4788-8.1"
+ARP-4754-8.1 is a OBJECTIVE,
+    has identifier "ARP-4754-8.1"
     has description "Compliance substantiation is provided.".
 
 

--- a/cli/setup-arcos.sh
+++ b/cli/setup-arcos.sh
@@ -25,7 +25,7 @@ rack model import ../STR-Ontology/OwlModels/import.yaml
 rack nodegroups import ../nodegroups/ingestion/arcos.arbiter
 
 ### Applicable Standards ### copy any of these to the instance data load script and use when applicable
-# rack data import --clear ../RACK-Ontology/OwlModels/ARP-4754A.yaml     # from datagraph http://rack001/arp-475a
+# rack data import --clear ../RACK-Ontology/OwlModels/ARP-4754A.yaml     # from datagraph http://rack001/arp-4754a
 # rack data import --clear ../RACK-Ontology/OwlModels/DO-330.yaml        # from datagraph http://rack001/do-330
 # rack data import --clear ../RACK-Ontology/OwlModels/DO-178C.yaml         # from datagraph http://rack001/do-178c
 # rack data import --clear ../RACK-Ontology/OwlModels/MIL-STD-881D.yaml  # from datagraph http://rack001/mil-std-881d

--- a/cli/setup-clear.sh
+++ b/cli/setup-clear.sh
@@ -8,7 +8,7 @@ rack model clear
 
 rack data clear                               \
     --data-graph http://rack001/data          \
-    --data-graph http://rack001/arp-475a      \
+    --data-graph http://rack001/arp-4754a     \
     --data-graph http://rack001/do-330        \
     --data-graph http://rack001/do-178c       \
     --data-graph http://rack001/mil-std-881d

--- a/cli/setup-turnstile.sh
+++ b/cli/setup-turnstile.sh
@@ -15,7 +15,7 @@ rack model import ../SRI-Ontology/OwlModels/import.yaml
 
 
 ### Applicable Standards ### copy any of these to the instance data load script and use when applicable
-# rack data import --clear ../RACK-Ontology/OwlModels/ARP-4754A.yaml     # from datagraph http://rack001/arp-475a
+# rack data import --clear ../RACK-Ontology/OwlModels/ARP-4754A.yaml     # from datagraph http://rack001/arp-4754a
 # rack data import --clear ../RACK-Ontology/OwlModels/DO-330.yaml        # from datagraph http://rack001/do-330
 rack data import --clear ../RACK-Ontology/OwlModels/DO-178C.yaml         # from datagraph http://rack001/do-178c
 # rack data import --clear ../RACK-Ontology/OwlModels/MIL-STD-881D.yaml  # from datagraph http://rack001/mil-std-881d


### PR DESCRIPTION
- Typos in ARP-4754A.sadl -- ARP-47** should have been ARP-4754.
- Typo in ARP-4754A.yaml -- data-graph was missing the number 4
- Typos in .sh -- comments needed updating on data-graph from ARP-4754A.yaml