### PR TITLE
Fix new shellcheck warnings in lint job

### DIFF
--- a/assist/bin/sadl2owl
+++ b/assist/bin/sadl2owl
@@ -52,7 +52,7 @@ skip=(
 )
 
 for SFile in $(find ${INPDIR} -name '*.sadl') ; do
-    for S in ${skip[*]} ; do
+    for S in "${skip[*]}" ; do
         if [ "$(basename ${SFile})" = "$S" ] ; then
             continue 2
         fi

--- a/assist/bin/sadl2owl
+++ b/assist/bin/sadl2owl
@@ -52,7 +52,7 @@ skip=(
 )
 
 for SFile in $(find ${INPDIR} -name '*.sadl') ; do
-    for S in "${skip[*]}" ; do
+    for S in "${skip[@]}" ; do
         if [ "$(basename ${SFile})" = "$S" ] ; then
             continue 2
         fi

--- a/assist/databin/gcc
+++ b/assist/databin/gcc
@@ -75,11 +75,11 @@ nonce="n$(date +%s)-$$"
     echo ":- discontiguous file_committer/2."
     echo "build_inputs(${nonce@Q}, [ ${inf[*]@Q} ])."
     echo "build_outputs(${nonce@Q}, [ ${outf@Q} ])."
-    for inp in ${inf[*]} ; do
+    for inp in "${inf[*]}" ; do
         git log -n 1 --pretty=format:"file_committer(${inp@Q}, '%al').%n" "$inp" 2>/dev/null
     done
-    for lf in ${libs[*]} ; do
-        for ld in ${libdirs[*]} ; do
+    for lf in "${libs[*]}" ; do
+        for ld in "${libdirs[*]}" ; do
             for ext in .so .a ; do
                 # shellcheck disable=SC2005,SC2164
                 ldr=$(cd "${ld}"; echo $(top_rel_curdir))

--- a/assist/databin/gcc
+++ b/assist/databin/gcc
@@ -75,11 +75,11 @@ nonce="n$(date +%s)-$$"
     echo ":- discontiguous file_committer/2."
     echo "build_inputs(${nonce@Q}, [ ${inf[*]@Q} ])."
     echo "build_outputs(${nonce@Q}, [ ${outf@Q} ])."
-    for inp in "${inf[*]}" ; do
+    for inp in "${inf[@]}" ; do
         git log -n 1 --pretty=format:"file_committer(${inp@Q}, '%al').%n" "$inp" 2>/dev/null
     done
-    for lf in "${libs[*]}" ; do
-        for ld in "${libdirs[*]}" ; do
+    for lf in "${libs[@]}" ; do
+        for ld in "${libdirs[@]}" ; do
             for ext in .so .a ; do
                 # shellcheck disable=SC2005,SC2164
                 ldr=$(cd "${ld}"; echo $(top_rel_curdir))


### PR DESCRIPTION
sadl2owl - Fix SC2048 warning by using quotes.

gcc - Fix SC2048 warning by using quotes.

I notice some RACK shell scripts have a lot of "# shellcheck disable"
lines.  Note that if a shellcheck warning is a true positive (not a
false positive), it's better to fix the warning than to disable the
warning.