### PR TITLE
migration update

### DIFF
--- a/migration/rack/commits/__init__.py
+++ b/migration/rack/commits/__init__.py
@@ -14,6 +14,12 @@ from typing import List
 from ontology_changes.ontology_change import Commit
 from rack.commits import (
     # <CHANGE_CRAWLER_IMPORTS> DO NOT EDIT OR MOVE THIS LINE
+    commit278481ce335c98723597eadf89052a4b28f2eeec,
+    commit6a647ff8342a1cca6bdef8620a5bc29b4243e794,
+    commit40955e24b4e38d45df2ffd0ad8aa47a827a4c72f,
+    commite696969a9d85ca8f894eea12305412bdc05521b3,
+    commitee148bca649a1b451085832a7e2a488ce4127de7,
+    commit27fa0d8fe813d341918465a7102bd2a8a859fa5a,
     commit05a03cd687e3bdce425794763e0957d3ccaf8ff0,
     commit09b79d6c0e7f72b533a3ad21e776b200a973698a,
     commit0a89f70ff929380269a79fe2fc82f5dde346ed8c,
@@ -135,6 +141,12 @@ commits_in_chronological_order: List[Commit] = [
 
     commit3908d68df1143537a49e1df9556dae8066b0e25f.commit, # 2021 Oct 26
     commit38d1e00f36dacfccf9cff8d7793cd39f55a83682.commit, # 2021 Oct 29
+    commit278481ce335c98723597eadf89052a4b28f2eeec.commit, # 2021 Nov 10
+    commit6a647ff8342a1cca6bdef8620a5bc29b4243e794.commit, # 2021 Nov 11
+    commit40955e24b4e38d45df2ffd0ad8aa47a827a4c72f.commit, # 2021 Nov 24
+    commite696969a9d85ca8f894eea12305412bdc05521b3.commit, # 2021 Nov 29
+    commitee148bca649a1b451085832a7e2a488ce4127de7.commit, # 2021 Nov 29
+    commit27fa0d8fe813d341918465a7102bd2a8a859fa5a.commit, # 2021 Nov 29
 
     # most recent (in history)
 ]

--- a/migration/rack/commits/commit05a03cd687e3bdce425794763e0957d3ccaf8ff0.py
+++ b/migration/rack/commits/commit05a03cd687e3bdce425794763e0957d3ccaf8ff0.py
@@ -9,7 +9,6 @@
 # material are those of the author(s) and do not necessarily reflect the views
 # of the Defense Advanced Research Projects Agency (DARPA).
 
-from migration_helpers.name_space import rack
 from ontology_changes import (
     AtMost,
     ChangeCardinality,
@@ -17,9 +16,7 @@ from ontology_changes import (
     Commit,
     RemoveIsATypeOf,
 )
-
-HAZARD = rack("HAZARD")
-PROV_S = rack("PROV-S")
+from rack.namespaces.rack_ontology import HAZARD, PROV_S
 
 commit = Commit(
     number="05a03cd687e3bdce425794763e0957d3ccaf8ff0",

--- a/migration/rack/commits/commit09b79d6c0e7f72b533a3ad21e776b200a973698a.py
+++ b/migration/rack/commits/commit09b79d6c0e7f72b533a3ad21e776b200a973698a.py
@@ -9,16 +9,12 @@
 # material are those of the author(s) and do not necessarily reflect the views
 # of the Defense Advanced Research Projects Agency (DARPA).
 
-from migration_helpers.name_space import rack
 from ontology_changes import AtMost, ChangeCardinality, Commit
-
-HAZARD = rack("HAZARD")
-SYSTEM = rack("SYSTEM")
+from rack.namespaces.rack_ontology import HAZARD, SYSTEM
 
 commit = Commit(
     number="09b79d6c0e7f72b533a3ad21e776b200a973698a",
     changes=[
-
         # HAZARD.sadl
         ChangeCardinality(
             name_space=HAZARD,
@@ -38,7 +34,6 @@ commit = Commit(
             property_id="likelihood",
             to_cardinality=AtMost(1),
         ),
-
         # SYSTEM.sadl
         ChangeCardinality(
             name_space=SYSTEM,
@@ -46,6 +41,5 @@ commit = Commit(
             property_id="parentFunction",
             to_cardinality=AtMost(1),
         ),
-
     ],
 )

--- a/migration/rack/commits/commit10da69db606ebdc721fd3f8e003ef2099a5fdc43.py
+++ b/migration/rack/commits/commit10da69db606ebdc721fd3f8e003ef2099a5fdc43.py
@@ -9,11 +9,8 @@
 # material are those of the author(s) and do not necessarily reflect the views
 # of the Defense Advanced Research Projects Agency (DARPA).
 
-from migration_helpers.name_space import rack
 from ontology_changes import Commit, CreateClass, RenameProperty
-
-DOCUMENT = rack("DOCUMENT")
-PROV_S = rack("PROV-S")
+from rack.namespaces.rack_ontology import DOCUMENT, PROV_S
 
 commit = Commit(
     number="10da69db606ebdc721fd3f8e003ef2099a5fdc43",

--- a/migration/rack/commits/commit13ed266ba5730cebe75c0c48f6ba83af69429122.py
+++ b/migration/rack/commits/commit13ed266ba5730cebe75c0c48f6ba83af69429122.py
@@ -9,11 +9,8 @@
 # material are those of the author(s) and do not necessarily reflect the views
 # of the Defense Advanced Research Projects Agency (DARPA).
 
-from migration_helpers.name_space import rack
 from ontology_changes import Commit, RenameProperty
-
-PROV_S = rack("PROV-S")
-REQUIREMENTS = rack("REQUIREMENTS")
+from rack.namespaces.rack_ontology import PROV_S, REQUIREMENTS
 
 commit = Commit(
     number="13ed266ba5730cebe75c0c48f6ba83af69429122",

--- a/migration/rack/commits/commit183dbba72623c2585a0451a19ac1ddb30f8a0ea6.py
+++ b/migration/rack/commits/commit183dbba72623c2585a0451a19ac1ddb30f8a0ea6.py
@@ -9,11 +9,8 @@
 # material are those of the author(s) and do not necessarily reflect the views
 # of the Defense Advanced Research Projects Agency (DARPA).
 
-from migration_helpers.name_space import rack
 from ontology_changes import ChangePropertyRange, Commit, RenameProperty
-
-FILE = rack("FILE")
-PROV_S = rack("PROV-S")
+from rack.namespaces.rack_ontology import FILE, PROV_S
 
 commit = Commit(
     number="183dbba72623c2585a0451a19ac1ddb30f8a0ea6",

--- a/migration/rack/commits/commit278481ce335c98723597eadf89052a4b28f2eeec.py
+++ b/migration/rack/commits/commit278481ce335c98723597eadf89052a4b28f2eeec.py
@@ -9,13 +9,11 @@
 # material are those of the author(s) and do not necessarily reflect the views
 # of the Defense Advanced Research Projects Agency (DARPA).
 
-from ontology_changes import Commit, FreeformNotes
+from ontology_changes import Commit
 
 commit = Commit(
-    number="0a89f70ff929380269a79fe2fc82f5dde346ed8c",
+    number="278481ce335c98723597eadf89052a4b28f2eeec",
     changes=[
-        FreeformNotes(
-            text="SACM-S.sadl was removed from the RACK-Ontology and moved to LM-Ontology",
-        )
+        # Nothing
     ],
 )

--- a/migration/rack/commits/commit27fa0d8fe813d341918465a7102bd2a8a859fa5a.py
+++ b/migration/rack/commits/commit27fa0d8fe813d341918465a7102bd2a8a859fa5a.py
@@ -1,0 +1,173 @@
+# Copyright (c) 2021, Galois, Inc.
+#
+# All Rights Reserved
+#
+# This material is based upon work supported by the Defense Advanced Research
+# Projects Agency (DARPA) under Contract No. FA8750-20-C-0203.
+#
+# Any opinions, findings and conclusions or recommendations expressed in this
+# material are those of the author(s) and do not necessarily reflect the views
+# of the Defense Advanced Research Projects Agency (DARPA).
+
+from ontology_changes import Commit, RenameProperty
+from rack.namespaces.rack_ontology import (
+    CONFIDENCE,
+    FILE,
+    HAZARD,
+    PROV_S,
+    REQUIREMENTS,
+    REVIEW,
+    SOFTWARE,
+    SYSTEM,
+    TESTING,
+)
+
+commit = Commit(
+    number="27fa0d8fe813d341918465a7102bd2a8a859fa5a",
+    changes=[
+        # CONFIDENCE.sadl
+        RenameProperty(
+            from_name_space=CONFIDENCE,
+            from_class="CONFIDENCE_ASSESSMENT",
+            from_name="createBy",
+            to_name_space=CONFIDENCE,
+            to_class="ENTITY",
+            to_name="wasGeneratedBy",
+        ),
+        RenameProperty(
+            from_name_space=CONFIDENCE,
+            from_class="ASSESSING_CONFIDENCE",
+            from_name="createBy",
+            to_name_space=CONFIDENCE,
+            to_class="ENTITY",
+            to_name="wasGeneratedBy",
+        ),
+        # FILE.sadl
+        RenameProperty(
+            from_name_space=FILE,
+            from_class="FILE",
+            from_name="createdBy",
+            to_name_space=PROV_S,
+            to_class="ENTITY",
+            to_name="wasGeneratedBy",
+        ),
+        # HAZARD.sadl
+        RenameProperty(
+            from_name_space=HAZARD,
+            from_class="HAZARD",
+            from_name="identified",
+            to_name_space=PROV_S,
+            to_class="ENTITY",
+            to_name="wasGeneratedBy",
+        ),
+        RenameProperty(
+            from_name_space=HAZARD,
+            from_class="HAZARD",
+            from_name="H:author",
+            to_name_space=PROV_S,
+            to_class="ACTIVITY",
+            to_name="wasAssociatedWith",
+        ),
+        # REQUIREMENTS.sadl
+        RenameProperty(
+            from_name_space=REQUIREMENTS,
+            from_class="REQUIREMENT",
+            from_name="Rq:createdBy",
+            to_name_space=PROV_S,
+            to_class="ENTITY",
+            to_name="wasGeneratedBy",
+        ),
+        RenameProperty(
+            from_name_space=REQUIREMENTS,
+            from_class="DATA_DICTIONARY_TERM",
+            from_name="Rq:createdBy",
+            to_name_space=PROV_S,
+            to_class="ENTITY",
+            to_name="wasGeneratedBy",
+        ),
+        RenameProperty(
+            from_name_space=REQUIREMENTS,
+            from_class="REQUIREMENT_DEVELOPMENT",
+            from_name="Rq:author",
+            to_name_space=PROV_S,
+            to_class="ACTIVITY",
+            to_name="wasAssociatedWith",
+        ),
+        # REVIEW.sadl
+        RenameProperty(
+            from_name_space=REVIEW,
+            from_class="REVIEW_LOG",
+            from_name="createBy",
+            to_name_space=PROV_S,
+            to_class="ENTITY",
+            to_name="wasGeneratedBy",
+        ),
+        # SOFTWARE.sadl
+        RenameProperty(
+            from_name_space=SOFTWARE,
+            from_class="CODE_DEVELOPMENT",
+            from_name="author",
+            to_name_space=PROV_S,
+            to_class="ACTIVITY",
+            to_name="wasAssociatedWith",
+        ),
+        RenameProperty(
+            from_name_space=SOFTWARE,
+            from_class="CODE_GEN",
+            from_name="sw:performedBy",
+            to_name_space=PROV_S,
+            to_class="ACTIVITY",
+            to_name="wasAssociatedWith",
+        ),
+        # SYSTEM.sadl
+        RenameProperty(
+            from_name_space=SYSTEM,
+            from_class="SYSTEM",
+            from_name="producedBy",
+            to_name_space=PROV_S,
+            to_class="ENTITY",
+            to_name="wasGeneratedBy",
+        ),
+        RenameProperty(
+            from_name_space=REQUIREMENTS,
+            from_class="INTERFACE",
+            from_name="identifiedBy",
+            to_name_space=PROV_S,
+            to_class="ENTITY",
+            to_name="wasGeneratedBy",
+        ),
+        RenameProperty(
+            from_name_space=REQUIREMENTS,
+            from_class="SYSTEM_DEVELOPMENT",
+            from_name="developedBy",
+            to_name_space=PROV_S,
+            to_class="ACTIVITY",
+            to_name="wasAssociatedWith",
+        ),
+        # TESTING.sadl
+        RenameProperty(
+            from_name_space=TESTING,
+            from_class="TEST_RESULT",
+            from_name="executedBy",
+            to_name_space=PROV_S,
+            to_class="ENTITY",
+            to_name="wasGeneratedBy",
+        ),
+        RenameProperty(
+            from_name_space=TESTING,
+            from_class="TEST_DEVELOPMENT",
+            from_name="developedBy",
+            to_name_space=PROV_S,
+            to_class="ACTIVITY",
+            to_name="wasAssociatedWith",
+        ),
+        RenameProperty(
+            from_name_space=TESTING,
+            from_class="TEST_EXECUTION",
+            from_name="executedOn",
+            to_name_space=PROV_S,
+            to_class="ACTIVITY",
+            to_name="wasAssociatedWith",
+        ),
+    ],
+)

--- a/migration/rack/commits/commit2e079bb2a32b3cc1b3153d44ad0c21e27507937f.py
+++ b/migration/rack/commits/commit2e079bb2a32b3cc1b3153d44ad0c21e27507937f.py
@@ -9,7 +9,6 @@
 # material are those of the author(s) and do not necessarily reflect the views
 # of the Defense Advanced Research Projects Agency (DARPA).
 
-from migration_helpers.name_space import rack
 from ontology_changes import (
     Commit,
     ChangeCardinality,
@@ -17,9 +16,7 @@ from ontology_changes import (
     ChangePropertyRange,
     SingleValue,
 )
-
-PROV_S = rack("PROV-S")
-TESTING = rack("TESTING")
+from rack.namespaces.rack_ontology import PROV_S, TESTING
 
 commit = Commit(
     number="2e079bb2a32b3cc1b3153d44ad0c21e27507937f",

--- a/migration/rack/commits/commit3908d68df1143537a49e1df9556dae8066b0e25f.py
+++ b/migration/rack/commits/commit3908d68df1143537a49e1df9556dae8066b0e25f.py
@@ -9,10 +9,8 @@
 # material are those of the author(s) and do not necessarily reflect the views
 # of the Defense Advanced Research Projects Agency (DARPA).
 
-from migration_helpers.name_space import rack
 from ontology_changes import Commit, RemovePropertyRestriction
-
-CONFIDENCE = rack("CONFIDENCE")
+from rack.namespaces.rack_ontology import CONFIDENCE
 
 commit = Commit(
     number="3908d68df1143537a49e1df9556dae8066b0e25f",

--- a/migration/rack/commits/commit40955e24b4e38d45df2ffd0ad8aa47a827a4c72f.py
+++ b/migration/rack/commits/commit40955e24b4e38d45df2ffd0ad8aa47a827a4c72f.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2021, Galois, Inc.
+#
+# All Rights Reserved
+#
+# This material is based upon work supported by the Defense Advanced Research
+# Projects Agency (DARPA) under Contract No. FA8750-20-C-0203.
+#
+# Any opinions, findings and conclusions or recommendations expressed in this
+# material are those of the author(s) and do not necessarily reflect the views
+# of the Defense Advanced Research Projects Agency (DARPA).
+
+from ontology_changes import (
+    Commit,
+    CreateProperty,
+    DeleteClass,
+    DeleteProperty,
+    RenameProperty,
+)
+from ontology_changes.create_class import CreateClass
+from rack.namespaces.rack_ontology import (
+    AGENTS,
+    ANALYSIS,
+    FILE,
+    PROCESS,
+    PROV_S,
+    TESTING,
+)
+
+commit = Commit(
+    number="40955e24b4e38d45df2ffd0ad8aa47a827a4c72f",
+    changes=[
+        # AGENTS.sadl
+        CreateProperty(
+            name_space=AGENTS,
+            class_id="TOOL",
+            property_id="toolInstallationConfiguration",
+        ),
+        # ANALYSIS.sadl
+        DeleteProperty(name_space=ANALYSIS, property_id="result"),
+        DeleteProperty(name_space=ANALYSIS, property_id="metric"),
+        DeleteProperty(name_space=ANALYSIS, property_id="producedBy"),
+        DeleteClass(name_space=ANALYSIS, class_id="ANALYSIS_RESULT"),
+        RenameProperty(
+            from_name_space=ANALYSIS,
+            from_class="ANALYSIS",
+            from_name="performedBy",
+            to_name_space=ANALYSIS,
+            to_class="ANALYSIS",
+            to_name="runBy",
+        ),
+        CreateProperty(
+            name_space=ANALYSIS,
+            class_id="ANALYSIS",
+            property_id="analyzedWith",
+        ),
+        CreateProperty(
+            name_space=ANALYSIS,
+            class_id="ANALYSIS",
+            property_id="analysisInput",
+        ),
+        CreateProperty(
+            name_space=ANALYSIS,
+            class_id="ANALYSIS",
+            property_id="analysisConfiguration",
+        ),
+        DeleteClass(name_space=ANALYSIS, class_id="ANALYSIS_ANNOTATION_TYPE"),
+        DeleteClass(name_space=ANALYSIS, class_id="PRECONDITION"),
+        DeleteClass(name_space=ANALYSIS, class_id="POSTCONDITION"),
+        DeleteClass(name_space=ANALYSIS, class_id="INVARIANT"),
+        DeleteClass(name_space=ANALYSIS, class_id="ANALYSIS_ANNOTATION"),
+        DeleteProperty(name_space=ANALYSIS, property_id="fromReport"),
+        DeleteProperty(name_space=ANALYSIS, property_id="annotationType"),
+        # FILE.sadl
+        RenameProperty(
+            from_name_space=FILE,
+            from_class="FILE",
+            from_name="createBy",
+            to_name_space=FILE,
+            to_class="FILE",
+            to_name="createdBy",
+        ),
+        # PROCESS.sadl
+        CreateClass(name_space=PROCESS, class_id="PROPERTY"),
+        CreateProperty(
+            name_space=PROCESS, class_id="PROPERTY", property_id="partiallySupports"
+        ),
+        CreateProperty(name_space=PROCESS, class_id="PROPERTY", property_id="scopeOf"),
+        CreateProperty(
+            name_space=PROCESS, class_id="PROPERTY", property_id="mitigates"
+        ),
+        # PROV-S.sadl
+        CreateProperty(name_space=PROV_S, class_id="ACTIVITY", property_id="goal"),
+        # TESTING.sadl
+        RenameProperty(
+            from_name_space=TESTING,
+            from_class="TEST",
+            from_name="producedBy",
+            to_name_space=PROV_S,
+            to_class="ENTITY",
+            to_name="wasGeneratedBy",
+        ),
+    ],
+)

--- a/migration/rack/commits/commit44393cc30bb0ba7482acd21b2e68576b577179f9.py
+++ b/migration/rack/commits/commit44393cc30bb0ba7482acd21b2e68576b577179f9.py
@@ -9,7 +9,6 @@
 # material are those of the author(s) and do not necessarily reflect the views
 # of the Defense Advanced Research Projects Agency (DARPA).
 
-from migration_helpers.name_space import rack
 from ontology_changes import (
     ChangeCardinality,
     ChangeClassIsATypeOf,
@@ -17,10 +16,7 @@ from ontology_changes import (
     Commit,
     SingleValue,
 )
-
-DOCUMENT = rack("DOCUMENT")
-PROV_S = rack("PROV-S")
-REVIEW = rack("REVIEW")
+from rack.namespaces.rack_ontology import DOCUMENT, PROV_S, REVIEW
 
 commit = Commit(
     number="44393cc30bb0ba7482acd21b2e68576b577179f9",

--- a/migration/rack/commits/commit581f1820855eee2445d9e8bfdbb639e169e9391e.py
+++ b/migration/rack/commits/commit581f1820855eee2445d9e8bfdbb639e169e9391e.py
@@ -9,12 +9,8 @@
 # material are those of the author(s) and do not necessarily reflect the views
 # of the Defense Advanced Research Projects Agency (DARPA).
 
-from migration_helpers.name_space import rack
 from ontology_changes import ChangeClassIsATypeOf, Commit
-
-DOCUMENT = rack("DOCUMENT")
-PROV_S = rack("PROV-S")
-REVIEW = rack("REVIEW")
+from rack.namespaces.rack_ontology import DOCUMENT, PROV_S, REVIEW
 
 commit = Commit(
     number="581f1820855eee2445d9e8bfdbb639e169e9391e",

--- a/migration/rack/commits/commit620b89db747b9834013502061040f179da67f123.py
+++ b/migration/rack/commits/commit620b89db747b9834013502061040f179da67f123.py
@@ -9,11 +9,8 @@
 # material are those of the author(s) and do not necessarily reflect the views
 # of the Defense Advanced Research Projects Agency (DARPA).
 
-from migration_helpers.name_space import rack
 from ontology_changes import ChangePropertyRange, Commit, RenameProperty
-
-FILE = rack("FILE")
-PROV_S = rack("PROV-S")
+from rack.namespaces.rack_ontology import FILE, PROV_S
 
 commit = Commit(
     number="620b89db747b9834013502061040f179da67f123",

--- a/migration/rack/commits/commit643839e7d8036731ba1da767942c8e74c2876e2e.py
+++ b/migration/rack/commits/commit643839e7d8036731ba1da767942c8e74c2876e2e.py
@@ -9,7 +9,6 @@
 # material are those of the author(s) and do not necessarily reflect the views
 # of the Defense Advanced Research Projects Agency (DARPA).
 
-from migration_helpers.name_space import rack
 from ontology_changes import (
     AtMost,
     ChangeCardinality,
@@ -19,10 +18,7 @@ from ontology_changes import (
     RenameProperty,
     SingleValue,
 )
-
-FILE = rack("FILE")
-PROV_S = rack("PROV-S")
-SOFTWARE = rack("SOFTWARE")
+from rack.namespaces.rack_ontology import FILE, PROV_S, SOFTWARE
 
 commit = Commit(
     number="643839e7d8036731ba1da767942c8e74c2876e2e",

--- a/migration/rack/commits/commit698bd1306d2e6efdc7b53bf0b6792ab2054d5389.py
+++ b/migration/rack/commits/commit698bd1306d2e6efdc7b53bf0b6792ab2054d5389.py
@@ -9,10 +9,8 @@
 # material are those of the author(s) and do not necessarily reflect the views
 # of the Defense Advanced Research Projects Agency (DARPA).
 
-from migration_helpers.name_space import rack
 from ontology_changes import AddClass, Commit
-
-BASELINE = rack("BASELINE")
+from rack.namespaces.rack_ontology import BASELINE
 
 commit = Commit(
     number="698bd1306d2e6efdc7b53bf0b6792ab2054d5389",

--- a/migration/rack/commits/commit6a647ff8342a1cca6bdef8620a5bc29b4243e794.py
+++ b/migration/rack/commits/commit6a647ff8342a1cca6bdef8620a5bc29b4243e794.py
@@ -9,13 +9,11 @@
 # material are those of the author(s) and do not necessarily reflect the views
 # of the Defense Advanced Research Projects Agency (DARPA).
 
-from ontology_changes import Commit, FreeformNotes
+from ontology_changes import Commit
 
 commit = Commit(
-    number="0a89f70ff929380269a79fe2fc82f5dde346ed8c",
+    number="6a647ff8342a1cca6bdef8620a5bc29b4243e794",
     changes=[
-        FreeformNotes(
-            text="SACM-S.sadl was removed from the RACK-Ontology and moved to LM-Ontology",
-        )
+        # Fixes in ARP-4754A.sadl
     ],
 )

--- a/migration/rack/commits/commit78eaae3db5ed184c90f4f14d34a4fc000f04bdac.py
+++ b/migration/rack/commits/commit78eaae3db5ed184c90f4f14d34a4fc000f04bdac.py
@@ -9,10 +9,8 @@
 # material are those of the author(s) and do not necessarily reflect the views
 # of the Defense Advanced Research Projects Agency (DARPA).
 
-from migration_helpers.name_space import rack
 from ontology_changes import Commit, RenameClass
-
-SOFTWARE = rack("SOFTWARE")
+from rack.namespaces.rack_ontology import SOFTWARE
 
 commit = Commit(
     number="78eaae3db5ed184c90f4f14d34a4fc000f04bdac",

--- a/migration/rack/commits/commit833ef18f5024fee255f77887de2c8e9bc136e56d.py
+++ b/migration/rack/commits/commit833ef18f5024fee255f77887de2c8e9bc136e56d.py
@@ -9,10 +9,7 @@
 # material are those of the author(s) and do not necessarily reflect the views
 # of the Defense Advanced Research Projects Agency (DARPA).
 
-from migration_helpers.name_space import rack
 from ontology_changes import AtMost, ChangeCardinality, Commit, RenameProperty
-
-PROV_S = rack("PROV-S")
 
 commit = Commit(
     number="833ef18f5024fee255f77887de2c8e9bc136e56d",

--- a/migration/rack/commits/commit90f2d4f55668786ffa01bba2a646c7468849c97d.py
+++ b/migration/rack/commits/commit90f2d4f55668786ffa01bba2a646c7468849c97d.py
@@ -9,7 +9,6 @@
 # material are those of the author(s) and do not necessarily reflect the views
 # of the Defense Advanced Research Projects Agency (DARPA).
 
-from migration_helpers.name_space import rack
 from ontology_changes import (
     AtMost,
     Commit,
@@ -18,9 +17,6 @@ from ontology_changes import (
     RenameClass,
     SingleValue,
 )
-
-ANALYSIS = rack("ANALYSIS")
-PROV_S = rack("PROV-S")
 
 commit = Commit(
     number="90f2d4f55668786ffa01bba2a646c7468849c97d",

--- a/migration/rack/commits/commit9af9030fe191d564875c067f6e0319ca6b52b798.py
+++ b/migration/rack/commits/commit9af9030fe191d564875c067f6e0319ca6b52b798.py
@@ -9,7 +9,6 @@
 # material are those of the author(s) and do not necessarily reflect the views
 # of the Defense Advanced Research Projects Agency (DARPA).
 
-from migration_helpers.name_space import rack
 from ontology_changes import (
     AtMost,
     ChangeCardinality,
@@ -18,9 +17,7 @@ from ontology_changes import (
     DeleteClass,
     RenameProperty,
 )
-
-AGENTS = rack("AGENTS")
-PROV_S = rack("PROV-S")
+from rack.namespaces.rack_ontology import AGENTS, PROV_S
 
 commit = Commit(
     number="9af9030fe191d564875c067f6e0319ca6b52b798",

--- a/migration/rack/commits/commitae0a7660b0afdd53ff334577fbdea7749abe6cf6.py
+++ b/migration/rack/commits/commitae0a7660b0afdd53ff334577fbdea7749abe6cf6.py
@@ -9,10 +9,8 @@
 # material are those of the author(s) and do not necessarily reflect the views
 # of the Defense Advanced Research Projects Agency (DARPA).
 
-from migration_helpers.name_space import rack
 from ontology_changes import Commit, CreateProperty
-
-PROV_S = rack("PROV-S")
+from rack.namespaces.rack_ontology import PROV_S
 
 commit = Commit(
     number="ae0a7660b0afdd53ff334577fbdea7749abe6cf6",

--- a/migration/rack/commits/commitb25d07626e4693cd370a2070e17f6baa825a1d43.py
+++ b/migration/rack/commits/commitb25d07626e4693cd370a2070e17f6baa825a1d43.py
@@ -9,11 +9,8 @@
 # material are those of the author(s) and do not necessarily reflect the views
 # of the Defense Advanced Research Projects Agency (DARPA).
 
-from migration_helpers.name_space import rack
 from ontology_changes import AddClass, Commit, DeleteProperty
-
-MODEL = rack("MODEL")
-REQUIREMENTS = rack("REQUIREMENTS")
+from rack.namespaces.rack_ontology import MODEL, REQUIREMENTS
 
 commit = Commit(
     number="b25d07626e4693cd370a2070e17f6baa825a1d43",

--- a/migration/rack/commits/commitb721c16f0f7420a8ccd92bda0d98a96c16dc62b8.py
+++ b/migration/rack/commits/commitb721c16f0f7420a8ccd92bda0d98a96c16dc62b8.py
@@ -9,10 +9,8 @@
 # material are those of the author(s) and do not necessarily reflect the views
 # of the Defense Advanced Research Projects Agency (DARPA).
 
-from migration_helpers.name_space import rack
 from ontology_changes import ChangeCardinality, Commit, Unconstrained
-
-REVIEW = rack("REVIEW")
+from rack.namespaces.rack_ontology import REVIEW
 
 commit = Commit(
     number="b721c16f0f7420a8ccd92bda0d98a96c16dc62b8",

--- a/migration/rack/commits/commitbdfef3d7ea9b3c9fc085defa8e26256f646097d9.py
+++ b/migration/rack/commits/commitbdfef3d7ea9b3c9fc085defa8e26256f646097d9.py
@@ -9,7 +9,6 @@
 # material are those of the author(s) and do not necessarily reflect the views
 # of the Defense Advanced Research Projects Agency (DARPA).
 
-from migration_helpers.name_space import rack
 from ontology_changes import (
     AddPropertyIsATypeOf,
     AtMost,
@@ -23,10 +22,7 @@ from ontology_changes import (
     RenameProperty,
     RemoveIsATypeOf,
 )
-
-PROV_S = rack("PROV-S")
-SOFTWARE = rack("SOFTWARE")
-SYSTEM = rack("SYSTEM")
+from rack.namespaces.rack_ontology import PROV_S, SOFTWARE, SYSTEM
 
 commit = Commit(
     number="bdfef3d7ea9b3c9fc085defa8e26256f646097d9",

--- a/migration/rack/commits/commitc41222325db52df0eb5c1e7cb3a091f8c62f5b57.py
+++ b/migration/rack/commits/commitc41222325db52df0eb5c1e7cb3a091f8c62f5b57.py
@@ -9,12 +9,9 @@
 # material are those of the author(s) and do not necessarily reflect the views
 # of the Defense Advanced Research Projects Agency (DARPA).
 
-from migration_helpers.name_space import rack
 from ontology_changes import ChangeCardinality, Commit
 from ontology_changes.cardinality import AtMost
-
-AGENTS = rack("AGENTS")
-PROV_S = rack("PROV-S")
+from rack.namespaces.rack_ontology import AGENTS, PROV_S
 
 commit = Commit(
     number="c41222325db52df0eb5c1e7cb3a091f8c62f5b57",

--- a/migration/rack/commits/commitd8271d216704351cf0007a04abac47f4abc993ad.py
+++ b/migration/rack/commits/commitd8271d216704351cf0007a04abac47f4abc993ad.py
@@ -9,11 +9,14 @@
 # material are those of the author(s) and do not necessarily reflect the views
 # of the Defense Advanced Research Projects Agency (DARPA).
 
-from migration_helpers.name_space import rack
-from ontology_changes import AtMost, ChangeCardinality, Commit, ChangePropertyIsATypeOf, SingleValue
-
-PROV_S = rack("PROV-S")
-REQUIREMENTS = rack("REQUIREMENTS")
+from ontology_changes import (
+    AtMost,
+    ChangeCardinality,
+    Commit,
+    ChangePropertyIsATypeOf,
+    SingleValue,
+)
+from rack.namespaces.rack_ontology import PROV_S, REQUIREMENTS
 
 commit = Commit(
     number="d8271d216704351cf0007a04abac47f4abc993ad",

--- a/migration/rack/commits/commite696969a9d85ca8f894eea12305412bdc05521b3.py
+++ b/migration/rack/commits/commite696969a9d85ca8f894eea12305412bdc05521b3.py
@@ -9,13 +9,13 @@
 # material are those of the author(s) and do not necessarily reflect the views
 # of the Defense Advanced Research Projects Agency (DARPA).
 
-from ontology_changes import Commit, FreeformNotes
+from ontology_changes import Commit, CreateProperty
+from rack.namespaces.rack_ontology import PROV_S
 
 commit = Commit(
-    number="0a89f70ff929380269a79fe2fc82f5dde346ed8c",
+    number="e696969a9d85ca8f894eea12305412bdc05521b3",
     changes=[
-        FreeformNotes(
-            text="SACM-S.sadl was removed from the RACK-Ontology and moved to LM-Ontology",
-        )
+        # PROV-S.sadl
+        CreateProperty(name_space=PROV_S, class_id="ENTITY", property_id="entityURL"),
     ],
 )

--- a/migration/rack/commits/commitee148bca649a1b451085832a7e2a488ce4127de7.py
+++ b/migration/rack/commits/commitee148bca649a1b451085832a7e2a488ce4127de7.py
@@ -9,13 +9,11 @@
 # material are those of the author(s) and do not necessarily reflect the views
 # of the Defense Advanced Research Projects Agency (DARPA).
 
-from ontology_changes import Commit, FreeformNotes
+from ontology_changes import Commit
 
 commit = Commit(
-    number="0a89f70ff929380269a79fe2fc82f5dde346ed8c",
+    number="ee148bca649a1b451085832a7e2a488ce4127de7",
     changes=[
-        FreeformNotes(
-            text="SACM-S.sadl was removed from the RACK-Ontology and moved to LM-Ontology",
-        )
+        # Nothing
     ],
 )

--- a/migration/rack/commits/commitfa603aad886439eb6a94e44e2c6f4851af16c9a3.py
+++ b/migration/rack/commits/commitfa603aad886439eb6a94e44e2c6f4851af16c9a3.py
@@ -9,11 +9,8 @@
 # material are those of the author(s) and do not necessarily reflect the views
 # of the Defense Advanced Research Projects Agency (DARPA).
 
-from migration_helpers.name_space import rack
 from ontology_changes import Commit, ChangePropertyIsATypeOf, DeleteClass
-
-CONFIDENCE = rack("CONFIDENCE")
-PROV_S = rack("PROV-S")
+from rack.namespaces.rack_ontology import CONFIDENCE, PROV_S
 
 commit = Commit(
     number="fa603aad886439eb6a94e44e2c6f4851af16c9a3",

--- a/migration/rack/commits/commitff31a28051a5e348fd2474fce5360195999ddb3a.py
+++ b/migration/rack/commits/commitff31a28051a5e348fd2474fce5360195999ddb3a.py
@@ -9,10 +9,8 @@
 # material are those of the author(s) and do not necessarily reflect the views
 # of the Defense Advanced Research Projects Agency (DARPA).
 
-from migration_helpers.name_space import rack
 from ontology_changes import ChangeCardinality, Commit, Unconstrained
-
-REQUIREMENTS = rack("REQUIREMENTS")
+from rack.namespaces.rack_ontology import REQUIREMENTS
 
 commit = Commit(
     number="ff31a28051a5e348fd2474fce5360195999ddb3a",

--- a/migration/rack/commits/template.py
+++ b/migration/rack/commits/template.py
@@ -9,7 +9,6 @@
 # material are those of the author(s) and do not necessarily reflect the views
 # of the Defense Advanced Research Projects Agency (DARPA).
 
-# from migration_helpers.name_space import rack
 from ontology_changes import Commit
 
 raise Exception(

--- a/migration/rack/namespaces/rack_ontology.py
+++ b/migration/rack/namespaces/rack_ontology.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2021, Galois, Inc.
+#
+# All Rights Reserved
+#
+# This material is based upon work supported by the Defense Advanced Research
+# Projects Agency (DARPA) under Contract No. FA8750-20-C-0203.
+#
+# Any opinions, findings and conclusions or recommendations expressed in this
+# material are those of the author(s) and do not necessarily reflect the views
+# of the Defense Advanced Research Projects Agency (DARPA).
+
+from migration_helpers.name_space import rack
+
+AGENTS = rack("AGENTS")
+ANALYSIS = rack("ANALYSIS")
+BASELINE = rack("BASELINE")
+CONFIDENCE = rack("CONFIDENCE")
+DOCUMENT = rack("DOCUMENT")
+FILE = rack("FILE")
+HAZARD = rack("HAZARD")
+MODEL = rack("MODEL")
+PROCESS = rack("PROCESS")
+PROV_S = rack("PROV-S")
+REQUIREMENTS = rack("REQUIREMENTS")
+REVIEW = rack("REVIEW")
+SOFTWARE = rack("SOFTWARE")
+SYSTEM = rack("SYSTEM")
+TESTING = rack("TESTING")


### PR DESCRIPTION
Updates up to today's state of the ontology.

@glguy I think I fairly represented when a property was removed vs. when it was subsumed by one of `wasGeneratedBy`/`wasAttributedTo`. Could you double-check that the instances I marked as `DeleteProperty` are indeed properties that were removed without a subsumption intent?