### PR TITLE
Readme updates corresponding to recent Turnstile changes.

### DIFF
--- a/Turnstile-Example/Turnstile-IngestionPackage/README.md
+++ b/Turnstile-Example/Turnstile-IngestionPackage/README.md
@@ -1,27 +1,36 @@
 # Instructions
 
+The following instructions assume that the user is operating from a
+checked-out (from github) version of RACK or one of the
+RACK-in-the-Box Docker or VM environments.  For either of these
+configurations, the following assumes that the `RACK` environment
+variable is set to the top of the RACK tree (`/home/ubuntu/RACK` for
+the Docker or VM environments).
+
 ## Run CLI in a virtual environment:
+Note: this step is not required when running in the RACK Docker image: the python environment is already setup and available in that image.
 Refer to the cli [README](../../cli/README.md) for installation instructions.
 ```sh
-$ cd RACK/cli
+$ cd ${RACK}/cli
 $ . venv/bin/activate
 ```
 If running on Windows, GitBash can be used with the following commands.
 ```sh
-$ cd RACK/cli
+$ cd ${RACK}/cli
 $ . venv/Scripts/activate
 ```
 
 ## Run the setup script:
 The script [setup-turnstile.sh](../../cli/setup-turnstile.sh) loads the [GE ontology overlay](../../GE-Ontology/ontology/GE.sadl). 
 ```sh
+(venv) $ cd ${RACK}/cli
 (venv) $ ./setup-turnstile.sh
 ```
 
 ## Ingest the turnstile data into RACK:
 Browse to the dataset location and load the data via the provided shell script.
 ```sh
-(venv) $ cd ../Turnstile-Example/Turnstile-IngestionPackage
+(venv) $ cd ${RACK}/Turnstile-Example/Turnstile-IngestionPackage
 (venv) $ ./Load-TurnstileData.sh
 ```
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -192,50 +192,13 @@ These examples uses the virtual environment as defined in the
 
 ### Import data
 
-This example populates the *Turnstile* example into a RACK-in-a-Box
-instance running in a Docker container on `localhost`:
+See the `setup-turnstile.sh` as an example for populating the model
+and nodegroups for the *Turnstile* example into RACK-in-a-Box.
 
-```shell
-$ source venv/bin/activate
-(venv) $ rack model import ../Turnstile-Ontology/99-Utils/import.yaml
-Ingesting ../Turnstile-Ontology/99-Utils/../OwlModels/DevelopmentPlan.owl...   OK
-
-(venv) $ rack nodegroups import ../Turnstile-Ontology/99-Utils/NodeGroups
-Storing nodegroups...
-
-(venv) $ rack data import --clear ../RACK-Ontology/OwlModels/DO-178C.yaml
-Clearing graph
-Success Update succeeded
-Ingesting DO-178C.owl                     OK
-
-(venv) $ rack data import --clear ../Turnstile-Ontology/99-Utils/Data/Model.yaml
-Clearing graph
-Success Update succeeded
-Loading Ingest-DataAndControlCouple...             OK Records: 24
-Loading Ingest-DataDictionary...                   OK Records: 5
-Loading Ingest-Engineer...                         OK Records: 3
-Loading Ingest-HAZARD...                           OK Records: 4
-Loading Ingest-HighLevelRequirements...            OK Records: 3
-Loading Ingest-LowLevelRequirements...             OK Records: 13
-Loading Ingest-Objective...                        OK Records: 99
-Loading Ingest-SoftwareComponentTest...            OK Records: 4
-Loading Ingest-SoftwareComponentTestExecution...   OK Records: 2
-Loading Ingest-SoftwareComponentTestResult...      OK Records: 8
-Loading Ingest-SoftwareDesign...                   OK Records: 2
-Loading Ingest-SoftwareDesignReview...             OK Records: 11
-Loading Ingest-SoftwareDesignReviewArtifacts...    OK Records: 11
-Loading Ingest-SoftwareRequirementsDefinition...   OK Records: 1
-Loading Ingest-SoftwareRequirementsReview...       OK Records: 9
-Loading Ingest-SoftwareRequirementsReviewArtifacts...OK Records: 3
-Loading Ingest-SoftwareThread...                   OK Records: 6
-Loading Ingest-SoftwareUnitTest...                 OK Records: 4
-Loading Ingest-SoftwareUnitTestExecution...        OK Records: 2
-Loading Ingest-SoftwareUnitTestResult...           OK Records: 8
-Loading Ingest-SystemComponent...                  OK Records: 4
-Loading Ingest-SystemInterfaceDefinition...        OK Records: 7
-Loading Ingest-SystemRequirement...                OK Records: 3
-Loading Ingest-SoftwareComponent...                OK Records: 3
-```
+See the
+`../Turnstile-Example/Turnstile-IngestionPackage/Load-TurnstileData.sh`
+as an example for populating data for the *Turnstile* example into
+Rack-in-a-Box.
 
 ### Export data
 
@@ -245,7 +208,7 @@ container on `localhost`:
 
 ```shell
 $ source venv/bin/activate
-(venv) $ rack data export --data-graph http://rack001/data "Ingest-SystemComponent"
+(venv) $ rack data export --data-graph http://rack001/turnstiledata ingest_turnstile_SystemComponent
 identifier_SystemComponent    identifier_SYSTEM
 ----------------------------  -------------------
 Counter Application           Turnstile
@@ -282,13 +245,13 @@ Examples:
 ```shell
 # Example using exact matches
 rack data export "query Requirements decomposition" \
-  --data-graph http://rack001/data \
+  --data-graph http://rack001/turnstiledata \
   --constraint req=HLR-1 \
   --constraint decomposition=IN-LLR-2
 
 # Example using regular expressions
 rack data export "query Requirements decomposition" \
-  --data-graph http://rack001/data \
+  --data-graph http://rack001/turnstiledata \
   --constraint "req~^HLR-.$" \
   --constraint "decomposition~^IN-"
 ```


### PR DESCRIPTION
Clarified the directory locations for the various examples by
referencing the root directory instead of a relative directory from
the current context (which wasn't always clear).

Removed obsolete CLI readme instructions; replaced with references to
the actual scripts to avoid future loss of synchronization.

Fixed some references to the new turnstile import URL.