### PR TITLE
Lock RACK to SADL-Eclipse v3.5.0-20211130

### DIFF
--- a/.github/workflows/actions/download/action.yml
+++ b/.github/workflows/actions/download/action.yml
@@ -43,8 +43,8 @@ runs:
     - name: Generate OWL files
       shell: bash
       run: |
-        docker pull sadl/sadl-eclipse:dev
-        docker run --rm -v $GITHUB_WORKSPACE/RACK:/RACK sadl/sadl-eclipse:dev -importAll /RACK -cleanBuild
+        docker pull sadl/sadl-eclipse:v3.5.0-20211130
+        docker run --rm -v $GITHUB_WORKSPACE/RACK:/RACK sadl/sadl-eclipse:v3.5.0-20211130 -importAll /RACK -cleanBuild
 
     - name: Package RACK ASSIST
       shell: bash


### PR DESCRIPTION
Lock our CI workflow's SADL-Eclipse version to v3.5.0-20211130.  Right
now sadl/sadl-eclipse:dev is the same Docker image as
sadl/sadl-eclipse:v3.5.0-20211130, so this change won't affect any OWL
files.  Using the same SADL pre-release or release will ensure all CI
jobs and all developers are able to generate consistent OWL files from
the same SADL-Eclipse image or SADL IDE until we bump SADL's version
to the next pre-release or release.