### PR TITLE
Support copying and building with the setup-owl script

### DIFF
--- a/.github/workflows/actions/download/action.yml
+++ b/.github/workflows/actions/download/action.yml
@@ -47,7 +47,7 @@ runs:
     - name: Generate OWL files
       shell: bash
       run: |
-        RACK/cli/setup-build-owl.sh
+        RACK/cli/setup-owl.sh -b
 
     - name: Package RACK ASSIST
       shell: bash

--- a/cli/setup-build-owl.sh
+++ b/cli/setup-build-owl.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-# Copyright (c) 2021, General Electric Company and Galois, Inc.
-
-set -e
-
-RACK_DIR=$(realpath "$(dirname "$0")"/..)
-
-docker run --rm -u 0 -e RUN_AS="$(id -u) $(id -g)" -v "$RACK_DIR:/RACK" sadl/sadl-eclipse:v3.5.0-20211204 -importAll /RACK -cleanBuild

--- a/cli/setup-owl.sh
+++ b/cli/setup-owl.sh
@@ -15,18 +15,11 @@ usage() {
         exit 1
 }
 
-args=`getopt hbt: $*` ; errcode=$?; set -- $args
-if [ $? != 0 ]; then
-        usage
-fi
-
-for i
-do
-        case "$i"
+while getopts "bt:" o; do
+        case "$o"
         in
-                -b) MODE="build"; shift; break;;
-                -t) DOCKER_TAG="$2"; shift; shift; break;;
-                --) shift; break;;
+                b) MODE="build"; break;;
+                t) DOCKER_TAG="$OPTARG"; break;;
                 *) usage;;
         esac
 done
@@ -35,7 +28,7 @@ case "$MODE"
 in
     build)
         docker run --rm -u 0 -e RUN_AS="$(id -u) $(id -g)" -v "$RACK_DIR:/RACK" sadl/sadl-eclipse:v3.5.0-20211204 -importAll /RACK -cleanBuild
-        break;;
+        ;;
 
     copy)
         CONTAINER=$(docker container ls -qf ancestor=gehighassurance/rack-box:"$DOCKER_TAG")
@@ -55,5 +48,5 @@ in
         docker cp "$CONTAINER:home/ubuntu/RACK/LM-Ontology/OwlModels/" "$RACK_DIR/LM-Ontology/OwlModels/"
         docker cp "$CONTAINER:home/ubuntu/RACK/SRI-Ontology/OwlModels/" "$RACK_DIR/SRI-Ontology/OwlModels/"
         docker cp "$CONTAINER:home/ubuntu/RACK/Turnstile-Example/Turnstile-IngestionPackage/CounterApplicationUnitTesting/OwlModels/" "$RACK_DIR/Turnstile-Example/Turnstile-IngestionPackage/CounterApplicationUnitTesting/OwlModels/"
-        break;;
+        ;;
 esac

--- a/cli/setup-owl.sh
+++ b/cli/setup-owl.sh
@@ -10,7 +10,7 @@ MODE=copy
 usage() {
         echo "Usage: setup-owl.sh [-h] [-b] [-t TAG]"
         echo "   -h    print help"
-        echo "   -b    build OWL files using Web SADL"
+        echo "   -b    build OWL files using sadl-eclipse"
         echo "   -t    specify rack-box tag when copying OWL files from running image"
         exit 1
 }

--- a/cli/setup-owl.sh
+++ b/cli/setup-owl.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+# Copyright (c) 2021, General Electric Company and Galois, Inc.
+
+set -e
+
+RACK_DIR=$(realpath "$(dirname "$0")"/..)
+DOCKER_TAG="v9.0"
+MODE=copy
+
+usage() {
+        echo "Usage: setup-owl.sh [-h] [-b] [-t TAG]"
+        echo "   -h    print help"
+        echo "   -b    build OWL files using Web SADL"
+        echo "   -t    specify rack-box tag when copying OWL files from running image"
+        exit 1
+}
+
+args=`getopt hbt: $*` ; errcode=$?; set -- $args
+if [ $? != 0 ]; then
+        usage
+fi
+
+for i
+do
+        case "$i"
+        in
+                -b) MODE="build"; shift; break;;
+                -t) DOCKER_TAG="$2"; shift; shift; break;;
+                --) shift; break;;
+                *) usage;;
+        esac
+done
+
+case "$MODE"
+in
+    build)
+        docker run --rm -u 0 -e RUN_AS="$(id -u) $(id -g)" -v "$RACK_DIR:/RACK" sadl/sadl-eclipse:v3.5.0-20211204 -importAll /RACK -cleanBuild
+        break;;
+
+    copy)
+        CONTAINER=$(docker container ls -qf ancestor=gehighassurance/rack-box:"$DOCKER_TAG")
+
+        if [ -z "$CONTAINER" ]; then
+                echo "Unable to find docker container rack-box:$DOCKER_TAG. Specify image tag with -t flag"
+                exit 1
+        fi
+
+        echo "Found container $CONTAINER; copying OwlModels"
+
+        docker cp "$CONTAINER:home/ubuntu/RACK/RACK-Ontology/OwlModels/" "$RACK_DIR/RACK-Ontology/OwlModels/"
+        docker cp "$CONTAINER:home/ubuntu/RACK/GE-Ontology/OwlModels/" "$RACK_DIR/GE-Ontology/OwlModels/"
+        docker cp "$CONTAINER:home/ubuntu/RACK/GrammaTech-Ontology/OwlModels/" "$RACK_DIR/GrammaTech-Ontology/OwlModels/"
+        docker cp "$CONTAINER:home/ubuntu/RACK/STR-Ontology/OwlModels/" "$RACK_DIR/STR-Ontology/OwlModels/"
+        docker cp "$CONTAINER:home/ubuntu/RACK/Boeing-Ontology/OwlModels/" "$RACK_DIR/Boeing-Ontology/OwlModels/"
+        docker cp "$CONTAINER:home/ubuntu/RACK/LM-Ontology/OwlModels/" "$RACK_DIR/LM-Ontology/OwlModels/"
+        docker cp "$CONTAINER:home/ubuntu/RACK/SRI-Ontology/OwlModels/" "$RACK_DIR/SRI-Ontology/OwlModels/"
+        docker cp "$CONTAINER:home/ubuntu/RACK/Turnstile-Example/Turnstile-IngestionPackage/CounterApplicationUnitTesting/OwlModels/" "$RACK_DIR/Turnstile-Example/Turnstile-IngestionPackage/CounterApplicationUnitTesting/OwlModels/"
+        break;;
+esac


### PR DESCRIPTION
This does a couple things

1. renames `setup-build-owl` to just `setup-owl`, it can both build and copy now.
2. updates CI to use the new name
3. changes the default behavior to copying from a running docker image, but still supports building with a flag.

`-b` flag tells the script to build using the docker sadl image, instead of copying

`-t` flag tells the script what tag to look for when doing the copying. I've defaulted this to our eventual `v9.0` tag, but when testing I'm using `-t dev`