### PR TITLE
add new subclass AcertTestExecution to GrammaTech.sadl

### DIFF
--- a/GrammaTech-Ontology/ontology/GrammaTech.sadl
+++ b/GrammaTech-Ontology/ontology/GrammaTech.sadl
@@ -34,12 +34,13 @@ AcertTestResult is a type of TEST_RESULT.
 	failureDetails (note "Additional detail describing the failure reason")
 	    describes AcertTestResult with values of type string.
 
+AcertTestExecution is a type of TEST_EXECUTION.
     /* Metrics */
     cpuTime (note "seconds of CPU time used when executing the test execution")
-        describes TEST_EXECUTION with values of type double.
+        describes AcertTestExecution with values of type double.
 
     memory (note "maximum bytes of resident memory used by test execution")
-        describes TEST_EXECUTION with values of type double.
+        describes AcertTestExecution with values of type double.
 
 FailureReason (note "High-level reasons for ACERT test result failure")
     is a type of THING,


### PR DESCRIPTION
Prior to this change, GrammaTech.sadl extended the core class TEST_EXECUTION with the properties cpuTime and memory. This change creates a new class called AcertTestExecution, which is a subclass of TEST_EXECUTION, with the properties cpuTime and memory. This is similar to how AcertTestResult is currently defined.

