### PR TITLE
Add virtualbox support to setup-owl

### DIFF
--- a/cli/.gitignore
+++ b/cli/.gitignore
@@ -1,1 +1,3 @@
 /venv
+/rack_ssh_key
+/rack_ssh_key.pub

--- a/cli/setup-owl.sh
+++ b/cli/setup-owl.sh
@@ -55,7 +55,7 @@ in
                         ssh-keygen -q -N "" -f rack_ssh_key
                 fi
 
-                echo "[setup-owl] Please confirm the SSH host key if prompted.
+                echo "[setup-owl] Please confirm the SSH host key if prompted."
                 echo "[setup-owl] Please enter the default password if prompted: $(tput bold)ubuntu$(tput sgr0)"
                 ssh "ubuntu@${virtualbox_ip}" "mkdir -p ~/.ssh/; cat >> ~/.ssh/authorized_keys" < rack_ssh_key.pub
         fi

--- a/cli/setup-owl.sh
+++ b/cli/setup-owl.sh
@@ -57,7 +57,9 @@ in
 
                 echo "[setup-owl] Please confirm the SSH host key if prompted."
                 echo "[setup-owl] Please enter the default password if prompted: $(tput bold)ubuntu$(tput sgr0)"
-                ssh-copy-id -i rack_ssh_key "ubuntu@${virtualbox_ip}"
+
+                # We're using this awkward command instead of ssh-copy-id because some old system don't have ssh-copy-id
+                ssh "ubuntu@${virtualbox_ip}" "mkdir -p ~/.ssh/; cat >> ~/.ssh/authorized_keys" < rack_ssh_key.pub
         fi
 
         echo "[setup-owl] Copying OwlModels"

--- a/cli/setup-owl.sh
+++ b/cli/setup-owl.sh
@@ -11,23 +11,25 @@ rack_tag="v9.0"
 sadl_image="sadl/sadl-eclipse"
 sadl_tag="v3.5.0-20211204"
 
-mode="copy"
+mode="docker"
 
 usage() {
-        echo "Usage: setup-owl.sh [-h] [-b] [-n NAME] [-t TAG]"
+        echo "Usage: setup-owl.sh [-h] [-b] [-n NAME] [-t TAG] [-i IPADDRESS]"
         echo "   -h    print help"
         echo "   -b    build OWL files using sadl-eclipse"
         echo "   -n    specify rack-box docker image name"
         echo "   -t    specify rack-box tag when copying OWL files from running image"
+        echo "   -i    get OWL files from VirtualBox VM by IP address"
         exit 1
 }
 
-while getopts "bn:t:" o; do
+while getopts "bi:n:t:" o; do
         case "$o"
         in
                 b) mode="build";;
                 n) rack_image="${OPTARG}";;
                 t) rack_tag="${OPTARG}";;
+                i) virtualbox_ip="${OPTARG}"; mode="virtualbox";;
                 *) usage;;
         esac
 done
@@ -35,10 +37,48 @@ done
 case "${mode}"
 in
     build)
+        echo "[setup-owl] Building OWL files using docker"
+
         docker run --rm -u 0 -e RUN_AS="$(id -u) $(id -g)" -v "${rack_dir}:/RACK" ${sadl_image}:${sadl_tag} -importAll /RACK -cleanBuild
         ;;
 
-    copy)
+    virtualbox)
+        echo "[setup-owl] Copying CDR and OWL files from VirtualBox"
+
+        if ! ssh -i rack_ssh_key -oBatchMode=true "ubuntu@${virtualbox_ip}" true
+        then
+                echo "[setup-owl] Unable to authenticate to VM, attempting to install key"
+
+                if [ ! -e rack_ssh_key ]
+                then
+                        echo "[setup-owl] Generating a fresh SSH keypair"
+                        ssh-keygen -q -N "" -f rack_ssh_key
+                fi
+
+                echo "[setup-owl] Please confirm the SSH host key if prompted.
+                echo "[setup-owl] Please enter the default password if prompted: $(tput bold)ubuntu$(tput sgr0)"
+                ssh "ubuntu@${virtualbox_ip}" "mkdir -p ~/.ssh/; cat >> ~/.ssh/authorized_keys" < rack_ssh_key.pub
+        fi
+
+        echo "[setup-owl] Copying OwlModels"
+        scp -q -i rack_ssh_key -r "ubuntu@${virtualbox_ip}:RACK/RACK-Ontology/OwlModels" "${rack_dir}/RACK-Ontology/"
+        scp -q -i rack_ssh_key -r "ubuntu@${virtualbox_ip}:RACK/GE-Ontology/OwlModels" "${rack_dir}/GE-Ontology/"
+        scp -q -i rack_ssh_key -r "ubuntu@${virtualbox_ip}:RACK/GrammaTech-Ontology/OwlModels" "${rack_dir}/GrammaTech-Ontology/"
+        scp -q -i rack_ssh_key -r "ubuntu@${virtualbox_ip}:RACK/STR-Ontology/OwlModels" "${rack_dir}/STR-Ontology/"
+        scp -q -i rack_ssh_key -r "ubuntu@${virtualbox_ip}:RACK/Boeing-Ontology/OwlModels" "${rack_dir}/Boeing-Ontology/"
+        scp -q -i rack_ssh_key -r "ubuntu@${virtualbox_ip}:RACK/LM-Ontology/OwlModels" "${rack_dir}/LM-Ontology/"
+        scp -q -i rack_ssh_key -r "ubuntu@${virtualbox_ip}:RACK/SRI-Ontology/OwlModels" "${rack_dir}/SRI-Ontology/"
+        scp -q -i rack_ssh_key -r "ubuntu@${virtualbox_ip}:RACK/Turnstile-Example/Turnstile-IngestionPackage/CounterApplicationUnitTesting/OwlModels" "${rack_dir}/Turnstile-Example/Turnstile-IngestionPackage/CounterApplicationUnitTesting/"
+
+        echo "[setup-owl] Copying nodegroups"
+        scp -q -i rack_ssh_key -r "ubuntu@${virtualbox_ip}:RACK/nodegroups/CDR" "${rack_dir}/nodegroups/"
+        scp -q -i rack_ssh_key -r "ubuntu@${virtualbox_ip}:RACK/nodegroups/ingestion" "${rack_dir}/nodegroups/"
+
+        ;;
+
+    docker)
+        echo "[setup-owl] Coping CDR and OWL files from Docker"
+
         container=$(docker container ls -qf "ancestor=${rack_image}:${rack_tag}")
 
         if [ -z "${container}" ]; then
@@ -47,9 +87,9 @@ in
                 exit 1
         fi
 
-        echo "Found container ${container}"
+        echo "[setup-owl] Found container ${container}"
 
-        echo "Copying OwlModels"
+        echo "[setup-owl] Copying OwlModels"
         docker cp "${container}:home/ubuntu/RACK/RACK-Ontology/OwlModels/" "${rack_dir}/RACK-Ontology/"
         docker cp "${container}:home/ubuntu/RACK/GE-Ontology/OwlModels/" "${rack_dir}/GE-Ontology/"
         docker cp "${container}:home/ubuntu/RACK/GrammaTech-Ontology/OwlModels/" "${rack_dir}/GrammaTech-Ontology/"
@@ -59,7 +99,7 @@ in
         docker cp "${container}:home/ubuntu/RACK/SRI-Ontology/OwlModels/" "${rack_dir}/SRI-Ontology/"
         docker cp "${container}:home/ubuntu/RACK/Turnstile-Example/Turnstile-IngestionPackage/CounterApplicationUnitTesting/OwlModels/" "${rack_dir}/Turnstile-Example/Turnstile-IngestionPackage/CounterApplicationUnitTesting/"
 
-        echo "Copying nodegroups"
+        echo "[setup-owl] Copying nodegroups"
         docker cp "${container}:home/ubuntu/RACK/nodegroups/CDR/" "${rack_dir}/nodegroups/"
         docker cp "${container}:home/ubuntu/RACK/nodegroups/ingestion/" "${rack_dir}/nodegroups/"
         ;;

--- a/cli/setup-owl.sh
+++ b/cli/setup-owl.sh
@@ -57,7 +57,7 @@ in
 
                 echo "[setup-owl] Please confirm the SSH host key if prompted."
                 echo "[setup-owl] Please enter the default password if prompted: $(tput bold)ubuntu$(tput sgr0)"
-                ssh "ubuntu@${virtualbox_ip}" "mkdir -p ~/.ssh/; cat >> ~/.ssh/authorized_keys" < rack_ssh_key.pub
+                ssh-copy-id -i rack_ssh_key "ubuntu@${virtualbox_ip}"
         fi
 
         echo "[setup-owl] Copying OwlModels"


### PR DESCRIPTION
This script will use SSH to extract OWL and CDR files from a running RACK VirtualBox instance given that instance's IP address passed to the `-i` parameter.

The script installs an SSH key-pair onto the VM to facilitate the running of scp commands as I couldn't find any other portable way to avoid repeated prompts for the SSH password.

I prefixed a bunch of outputs with `[setup-owl]` to help differentiate them from outputs that might leak out from other executables along the way.