### PR TITLE
Updates to ASSIST-DV checks

### DIFF
--- a/RACK-Ontology/ontology/HARDWARE.sadl
+++ b/RACK-Ontology/ontology/HARDWARE.sadl
@@ -13,7 +13,7 @@
 uri "http://arcos.rack/HARDWARE" alias hw.
 import "http://arcos.rack/PROV-S".
 
-HWCOMPONENT is a type of ENTITY.
+HWCOMPONENT (note "A generic physical hardware component") is a type of ENTITY.
     instantiates (note "What logical component (system) does this physical component instantiate or implement?")
         describes HWCOMPONENT with values of type ENTITY.
     componentType (note "Type of component")

--- a/RACK-Ontology/ontology/SECURITY.sadl
+++ b/RACK-Ontology/ontology/SECURITY.sadl
@@ -48,7 +48,7 @@ THREAT_IDENTIFICATION
 	Sec:author (note "AGENT(s) who work on this ACTIVITY") describes THREAT_IDENTIFICATION with values of type AGENT.
 	Sec:author is a type of wasAssociatedWith.
 
-SECURITY_LABEL is a type of THING.
+SECURITY_LABEL (note "A label to help categorize the associated SECURITY concern") is a type of THING.
 
 // A few common instances: additional ones could be Authorization, Non-repudiation, Privacy, etc.
 Confidentiality is a SECURITY_LABEL 
@@ -63,7 +63,7 @@ Availability is a SECURITY_LABEL
 
 CONTROL (note "CONTROLs mitigate THREATs") is a type of ENTITY.
 
-CONTROLSET is a type of COLLECTION.
+CONTROLSET (note "A set of CONTROLs that combine to mitigate a THREAT") is a type of COLLECTION.
     content of CONTROLSET only has values of type CONTROL.
 
     // A THREAT can be mitigated by a set of CONTROLs etc., mitigation by CONTROL is defined in CONTROL.sadl.

--- a/assist/bin/README.md
+++ b/assist/bin/README.md
@@ -337,21 +337,23 @@ build tools can use a similar technique.
 The following data is collected for processing a moderately large code
 base (turnstile + ffmpeg) and a very large codebase.
 
- | Codebase         | Tool    | Runtime | Notes                                                |
- |------------------|---------|---------|------------------------------------------------------|
- | moderately large | ingest  | 9m30s   | Saved 38,880 triples about 6,649 subjects            |
- |                  | -       |         |                                                      |
- |                  | analyze | 12.2s   | 1,878 `http://arcos.rack/SOFTWARE#COMPILE` instances |
- |                  |         |         | 4,756 `http://arcos.rack/SOFTWARE#FILE` instances    |
- |                  |         |         | 9     `http://arcos.rack/PROV-S#ACTIVITY` instances  |
- |------------------|---------|---------|------------------------------------------------------|
- | huge             | ingest  | 14m7s   | Saved 455,231 triples about 89,945 subjects          |
- |                  | -       |         |                                                      |
- |                  | analyze | 15m36s  | 1,880 `http://arcos.rack/SOFTWARE#COMPILE` instances |
- |                  |         |         | 88,049 `http://arcos.rack/SOFTWARE#FILE` instances   |
+ | Codebase         | Tool    | Runtime | Notes                                                               |
+ |------------------|---------|---------|---------------------------------------------------------------------|
+ | moderately large | ingest  | 9m30s   | Saved 38,880 triples about 6,649 subjects                           |
+ |                  | -       |         |                                                                     |
+ |                  | analyze | 12.2s   | 1,878 `http://arcos.rack/SOFTWARE#COMPILE` instances                |
+ |                  |         |         | 4,756 `http://arcos.rack/SOFTWARE#FILE` instances                   |
+ |                  |         |         | 9     `http://arcos.rack/PROV-S#ACTIVITY` instances                 |
+ |------------------|---------|---------|---------------------------------------------------------------------|
+ | large            | check   | 33.6s   | 69 core ontology classes, 120 overlay classes, 75583 data instances |
+ |------------------|---------|---------|---------------------------------------------------------------------|
+ | huge             | ingest  | 14m7s   | Saved 455,231 triples about 89,945 subjects                         |
+ |                  | -       |         |                                                                     |
+ |                  | analyze | 15m36s  | 1,880 `http://arcos.rack/SOFTWARE#COMPILE` instances                |
+ |                  |         |         | 88,049 `http://arcos.rack/SOFTWARE#FILE` instances                  |
 
 ---
-Copyright (c) 2020, Galois, Inc.
+Copyright (c) 2020-2022, Galois, Inc.
 
 All Rights Reserved
 

--- a/assist/bin/check
+++ b/assist/bin/check
@@ -17,13 +17,14 @@
 :- use_module(library(optparse)).
 :- consult(common_opts).
 :- consult(rack(check)).
+:- consult(rack(check_runner)).
 
 main :-
     help_banner(B),
     (
         (
             parse_args([], _Opts, _PosArgs, B),
-            check_rack
+            run_checks
         ) ;
         print_message(error, bad_arguments),
         help_abort(none, B)

--- a/assist/bin/checks/interfaceChecks.pl
+++ b/assist/bin/checks/interfaceChecks.pl
@@ -14,52 +14,28 @@
               check_INTERFACE/1
           ]).
 
-something_is_true.
-
 :- ensure_loaded('../paths').
-
 :- use_module(rack(model)).
 
-prolog:message(missing_dest_system(IFace, Name)) -->
-    [ 'INTERFACE ~w (~w) has no destination SYSTEM'-[IFace, Name] ].
-prolog:message(missing_src_system(IFace, Name)) -->
-    [ 'INTERFACE ~w (~w) has no source SYSTEM'-[IFace, Name] ].
-
-get_interface_instance(IFACE) :-
-    rdf_reachable(C, rdf:subClass, 'http://arcos.rack/SYSTEM#INTERFACE'),
-    rdf(IFACE, rdf:type, C).
-
-interface_ident(IFACE, Name) :-
-    rdf(IFACE, 'http://arcos.rack/PROV-S#identifier', Name), !.
-interface_ident(_, "<unknown>").
-
-no_dest_system(IFACE) :-
-    rdf(IFACE, 'http://arcos.rack/SYSTEM#destination', _), !, fail.
-no_dest_system(_).
-
-no_src_system(IFACE) :-
-    rdf(IFACE, 'http://arcos.rack/SYSTEM#source', _), !, fail.
-no_src_system(_).
 
 %! check_INTERFACE_no_dest_SYSTEM is det.
 %
 %    Checks that no INTERFACE is lacking a destination SYSTEM.
 %    Always succeeds, emits warnings.
 check_INTERFACE_no_dest_SYSTEM(IFACE) :-
-    get_interface_instance(IFACE),
-    no_dest_system(IFACE),
-    interface_ident(IFACE, Name),
-    print_message(warning, missing_dest_system(IFACE, Name)).
+    check_has_no_rel('http://arcos.rack/SYSTEM#INTERFACE',
+                     'http://arcos.rack/SYSTEM#destination',
+                     'http://arcos.rack/SYSTEM#SYSTEM', IFACE).
+
 
 %! check_INTERFACE_no_src_SYSTEM is det.
 %
 %    Checks that no INTERFACE is lacking a source SYSTEM.
 %    Always succeeds, emits warnings.
 check_INTERFACE_no_src_SYSTEM(IFACE) :-
-    get_interface_instance(IFACE),
-    no_src_system(IFACE),
-    interface_ident(IFACE, Name),
-    print_message(warning, missing_src_system(IFACE, Name)).
+    check_has_no_rel('http://arcos.rack/SYSTEM#INTERFACE',
+                     'http://arcos.rack/SYSTEM#source',
+                     'http://arcos.rack/SYSTEM#SYSTEM', IFACE).
 
 %! check_INTERFACE is det.
 %

--- a/assist/bin/checks/interfaceChecks.pl
+++ b/assist/bin/checks/interfaceChecks.pl
@@ -20,8 +20,10 @@ something_is_true.
 
 :- use_module(rack(model)).
 
-prolog:message(no_dest_system(IFace, Name)) -->
+prolog:message(missing_dest_system(IFace, Name)) -->
     [ 'INTERFACE ~w (~w) has no destination SYSTEM'-[IFace, Name] ].
+prolog:message(missing_src_system(IFace, Name)) -->
+    [ 'INTERFACE ~w (~w) has no source SYSTEM'-[IFace, Name] ].
 
 get_interface_instance(IFACE) :-
     rdf_reachable(C, rdf:subClass, 'http://arcos.rack/SYSTEM#INTERFACE'),
@@ -31,9 +33,13 @@ interface_ident(IFACE, Name) :-
     rdf(IFACE, 'http://arcos.rack/PROV-S#identifier', Name), !.
 interface_ident(_, "<unknown>").
 
-no_system(IFACE) :-
+no_dest_system(IFACE) :-
     rdf(IFACE, 'http://arcos.rack/SYSTEM#destination', _), !, fail.
-no_system(_).
+no_dest_system(_).
+
+no_src_system(IFACE) :-
+    rdf(IFACE, 'http://arcos.rack/SYSTEM#source', _), !, fail.
+no_src_system(_).
 
 %! check_INTERFACE_no_dest_SYSTEM is det.
 %
@@ -41,12 +47,23 @@ no_system(_).
 %    Always succeeds, emits warnings.
 check_INTERFACE_no_dest_SYSTEM(IFACE) :-
     get_interface_instance(IFACE),
-    no_system(IFACE),
+    no_dest_system(IFACE),
     interface_ident(IFACE, Name),
-    print_message(warning, no_dest_system(IFACE, Name)).
+    print_message(warning, missing_dest_system(IFACE, Name)).
+
+%! check_INTERFACE_no_src_SYSTEM is det.
+%
+%    Checks that no INTERFACE is lacking a source SYSTEM.
+%    Always succeeds, emits warnings.
+check_INTERFACE_no_src_SYSTEM(IFACE) :-
+    get_interface_instance(IFACE),
+    no_src_system(IFACE),
+    interface_ident(IFACE, Name),
+    print_message(warning, missing_src_system(IFACE, Name)).
 
 %! check_INTERFACE is det.
 %
 %    Performs all checks for INTERFACEs.  Always succeeds, emits warnings.
 check_INTERFACE(IFACE) :-
-    check_INTERFACE_no_dest_SYSTEM(IFACE).
+    check_INTERFACE_no_dest_SYSTEM(IFACE);
+    check_INTERFACE_no_src_SYSTEM(IFACE).

--- a/assist/bin/checks/interfaceChecks.pl
+++ b/assist/bin/checks/interfaceChecks.pl
@@ -1,4 +1,4 @@
-% Copyright (c) 2020, Galois, Inc.
+% Copyright (c) 2022, Galois, Inc.
 %
 % All Rights Reserved
 %

--- a/assist/bin/checks/interfaceChecks.pl
+++ b/assist/bin/checks/interfaceChecks.pl
@@ -1,0 +1,52 @@
+% Copyright (c) 2020, Galois, Inc.
+%
+% All Rights Reserved
+%
+% This material is based upon work supported by the Defense Advanced Research
+% Projects Agency (DARPA) under Contract No. FA8750-20-C-0203.
+%
+% Any opinions, findings and conclusions or recommendations expressed in this
+% material are those of the author(s) and do not necessarily reflect the views
+% of the Defense Advanced Research Projects Agency (DARPA).
+
+:- module(interfaceChecks,
+          [
+              check_INTERFACE/1
+          ]).
+
+something_is_true.
+
+:- ensure_loaded('../paths').
+
+:- use_module(rack(model)).
+
+prolog:message(no_dest_system(IFace, Name)) -->
+    [ 'INTERFACE ~w (~w) has no destination SYSTEM'-[IFace, Name] ].
+
+get_interface_instance(IFACE) :-
+    rdf_reachable(C, rdf:subClass, 'http://arcos.rack/SYSTEM#INTERFACE'),
+    rdf(IFACE, rdf:type, C).
+
+interface_ident(IFACE, Name) :-
+    rdf(IFACE, 'http://arcos.rack/PROV-S#identifier', Name), !.
+interface_ident(_, "<unknown>").
+
+no_system(IFACE) :-
+    rdf(IFACE, 'http://arcos.rack/SYSTEM#destination', _), !, fail.
+no_system(_).
+
+%! check_INTERFACE_no_dest_SYSTEM is det.
+%
+%    Checks that no INTERFACE is lacking a destination SYSTEM.
+%    Always succeeds, emits warnings.
+check_INTERFACE_no_dest_SYSTEM(IFACE) :-
+    get_interface_instance(IFACE),
+    no_system(IFACE),
+    interface_ident(IFACE, Name),
+    print_message(warning, no_dest_system(IFACE, Name)).
+
+%! check_INTERFACE is det.
+%
+%    Performs all checks for INTERFACEs.  Always succeeds, emits warnings.
+check_INTERFACE(IFACE) :-
+    check_INTERFACE_no_dest_SYSTEM(IFACE).

--- a/assist/bin/checks/interfaceChecks.pl
+++ b/assist/bin/checks/interfaceChecks.pl
@@ -22,6 +22,9 @@
 %
 %    Checks that no INTERFACE is lacking a destination SYSTEM.
 %    Always succeeds, emits warnings.
+%
+% Similar to "nodegroups/query/query dataVer INTERFACE without destination SYSTEM.json"
+%
 check_INTERFACE_no_dest_SYSTEM(IFACE) :-
     check_has_no_rel('http://arcos.rack/SYSTEM#INTERFACE',
                      'http://arcos.rack/SYSTEM#destination',
@@ -32,6 +35,9 @@ check_INTERFACE_no_dest_SYSTEM(IFACE) :-
 %
 %    Checks that no INTERFACE is lacking a source SYSTEM.
 %    Always succeeds, emits warnings.
+%
+% Similar to "nodegroups/query/query dataVer INTERFACE without source SYSTEM.json"
+%
 check_INTERFACE_no_src_SYSTEM(IFACE) :-
     check_has_no_rel('http://arcos.rack/SYSTEM#INTERFACE',
                      'http://arcos.rack/SYSTEM#source',

--- a/assist/bin/checks/sbvt_checks.pl
+++ b/assist/bin/checks/sbvt_checks.pl
@@ -21,19 +21,37 @@
 %
 %    Checks that no SBVT_Result is lacking a confirming TEST.
 %    Always succeeds, emits warnings.
+%
+% NOTE: this test is superfluous since it's already validated by the
+% base checks for cardinality constraints, but it's included here as
+% an example of how a higher-level check might be written.
+%
+% Similar to "nodegroups/query/query
+% dataVer SBVT_Result without confirms_SBVT_Test.json"
+%
 check_Result_not_confirmed(I) :-
     check_has_no_rel('http://arcos.AH-64D/Boeing#SBVT_Result',
                      'http://arcos.rack/TESTING#confirms',
-                     'http://arcos.rack/TESTING#TEST',
+                     'http://arcos.AH-64D/Boeing#SBVT_Test',
                      I).
 
 %! check_no_Test_requirement is det.
 %
 %    Checks that no SBVT_Test is lacking a Requirement to verify.
 %    Always succeeds, emits warnings.
+%
+% NOTE: the core ontology specifies that an SBVT_Test is a type of
+% TESTING#TEST, and TESTING#verifies specifies it must describe an
+% ENTITY.  Here, there is a higher-level semantic assertion that an
+% SBVT_Test must "verifies" a REQUIREMENT.
+%
+% Similar to "nodegroups/query/query dataVer SBVT_Test without
+% REQUIREMENT.json"
+%
 check_no_Test_requirement(I) :-
     check_has_no_rel('http://arcos.AH-64D/Boeing#SBVT_Test',
                      'http://arcos.rack/TESTING#verifies',
+                     'http://arcos.rack/REQUIREMENTS#REQUIREMENT',
                      I).
 
 %! check_SBVT is det.

--- a/assist/bin/checks/sbvt_checks.pl
+++ b/assist/bin/checks/sbvt_checks.pl
@@ -1,4 +1,4 @@
-% Copyright (c) 2020, Galois, Inc.
+% Copyright (c) 2022, Galois, Inc.
 %
 % All Rights Reserved
 %
@@ -45,13 +45,15 @@ check_Result_not_confirmed(I) :-
 % ENTITY.  Here, there is a higher-level semantic assertion that an
 % SBVT_Test must "verifies" a REQUIREMENT.
 %
-% Similar to "nodegroups/query/query dataVer SBVT_Test without
-% REQUIREMENT.json"
+% Similar to "nodegroups/query/query dataVer SBVT_Test without REQUIREMENT.json"
+% and "nodegroups/query/query dataVer SRS_Req without verifies SBVT_Test.json"
+% where the latter additionally qualifies the target of the former.
 %
 check_no_Test_requirement(I) :-
     check_has_no_rel('http://arcos.AH-64D/Boeing#SBVT_Test',
                      'http://arcos.rack/TESTING#verifies',
-                     'http://arcos.rack/REQUIREMENTS#REQUIREMENT',
+                     'http://arcos.AH-64D/Boeing#SRS_Req',
+                     %% 'http://arcos.rack/REQUIREMENTS#REQUIREMENT',
                      I).
 
 %! check_SBVT is det.

--- a/assist/bin/checks/sbvt_checks.pl
+++ b/assist/bin/checks/sbvt_checks.pl
@@ -1,0 +1,44 @@
+% Copyright (c) 2020, Galois, Inc.
+%
+% All Rights Reserved
+%
+% This material is based upon work supported by the Defense Advanced Research
+% Projects Agency (DARPA) under Contract No. FA8750-20-C-0203.
+%
+% Any opinions, findings and conclusions or recommendations expressed in this
+% material are those of the author(s) and do not necessarily reflect the views
+% of the Defense Advanced Research Projects Agency (DARPA).
+
+:- module(sbvt_checks,
+          [
+              check_SBVT/1
+          ]).
+
+:- ensure_loaded('../paths').
+:- use_module(rack(model)).
+
+%! check_Result_not_confirmed is det.
+%
+%    Checks that no SBVT_Result is lacking a confirming TEST.
+%    Always succeeds, emits warnings.
+check_Result_not_confirmed(I) :-
+    check_has_no_rel('http://arcos.AH-64D/Boeing#SBVT_Result',
+                     'http://arcos.rack/TESTING#confirms',
+                     'http://arcos.rack/TESTING#TEST',
+                     I).
+
+%! check_no_Test_requirement is det.
+%
+%    Checks that no SBVT_Test is lacking a Requirement to verify.
+%    Always succeeds, emits warnings.
+check_no_Test_requirement(I) :-
+    check_has_no_rel('http://arcos.AH-64D/Boeing#SBVT_Test',
+                     'http://arcos.rack/TESTING#verifies',
+                     I).
+
+%! check_SBVT is det.
+%
+%    Performs all checks for SBVT classes.  Always succeeds, emits warnings.
+check_SBVT(SBVT) :-
+    check_Result_not_confirmed(SBVT).
+    %% check_no_Test_requirement(SBVT).

--- a/assist/bin/checks/sbvt_checks.pl
+++ b/assist/bin/checks/sbvt_checks.pl
@@ -40,5 +40,5 @@ check_no_Test_requirement(I) :-
 %
 %    Performs all checks for SBVT classes.  Always succeeds, emits warnings.
 check_SBVT(SBVT) :-
-    check_Result_not_confirmed(SBVT).
-    %% check_no_Test_requirement(SBVT).
+    check_Result_not_confirmed(SBVT);
+    check_no_Test_requirement(SBVT).

--- a/assist/bin/checks/software_checks.pl
+++ b/assist/bin/checks/software_checks.pl
@@ -1,0 +1,52 @@
+% Copyright (c) 2022, Galois, Inc.
+%
+% All Rights Reserved
+%
+% This material is based upon work supported by the Defense Advanced Research
+% Projects Agency (DARPA) under Contract No. FA8750-20-C-0203.
+%
+% Any opinions, findings and conclusions or recommendations expressed in this
+% material are those of the author(s) and do not necessarily reflect the views
+% of the Defense Advanced Research Projects Agency (DARPA).
+
+:- module(software_checks,
+          [
+              check_SOFTWARE/1
+          ]).
+
+:- ensure_loaded('../paths').
+:- use_module(rack(model)).
+
+
+%! check_SOFTWARE_partOf_SOFTWARE is det.
+%
+%    Checks every SOFTWARE partOf target is a SOFTWARE.
+%    Always succeeds, emits warnings.
+%
+% Similar to "nodegroups/query/query dataVer SOFTWARE without partOf SOFTWARE.json"
+%
+check_SOFTWARE_COMPONENT_contained(I) :-
+    check_has_no_rel('http://arcos.rack/SOFTWARE#SWCOMPONENT',
+                     'http://arcos.rack/SOFTWARE#subcomponentOf',
+                     'http://arcos.rack/SOFTWARE#SWCOMPONENT',
+                     I).
+
+%! check_SOFTWARE_COMPONENT_impact is det.
+%
+%    Checks every SOFTWARE partOf target is a SOFTWARE.
+%    Always succeeds, emits warnings.
+%
+% Similar to "nodegroups/query/query dataVer SOFTWARE without partOf SOFTWARE.json"
+%
+check_SOFTWARE_COMPONENT_impact(I) :-
+    check_has_no_rel('http://arcos.rack/SOFTWARE#SWCOMPONENT',
+                     'http://arcos.rack/PROV-S#wasImpactedBy',
+                     'http://arcos.rack/REQUIREMENTS#REQUIREMENT',
+                     I).
+
+%! check_SOFTWARE is det.
+%
+%    Performs all checks for SOFTWARE classes.  Always succeeds, emits warnings.
+check_SOFTWARE(SC) :-
+    check_SOFTWARE_COMPONENT_contained(SC);
+    check_SOFTWARE_COMPONENT_impact(SC).

--- a/assist/bin/checks/srs_checks.pl
+++ b/assist/bin/checks/srs_checks.pl
@@ -1,0 +1,111 @@
+% Copyright (c) 2022, Galois, Inc.
+%
+% All Rights Reserved
+%
+% This material is based upon work supported by the Defense Advanced Research
+% Projects Agency (DARPA) under Contract No. FA8750-20-C-0203.
+%
+% Any opinions, findings and conclusions or recommendations expressed in this
+% material are those of the author(s) and do not necessarily reflect the views
+% of the Defense Advanced Research Projects Agency (DARPA).
+
+:- module(srs_checks,
+          [
+              check_SRS/1
+          ]).
+
+:- ensure_loaded('../paths').
+:- use_module(rack(model)).
+
+
+%! check_SRS_insertion_source is det.
+%
+%    Checks that no SRS_Req is inserted by any activity other than
+%    "SRS Data Ingestion".  Always succeeds, emits warnings.
+%
+% Similar to "nodegroups/query/query dataVer SRS_Req dataInsertedBy other than SRS Data Ingestion.json"
+%
+check_SRS_insertion_source(I) :-
+    T = 'http://arcos.AH-64D/Boeing#SRS_Req',
+    rack_data_instance(T, I),
+    rdf(I, 'http://arcos.rack/PROV-S#dataInsertedBy', A),
+    rack_instance_ident(A, AName),
+    \+ AName = 'SRS Data Ingestion',
+    rack_instance_ident(I, IN),
+    rdf(A, rdf:type, ATy),
+    print_message(warning, invalid_srs_req_inserter(T, I, IN, ATy, A, AName)).
+
+%! check_SRS_Req_CSID_or_PIDS is det.
+%
+%    Checks every SRS_Req satisfies only a CSID or PIDS.
+%    Always succeeds, emits warnings.
+%
+% Similar to "nodegroups/query/query dataVer SRS_Req without CSID or PIDS.json"
+%
+check_SRS_Req_CSID_or_PIDS(I) :-
+    T = 'http://arcos.AH-64D/Boeing#SRS_Req',
+    rack_data_instance(T, I),
+    rdf(I, 'http://arcos.rack/REQUIREMENTS#satisfies', R),
+    \+ is_CSID_or_PIDS(R),
+    rack_instance_ident(I, Ident),
+    rack_instance_ident(R, RIdent),
+    rdf(R, rdf:type, RTy),
+    print_message(warning, invalid_srs_req_satisfies(T, I, Ident, RTy, R, RIdent)).
+
+is_CSID_or_PIDS(Inst) :- rdf(Inst, rdf:type, 'http://arcos.AH-64D/Boeing#PIDS_Req').
+is_CSID_or_PIDS(Inst) :- rdf(Inst, rdf:type, 'http://arcos.AH-64D/Boeing#CSID_Req').
+
+
+%! check_SRS_Req_description is det.
+%
+%    Checks every SRS_Req has a PROV-S description
+%    Always succeeds, emits warnings.
+%
+% Similar to "nodegroups/query/query dataVer SRS_Req without description.json"
+%
+check_SRS_Req_description(I) :-
+    check_has_no_rel('http://arcos.AH-64D/Boeing#SRS_Req',
+                     'http://arcos.rack/PROV-S#description',
+                     I).
+
+
+%! check_SubDD_Req_satisifies_SRS_Req is det.
+%
+%    Checks every SubDD_Req satisifes an SRS_Req.
+%    Always succeeds, emits warnings.
+%
+% Similar to "nodegroups/query/query dataVer SubDD_Req without satisfies SRS_Req.json"
+%
+check_SubDD_Req_satisfies_SRS_Req(I) :-
+    check_has_no_rel('http://arcos.AH-64D/Boeing#SubDD_Req',
+                     'http://arcos.rack/TESTING#satisifes',
+                     'http://arcos.AH-64D/Boeing#SRS_Req',
+                     I).
+
+
+prolog:message(invalid_srs_req_inserter(ITy, Inst, InstIdent, InsTy, InsI, InsN)) -->
+    { prefix_shorten(ITy, SIT),
+      prefix_shorten(Inst, SII),
+      prefix_shorten(InsTy, STT),
+      prefix_shorten(InsI, STI)
+    },
+    [ '~w instance ~w (~w) inserted by invalid ACTIVITY: ~w ~w (~w)'-[
+          SIT, SII, InstIdent, STT, STI, InsN ] ].
+prolog:message(invalid_srs_req_satisfies(ITy, Inst, InstIdent, TgtTy, Tgt, TgtIdent)) -->
+    { prefix_shorten(Inst, SI),
+      prefix_shorten(ITy, ST),
+      prefix_shorten(Tgt, SR),
+      prefix_shorten(TgtTy, SRT)
+    },
+    [ '~w instance ~w (~w) satisifes something not a PIDS_Req or CSID_Req: ~w ~w (~w)'-[
+          ST, SI, InstIdent, SRT, SR, TgtIdent ] ].
+
+
+%! check_SRS is det.
+%
+%    Performs all checks for SRS classes.  Always succeeds, emits warnings.
+check_SRS(SRS) :-
+    check_SRS_insertion_source(SRS);
+    check_SRS_Req_CSID_or_PIDS(SRS);
+    check_SRS_Req_description(SRS);
+    check_SubDD_Req_satisfies_SRS_Req(SRS).

--- a/assist/bin/checks/system_checks.pl
+++ b/assist/bin/checks/system_checks.pl
@@ -1,0 +1,38 @@
+% Copyright (c) 2022, Galois, Inc.
+%
+% All Rights Reserved
+%
+% This material is based upon work supported by the Defense Advanced Research
+% Projects Agency (DARPA) under Contract No. FA8750-20-C-0203.
+%
+% Any opinions, findings and conclusions or recommendations expressed in this
+% material are those of the author(s) and do not necessarily reflect the views
+% of the Defense Advanced Research Projects Agency (DARPA).
+
+:- module(system_checks,
+          [
+              check_SYSTEM/1
+          ]).
+
+:- ensure_loaded('../paths').
+:- use_module(rack(model)).
+
+
+%! check_SYSTEM_partOf_SYSTEM is det.
+%
+%    Checks every SYSTEM partOf target is a SYSTEM.
+%    Always succeeds, emits warnings.
+%
+% Similar to "nodegroups/query/query dataVer SYSTEM without partOf SYSTEM.json"
+%
+check_SYSTEM_partOf_SYSTEM(I) :-
+    check_has_no_rel('http://arcos.rack/SYSTEM#SYSTEM',
+                     'http://arcos.rack/SYSTEM#partOf',
+                     'http://arcos.rack/SYSTEM#SYSTEM',
+                     I).
+
+%! check_SYSTEM is det.
+%
+%    Performs all checks for SYSTEM classes.  Always succeeds, emits warnings.
+check_SYSTEM(SYS) :-
+    check_SYSTEM_partOf_SYSTEM(SYS).

--- a/assist/bin/rack/check.pl
+++ b/assist/bin/rack/check.pl
@@ -99,6 +99,7 @@ check_instance_property_violations(Property) :-
     % Exclude namespaces we aren't interested in
     has_interesting_prefix(I),
     % Find a required property defined on that instance type (or parent type)
+    rdf(I, rdf:type, T),
     (check_cardinality_exact(Property, I, T);
      check_cardinality_min(Property, I, T);
      check_cardinality_max(Property, I, T);

--- a/assist/bin/rack/check.pl
+++ b/assist/bin/rack/check.pl
@@ -224,8 +224,7 @@ has_interesting_prefix(I) :-
     member(Pfx, [ 'http://sadl.org/',
                   'http://com.ge.research/',
                   'http://demo/',
-                  'http://research.ge.com/',
-                  'http://semtk.research.ge.com/'
+                  'http://research.ge.com/'
                 ]),
     atom_concat(Pfx, _Local, I), !, fail.
 has_interesting_prefix(_).

--- a/assist/bin/rack/check.pl
+++ b/assist/bin/rack/check.pl
@@ -117,6 +117,8 @@ check_maybe_prop(Property, I, T) :-
 check_target_type(Property, I, T) :-
     property_target(T, Property, _PUsage, Target, _Restr),
     has_interesting_prefix(Property),
+    rdf(Property, rdfs:range, TTy),
+    rdf_reachable(Target, rdfs:subClassOf, TTy),
     rdf(I, Property, Val),
     \+ rdf_is_literal(Val),  % TODO check these as well?
     rdf(Val, rdf:type, DefTy),

--- a/assist/bin/rack/check.pl
+++ b/assist/bin/rack/check.pl
@@ -13,8 +13,10 @@
 
 :- use_module(library(semweb/rdf11)).
 :- use_module(rack(model)).
+:- use_module(checks(interfaceChecks)).
 
 check_rack :-
+    findall(IFC, check_INTERFACE(IFC), IFCS),
     findall(C, check_missing_notes(C), CS),
     findall(NPC, check_not_prov_s(NPC), NPCS),
     findall(BI, check_instance_types(BI), BIS),
@@ -23,13 +25,19 @@ check_rack :-
     length(NPCS, NPCSLen),
     length(BIS, BISLen),
     length(MIS, MISLen),
+    length(IFCS, IFCSLen),
     format('~`.t Summary ~`.t~78|~n'),
     warn_if_nonzero("missing a Note/Description", CSLen),
     warn_if_nonzero("not a subclass of PROV-S#THING", NPCSLen),
     warn_if_nonzero("with instance issues", BISLen),
     warn_if_nonzero("with instance property issues", MISLen),
-    (CSLen == 0, NPCSLen == 0, BISLen == 0, MISLen == 0, !,
-     format('No issues found~n') ; format('ISSUES FOUND IN CHECK~n'), halt(1)),
+    warn_if_nonzero("with INTERFACE instance issues", IFCSLen),
+    TotalIssues = CSLen + NPCSLen + BISLen + MISLen + IFCSLen,
+    (TotalIssues == 0,
+     !,
+     format('No issues found~n')
+    ;
+    format('ISSUES FOUND IN CHECK~n'), halt(1)),
     true.
 
 check_missing_notes(Class) :-

--- a/assist/bin/rack/check.pl
+++ b/assist/bin/rack/check.pl
@@ -25,7 +25,7 @@ overlay_ontology_size(Size) :-
     findall(Class,
             (rdf(Class, rdf:type, owl:'Class'),
              \+ rack_ontology_node(Class, _, _),
-             \+ rdf_bnode(Class)),
+             \+ rdf_is_bnode(Class)),
             Classes),
     length(Classes, Size).
 
@@ -37,7 +37,7 @@ check_missing_notes(Class) :-
     rdf(Class, rdf:type, owl:'Class'),
     has_interesting_prefix(Class),
     \+ rdf(Class, rdfs:comment, _),
-    \+ rdf_bnode(Class),
+    \+ rdf_is_bnode(Class),
     print_message(warning, class_missing_note(Class)).
 
 check_not_prov_s(Class) :-
@@ -45,7 +45,7 @@ check_not_prov_s(Class) :-
     has_interesting_prefix(Class),
     rack_ref('PROV-S#THING', Thing),
     \+ rdf_reachable(Class, rdfs:subClassOf, Thing),
-    \+ rdf_bnode(Class),
+    \+ rdf_is_bnode(Class),
     print_message(warning, not_prov_s_thing_class(Class)).
 
 check_instance_types(I) :-
@@ -134,7 +134,7 @@ check_values_from(Property, I, T) :-
     DefTy \= Cls,
     rack_instance_ident(I, IName),
     % Cls might be a direct type or a oneOf restriction to a list of types
-    ( rdf_bnode(Cls), rdf(Cls, owl:oneOf, ClsLst), !,
+    ( rdf_is_bnode(Cls), rdf(Cls, owl:oneOf, ClsLst), !,
       rdf_list(ClsLst, CList),
       ( member(CL, CList),
         rdf_reachable(DefTy, rdfs:subClassOf, CL), !  % matches, stop processing

--- a/assist/bin/rack/check.pl
+++ b/assist/bin/rack/check.pl
@@ -76,7 +76,7 @@ check_instance_property_violations(Property) :-
     ).
 
 check_cardinality_exact(Property, I, T) :-
-    property_target(T, Property, _PUsage, cardinality(N)),
+    property_extra(T, Property, cardinality(N)),
     has_interesting_prefix(Property),
     % How many actual values for that property on this instance
     findall(V, rdf(I, Property, V), VS),
@@ -86,7 +86,7 @@ check_cardinality_exact(Property, I, T) :-
     print_message(error, cardinality_violation(I, IName, Property, N, VSLen)).
 
 check_cardinality_min(Property, I, T) :-
-    property_target(T, Property, _PUsage, min_cardinality(N)),
+    property_extra(T, Property, min_cardinality(N)),
     has_interesting_prefix(Property),
     % How many actual values for that property on this instance
     findall(V, rdf(I, Property, V), VS),
@@ -96,7 +96,7 @@ check_cardinality_min(Property, I, T) :-
     print_message(error, min_cardinality_violation(I, IName, Property, N, VSLen)).
 
 check_cardinality_max(Property, I, T) :-
-    property_target(T, Property, _PUsage, max_cardinality(N)),
+    property_extra(T, Property, max_cardinality(N)),
     has_interesting_prefix(Property),
     % How many actual values for that property on this instance
     findall(V, rdf(I, Property, V), VS),
@@ -106,7 +106,7 @@ check_cardinality_max(Property, I, T) :-
     print_message(error, max_cardinality_violation(I, IName, Property, N, VSLen)).
 
 check_maybe_prop(Property, I, T) :-
-    property_target(T, Property, _PUsage, maybe),
+    property_extra(T, Property, maybe),
     has_interesting_prefix(Property),
     % How many actual values for that property on this instance
     findall(V, rdf(I, Property, V), VS),
@@ -117,7 +117,7 @@ check_maybe_prop(Property, I, T) :-
      print_message(error, maybe_restriction(I, IName, Property, VSLen))).
 
 check_target_type(Property, I, T) :-
-    property_target(T, Property, _PUsage, Target, _Restr),
+    property_extra(T, Property, _Restr),
     has_interesting_prefix(Property),
     rdf(Property, rdfs:range, TTy),
     rdf_reachable(Target, rdfs:subClassOf, TTy),
@@ -149,7 +149,7 @@ check_target_type_restrictions(Property, I, T) :-
     ).
 
 check_values_from(Property, I, T) :-
-    property_target(T, Property, _PUsage, value_from(Cls)),
+    property_extra(T, Property, value_from(Cls)),
     has_interesting_prefix(Property),
     rdf(I, Property, Val),
     \+ rdf_is_literal(Val),  % TODO check these as well?
@@ -169,7 +169,7 @@ check_values_from(Property, I, T) :-
     ).
 
 check_invalid_value(Property, I, T) :-
-    property_target(T, Property, _PUsage, _Restr),
+    property_extra(T, Property, _Restr),
     has_interesting_prefix(Property),
     rdf(I, Property, V),
     \+ rdf_is_literal(V),  % literals checked elsewhere
@@ -182,7 +182,7 @@ check_invalid_value(Property, I, T) :-
     print_message(error, invalid_value_in_enum(I, IName, Property, V, L)).
 
 check_invalid_value(Property, I, T) :-
-    property_target(T, Property, _PUsage, _Restr),
+    property_extra(T, Property, _Restr),
     has_interesting_prefix(Property),
     rdf(I, Property, V),
     rdf_is_literal(V),  % non-literals handled elsewhere

--- a/assist/bin/rack/check.pl
+++ b/assist/bin/rack/check.pl
@@ -34,15 +34,15 @@ check_rack :-
 
 check_missing_notes(Class) :-
     rdf(Class, rdf:type, owl:'Class'),
-    rack_ontology_node(Class, _, _),
     \+ rdf(Class, rdfs:comment, _),
+    \+ rdf_bnode(Class),
     print_message(warning, class_missing_note(Class)).
 
 check_not_prov_s(Class) :-
     rdf(Class, rdf:type, owl:'Class'),
-    rack_ontology_node(Class, _, _),
     rack_ref('PROV-S#THING', Thing),
     \+ rdf_reachable(Class, rdfs:subClassOf, Thing),
+    \+ rdf_bnode(Class),
     print_message(warning, not_prov_s_thing_class(Class)).
 
 check_instance_types(I) :-

--- a/assist/bin/rack/check.pl
+++ b/assist/bin/rack/check.pl
@@ -35,12 +35,14 @@ num_instances(Count) :-
 
 check_missing_notes(Class) :-
     rdf(Class, rdf:type, owl:'Class'),
+    has_interesting_prefix(Class),
     \+ rdf(Class, rdfs:comment, _),
     \+ rdf_bnode(Class),
     print_message(warning, class_missing_note(Class)).
 
 check_not_prov_s(Class) :-
     rdf(Class, rdf:type, owl:'Class'),
+    has_interesting_prefix(Class),
     rack_ref('PROV-S#THING', Thing),
     \+ rdf_reachable(Class, rdfs:subClassOf, Thing),
     \+ rdf_bnode(Class),

--- a/assist/bin/rack/check.pl
+++ b/assist/bin/rack/check.pl
@@ -69,7 +69,7 @@ check_instance_property_violations(Property) :-
     ; check_cardinality_min(Property, I, T)
     ; check_cardinality_max(Property, I, T)
     ; check_maybe_prop(Property, I, T)
-    ; check_target_type(Property, I, T),
+    ; check_target_type(Property, I, T)
     ; check_target_type_restrictions(Property, I, T)
     ; check_values_from(Property, I, T)
     ; check_invalid_value(Property, I, T)

--- a/assist/bin/rack/check.pl
+++ b/assist/bin/rack/check.pl
@@ -74,7 +74,7 @@ check_instance_property_violations(Property) :-
      check_invalid_value(Property, I, T)).
 
 check_cardinality_exact(Property, I, T) :-
-    property_target(T, Property, _PUsage, _Target, cardinality(N)),
+    property_target(T, Property, _PUsage, cardinality(N)),
     has_interesting_prefix(Property),
     % How many actual values for that property on this instance
     findall(V, rdf(I, Property, V), VS),
@@ -84,7 +84,7 @@ check_cardinality_exact(Property, I, T) :-
     print_message(error, cardinality_violation(I, IName, Property, N, VSLen)).
 
 check_cardinality_min(Property, I, T) :-
-    property_target(T, Property, _PUsage, _Target, min_cardinality(N)),
+    property_target(T, Property, _PUsage, min_cardinality(N)),
     has_interesting_prefix(Property),
     % How many actual values for that property on this instance
     findall(V, rdf(I, Property, V), VS),
@@ -94,7 +94,7 @@ check_cardinality_min(Property, I, T) :-
     print_message(error, min_cardinality_violation(I, IName, Property, N, VSLen)).
 
 check_cardinality_max(Property, I, T) :-
-    property_target(T, Property, _PUsage, _Target, max_cardinality(N)),
+    property_target(T, Property, _PUsage, max_cardinality(N)),
     has_interesting_prefix(Property),
     % How many actual values for that property on this instance
     findall(V, rdf(I, Property, V), VS),
@@ -104,7 +104,7 @@ check_cardinality_max(Property, I, T) :-
     print_message(error, max_cardinality_violation(I, IName, Property, N, VSLen)).
 
 check_maybe_prop(Property, I, T) :-
-    property_target(T, Property, _PUsage, _Target, maybe),
+    property_target(T, Property, _PUsage, maybe),
     has_interesting_prefix(Property),
     % How many actual values for that property on this instance
     findall(V, rdf(I, Property, V), VS),
@@ -126,7 +126,7 @@ check_target_type(Property, I, T) :-
     print_message(error, property_value_wrong_type(I, IName, Property, DefTy, Val, Target)).
 
 check_values_from(Property, I, T) :-
-    property_target(T, Property, _PUsage, _Target, value_from(Cls)),
+    property_target(T, Property, _PUsage, value_from(Cls)),
     has_interesting_prefix(Property),
     rdf(I, Property, Val),
     \+ rdf_is_literal(Val),  % TODO check these as well?
@@ -146,7 +146,7 @@ check_values_from(Property, I, T) :-
     ).
 
 check_invalid_value(Property, I, T) :-
-    property_target(T, Property, _PUsage, _Target, _Restr),
+    property_target(T, Property, _PUsage, _Restr),
     has_interesting_prefix(Property),
     rdf(I, Property, V),
     \+ rdf_is_literal(V),  % literals checked elsewhere
@@ -159,7 +159,7 @@ check_invalid_value(Property, I, T) :-
     print_message(error, invalid_value_in_enum(I, IName, Property, V, L)).
 
 check_invalid_value(Property, I, T) :-
-    property_target(T, Property, _PUsage, _Target, _Restr),
+    property_target(T, Property, _PUsage, _Restr),
     has_interesting_prefix(Property),
     rdf(I, Property, V),
     rdf_is_literal(V),  % non-literals handled elsewhere

--- a/assist/bin/rack/check.pl
+++ b/assist/bin/rack/check.pl
@@ -37,12 +37,12 @@ check_rack :-
     warn_if_nonzero("with instance issues", BISLen),
     warn_if_nonzero("with instance property issues", MISLen),
     warn_if_nonzero("with INTERFACE instance issues", IFCSLen),
-    TotalIssues = CSLen + NPCSLen + BISLen + MISLen + IFCSLen,
+    TotalIssues is CSLen + NPCSLen + BISLen + MISLen + IFCSLen,
     (TotalIssues == 0,
      !,
      format('No issues found~n')
     ;
-    format('ISSUES FOUND IN CHECK~n'), halt(1)),
+    format('~w ISSUES FOUND IN CHECK~n', [TotalIssues]), halt(1)),
     true.
 
 core_ontology_size(Size) :-

--- a/assist/bin/rack/check.pl
+++ b/assist/bin/rack/check.pl
@@ -271,7 +271,7 @@ prolog:message(class_missing_note(Class)) -->
 prolog:message(not_prov_s_thing_class(Class)) -->
     [ 'Not a subclass of PROV-S#THING: ~w'-[Class] ].
 prolog:message(num_classes(What, Count)) -->
-    [ 'There are ~:d RACK definitions ~w.'-[Count, What] ].
+    [ 'There are ~:d RACK ~w.'-[Count, What] ].
 prolog:message(cardinality_violation(InstType, Instance, InstanceIdent, Property, Specified, Actual)) -->
     { prefix_shorten(Instance, SI),
       prefix_shorten(InstType, ST),

--- a/assist/bin/rack/check_runner.pl
+++ b/assist/bin/rack/check_runner.pl
@@ -47,13 +47,13 @@ check_each_with(CheckFun, NFail) :-
 % Oh this will be fun.
 % Run fun, run.
 % Oh when will we be done.
-runnable_check("missing a Note/Description", Num) :-
+runnable_check("definitions missing a Note/Description", Num) :-
     check_each_with(check_missing_notes, Num).
-runnable_check("not a subclass of PROV-S#THING", Num) :-
+runnable_check("definitions not a subclass of PROV-S#THING", Num) :-
     check_each_with(check_not_prov_s, Num).
-runnable_check("with instance type issues", Num) :-
+runnable_check("instance type issues", Num) :-
     check_each_with(check_instance_types, Num).
-runnable_check("with instance property issues", Num) :-
+runnable_check("instance property issues", Num) :-
     check_each_with(check_instance_property_violations, Num).
 runnable_check("INTERFACE issues", Num) :- check_each_with(check_INTERFACE, Num).
 runnable_check("SBVT issues",      Num) :- check_each_with(check_SBVT,      Num).

--- a/assist/bin/rack/check_runner.pl
+++ b/assist/bin/rack/check_runner.pl
@@ -15,6 +15,8 @@
 :- use_module(checks(interfaceChecks)).
 :- use_module(checks(sbvt_checks)).
 :- use_module(checks(srs_checks)).
+:- use_module(checks(system_checks)).
+:- use_module(checks(software_checks)).
 
 
 run_checks :-
@@ -56,3 +58,5 @@ runnable_check("with instance property issues", Num) :-
 runnable_check("INTERFACE issues", Num) :- check_each_with(check_INTERFACE, Num).
 runnable_check("SBVT issues",      Num) :- check_each_with(check_SBVT,      Num).
 runnable_check("SRS issues",       Num) :- check_each_with(check_SRS,       Num).
+runnable_check("SYSTEM issues",    Num) :- check_each_with(check_SYSTEM,    Num).
+runnable_check("SOFTWARE issues",  Num) :- check_each_with(check_SOFTWARE,  Num).

--- a/assist/bin/rack/check_runner.pl
+++ b/assist/bin/rack/check_runner.pl
@@ -13,6 +13,7 @@
 
 :- ensure_loaded('../paths').
 :- use_module(checks(interfaceChecks)).
+:- use_module(checks(sbvt_checks)).
 
 
 run_checks :-
@@ -51,5 +52,5 @@ runnable_check("with instance type issues", Num) :-
     check_each_with(check_instance_types, Num).
 runnable_check("with instance property issues", Num) :-
     check_each_with(check_instance_property_violations, Num).
-runnable_check("INTERFACE issues", Num) :-
-    check_each_with(check_INTERFACE, Num).
+runnable_check("INTERFACE issues", Num) :- check_each_with(check_INTERFACE, Num).
+runnable_check("SBVT issues",      Num) :- check_each_with(check_SBVT,      Num).

--- a/assist/bin/rack/check_runner.pl
+++ b/assist/bin/rack/check_runner.pl
@@ -1,0 +1,55 @@
+% Copyright (c) 2022, Galois, Inc.
+%
+% All Rights Reserved
+%
+% This material is based upon work supported by the Defense Advanced Research
+% Projects Agency (DARPA) under Contract No. FA8750-20-C-0203.
+%
+% Any opinions, findings and conclusions or recommendations expressed in this
+% material are those of the author(s) and do not necessarily reflect the views
+% of the Defense Advanced Research Projects Agency (DARPA).
+
+:- module(check_runner, [ run_checks/0 ]).
+
+:- ensure_loaded('../paths').
+:- use_module(checks(interfaceChecks)).
+
+
+run_checks :-
+    findall((C,N), runnable_check(C, N), CNS),
+    format('~`.t Summary ~`.t~78|~n'),
+    core_ontology_size(CoreSize),
+    overlay_ontology_size(OverlaySize),
+    num_instances(InstanceCount),
+    format('Checked ~w core ontology classes, ~w overlay ontology classes, and ~w data instances~n',
+           [CoreSize, OverlaySize, InstanceCount]),
+    warn_all_nonzero(CNS),
+    sum_all_nonzero(CNS, TotalIssues),
+    (TotalIssues == 0,
+     !,
+     format('No issues found~n')
+    ;
+    format('~w ISSUES FOUND IN CHECK~n', [TotalIssues]), halt(1)),
+    true.
+
+% A check function shouldn't succeed unless there's a problem.  This
+% returns the number of times the passed check function succeeds.
+check_each_with(CheckFun, NFail) :-
+    findall(C, call(CheckFun, C), CS),
+    length(CS, NFail).
+
+
+% Oh the checks we will run.
+% Oh this will be fun.
+% Run fun, run.
+% Oh when will we be done.
+runnable_check("missing a Note/Description", Num) :-
+    check_each_with(check_missing_notes, Num).
+runnable_check("not a subclass of PROV-S#THING", Num) :-
+    check_each_with(check_not_prov_s, Num).
+runnable_check("with instance type issues", Num) :-
+    check_each_with(check_instance_types, Num).
+runnable_check("with instance property issues", Num) :-
+    check_each_with(check_instance_property_violations, Num).
+runnable_check("INTERFACE issues", Num) :-
+    check_each_with(check_INTERFACE, Num).

--- a/assist/bin/rack/check_runner.pl
+++ b/assist/bin/rack/check_runner.pl
@@ -14,6 +14,7 @@
 :- ensure_loaded('../paths').
 :- use_module(checks(interfaceChecks)).
 :- use_module(checks(sbvt_checks)).
+:- use_module(checks(srs_checks)).
 
 
 run_checks :-
@@ -54,3 +55,4 @@ runnable_check("with instance property issues", Num) :-
     check_each_with(check_instance_property_violations, Num).
 runnable_check("INTERFACE issues", Num) :- check_each_with(check_INTERFACE, Num).
 runnable_check("SBVT issues",      Num) :- check_each_with(check_SBVT,      Num).
+runnable_check("SRS issues",       Num) :- check_each_with(check_SRS,       Num).

--- a/assist/bin/rack/model.pl
+++ b/assist/bin/rack/model.pl
@@ -485,7 +485,7 @@ property_target(Class, Property, PropUsage, Restrictions) :-
 % For Cardinality information, see: https://w3.org/2001/sw/BestPratices/OEP/QCR
 
 property_extra(Class, Property, cardinality(N)) :-
-    rdf(Class, rdfs:subClassOf, B),
+    rdf_reachable(Class, rdfs:subClassOf, B),
     rdf_bnode(B),
     rdf(B, owl:onProperty, Property),
     rdf(B, rdf:type, owl:'Restriction'), !,
@@ -495,14 +495,14 @@ property_extra(Class, Property, cardinality(N)) :-
 property_extra(_Class, Property, maybe) :-
     rdf(Property, rdf:type, owl:'FunctionalProperty'), !.
 property_extra(Class, Property, min_cardinality(N)) :-
-    rdf(Class, rdfs:subClassOf, B),
+    rdf_reachable(Class, rdfs:subClassOf, B),
     rdf_bnode(B),
     rdf(B, owl:onProperty, Property),
     rdf(B, rdf:type, owl:'Restriction'), !,
     (rdf(B, owl:minCardinality, I), rdf_literal(I), rdf_numeric(I, N) ;
      rdf(B, owl:someValuesFrom, _T), N == 1).
 property_extra(Class, Property, max_cardinality(N)) :-
-    rdf(Class, rdfs:subClassOf, B),
+    rdf_reachable(Class, rdfs:subClassOf, B),
     rdf_bnode(B),
     rdf(B, owl:onProperty, Property),
     rdf(B, rdf:type, owl:'Restriction'), !,
@@ -619,11 +619,11 @@ rack_data_instance(Class, I) :-
 % separately via rdf(SourceInstance, property, TargetInstance) calls).
 
 rack_instance_relationship(SrcCls, Rel, TgtCls, SrcInst) :-
-    rdf_reachable(C, rdf:subClass, SrcCls),
+    rdf_reachable(C, rdfs:subClassOf, SrcCls),
     rdf(SrcInst, rdf:type, C),
     rdf(SrcInst, Rel, TgtInst),
     rdf(TgtInst, rdf:type, TC),
-    rdf_reachable(TC, rdf:subClass, TgtCls).
+    rdf_reachable(TC, rdfs:subClassOf, TgtCls).
 
 %! rack_instance_relationship(+SourceClass:atom, +property:atom, -SourceInstance)
 %
@@ -633,7 +633,7 @@ rack_instance_relationship(SrcCls, Rel, TgtCls, SrcInst) :-
 % separately via rdf(SourceInstance, property, TargetInstance) calls).
 
 rack_instance_relationship(SrcCls, Rel, SrcInst) :-
-    rdf_reachable(C, rdf:subClass, SrcCls),
+    rdf_reachable(C, rdfs:subClassOf, SrcCls),
     rdf(SrcInst, rdf:type, C),
     rdf(SrcInst, Rel, _).
 

--- a/assist/bin/rack/model.pl
+++ b/assist/bin/rack/model.pl
@@ -312,7 +312,7 @@ is_owl_class(E) :-
 
 owl_list(B, PL) :-
     is_owl_class(B),
-    rdf_bnode(B),
+    rdf_is_bnode(B),
     rdf_literal(B),
     rdf(B,owl:unionOf,L),
     rdf_list(L),
@@ -344,7 +344,7 @@ rack_ontology_node(Node, Area, Item) :-
 entity(E) :-
     is_owl_class(E),
     rdf(E, rdfs:subClassOf, rack:'PROV-S#ENTITY'),
-    \+ rdf_bnode(E).
+    \+ rdf_is_bnode(E).
 
 %! entity(?Entity:atom, -Comment:atom)
 %
@@ -514,7 +514,7 @@ property_extra(Class, Property, _Target, max_cardinality(N)) :-
     rdf_numeric(I, N).
 property_extra(Class, Property, _Target, value_from(Cls)) :-
     rdf(Class, rdfs:subClassOf, B),
-    rdf_bnode(B),
+    rdf_is_bnode(B),
     rdf(B, owl:onProperty, Property),
     rdf(B, rdf:type, owl:'Restriction'), !,
     rdf(B, owl:someValuesFrom, Cls).

--- a/assist/bin/rack/model.pl
+++ b/assist/bin/rack/model.pl
@@ -479,6 +479,17 @@ property_target(Class, Property, PropUsage, Restrictions) :-
     property(SrcCls, Property, PropUsage),
     property_extra(Class, Property, Restrictions).
 
+% If there is a restriction for this property, this will be true and
+% return the restriction node.
+
+property_restriction(Class, Property, RestrictionNode) :-
+    rdf_reachable(Class, rdfs:subClassOf, B),
+    rdf_is_bnode(B),
+    rdf(B, owl:onProperty, Property),
+    rdf(B, rdf:type, owl:'Restriction'),
+    RestrictionNode = B.
+
+
 % Various recognizers used by property_target to translate RDF
 % relation restrictions into an identified local restriction type like
 % "cardinality(N)", "maybe", "normal", etc.
@@ -486,35 +497,23 @@ property_target(Class, Property, PropUsage, Restrictions) :-
 % For Cardinality information, see: https://w3.org/2001/sw/BestPratices/OEP/QCR
 
 property_extra(Class, Property, cardinality(N)) :-
-    rdf_reachable(Class, rdfs:subClassOf, B),
-    rdf_is_bnode(B),
-    rdf(B, owl:onProperty, Property),
-    rdf(B, rdf:type, owl:'Restriction'),
+    property_restriction(Class, Property, B),
     rdf(B, owl:cardinality, I),
     rdf_literal(I),
     rdf_numeric(I, N).
 property_extra(_Class, Property, maybe) :-
     rdf(Property, rdf:type, owl:'FunctionalProperty'), !.
 property_extra(Class, Property, min_cardinality(N)) :-
-    rdf_reachable(Class, rdfs:subClassOf, B),
-    rdf_is_bnode(B),
-    rdf(B, owl:onProperty, Property),
-    rdf(B, rdf:type, owl:'Restriction'),
+    property_restriction(Class, Property, B),
     (rdf(B, owl:minCardinality, I), rdf_literal(I), rdf_numeric(I, N) ;
      rdf(B, owl:someValuesFrom, _T), N == 1).
 property_extra(Class, Property, max_cardinality(N)) :-
-    rdf_reachable(Class, rdfs:subClassOf, B),
-    rdf_is_bnode(B),
-    rdf(B, owl:onProperty, Property),
-    rdf(B, rdf:type, owl:'Restriction'),
+    property_restriction(Class, Property, B),
     rdf(B, owl:maxCardinality, I),
     rdf_literal(I),
     rdf_numeric(I, N).
 property_extra(Class, Property, value_from(Cls)) :-
-    rdf(Class, rdfs:subClassOf, B),
-    rdf_is_bnode(B),
-    rdf(B, owl:onProperty, Property),
-    rdf(B, rdf:type, owl:'Restriction'),
+    property_restriction(Class, Property, B),
     rdf(B, owl:someValuesFrom, Cls).
 property_extra(_Class, _Property, normal).
 

--- a/assist/bin/rack/model.pl
+++ b/assist/bin/rack/model.pl
@@ -488,7 +488,7 @@ property_extra(Class, Property, cardinality(N)) :-
     rdf_reachable(Class, rdfs:subClassOf, B),
     rdf_bnode(B),
     rdf(B, owl:onProperty, Property),
-    rdf(B, rdf:type, owl:'Restriction'), !,
+    rdf(B, rdf:type, owl:'Restriction'),
     rdf(B, owl:cardinality, I),
     rdf_literal(I),
     rdf_numeric(I, N).
@@ -498,14 +498,14 @@ property_extra(Class, Property, min_cardinality(N)) :-
     rdf_reachable(Class, rdfs:subClassOf, B),
     rdf_bnode(B),
     rdf(B, owl:onProperty, Property),
-    rdf(B, rdf:type, owl:'Restriction'), !,
+    rdf(B, rdf:type, owl:'Restriction'),
     (rdf(B, owl:minCardinality, I), rdf_literal(I), rdf_numeric(I, N) ;
      rdf(B, owl:someValuesFrom, _T), N == 1).
 property_extra(Class, Property, max_cardinality(N)) :-
     rdf_reachable(Class, rdfs:subClassOf, B),
     rdf_bnode(B),
     rdf(B, owl:onProperty, Property),
-    rdf(B, rdf:type, owl:'Restriction'), !,
+    rdf(B, rdf:type, owl:'Restriction'),
     rdf(B, owl:maxCardinality, I),
     rdf_literal(I),
     rdf_numeric(I, N).
@@ -513,7 +513,7 @@ property_extra(Class, Property, value_from(Cls)) :-
     rdf(Class, rdfs:subClassOf, B),
     rdf_is_bnode(B),
     rdf(B, owl:onProperty, Property),
-    rdf(B, rdf:type, owl:'Restriction'), !,
+    rdf(B, rdf:type, owl:'Restriction'),
     rdf(B, owl:someValuesFrom, Cls).
 property_extra(_Class, _Property, normal).
 

--- a/assist/bin/rack/model.pl
+++ b/assist/bin/rack/model.pl
@@ -486,7 +486,7 @@ property_target(Class, Property, PropUsage, Restrictions) :-
 
 property_extra(Class, Property, cardinality(N)) :-
     rdf_reachable(Class, rdfs:subClassOf, B),
-    rdf_bnode(B),
+    rdf_is_bnode(B),
     rdf(B, owl:onProperty, Property),
     rdf(B, rdf:type, owl:'Restriction'),
     rdf(B, owl:cardinality, I),
@@ -496,14 +496,14 @@ property_extra(_Class, Property, maybe) :-
     rdf(Property, rdf:type, owl:'FunctionalProperty'), !.
 property_extra(Class, Property, min_cardinality(N)) :-
     rdf_reachable(Class, rdfs:subClassOf, B),
-    rdf_bnode(B),
+    rdf_is_bnode(B),
     rdf(B, owl:onProperty, Property),
     rdf(B, rdf:type, owl:'Restriction'),
     (rdf(B, owl:minCardinality, I), rdf_literal(I), rdf_numeric(I, N) ;
      rdf(B, owl:someValuesFrom, _T), N == 1).
 property_extra(Class, Property, max_cardinality(N)) :-
     rdf_reachable(Class, rdfs:subClassOf, B),
-    rdf_bnode(B),
+    rdf_is_bnode(B),
     rdf(B, owl:onProperty, Property),
     rdf(B, rdf:type, owl:'Restriction'),
     rdf(B, owl:maxCardinality, I),

--- a/assist/bin/rack/model.pl
+++ b/assist/bin/rack/model.pl
@@ -102,8 +102,6 @@ file_to_fpath(File, DirPath, FilePath) :-
     prolog_to_os_filename(Y, FilePath).
 
 
-none(CandidateQuery, Pred) :- call(CandidateQuery, C), none_of(C, Pred).
-
 none_of(Candidate, Pred) :- call(Pred, Candidate), !, fail.
 none_of(_, _).
 

--- a/assist/bin/rack/model.pl
+++ b/assist/bin/rack/model.pl
@@ -44,6 +44,7 @@ description DSL into instances in the model.
               ontology_leaf_class/1,
               property/3,
               property_target/4,
+              property_extra/3,
               rack_instance/2,
               rack_instance_assert/2,
               rack_property_assert/3,

--- a/cli/setup-owl.sh
+++ b/cli/setup-owl.sh
@@ -79,7 +79,7 @@ in
         ;;
 
     docker)
-        echo "[setup-owl] Coping CDR and OWL files from Docker"
+        echo "[setup-owl] Copying CDR and OWL files from Docker"
 
         container=$(docker container ls -qf "ancestor=${rack_image}:${rack_tag}")
 


### PR DESCRIPTION
* Enables verification of data instances as ingested by semtk
* Adds additional common processing to simplify check implementation
* Adds checks for INTERFACE and SBVT validation.
* Display PROV-S#identifier (where available) when reporting check issues on data instances, since node ID's are generated UUID values and not informative.
* Enhanced reporting of total results.