### PR TITLE
Add range restrictions on wasGeneratedBy for well-known generation activities

### DIFF
--- a/RACK-Ontology/ontology/ANALYSIS.sadl
+++ b/RACK-Ontology/ontology/ANALYSIS.sadl
@@ -47,3 +47,5 @@ ANALYSIS_OUTPUT
 
     analyzes (note "ENTITY(s) under analysis") describes ANALYSIS_OUTPUT with values of type ENTITY.
     analyzes is a type of wasImpactedBy.
+    
+    wasGeneratedBy of ANALYSIS_OUTPUT only has values of type ANALYSIS.

--- a/RACK-Ontology/ontology/CONFIDENCE.sadl
+++ b/RACK-Ontology/ontology/CONFIDENCE.sadl
@@ -28,6 +28,8 @@ CONFIDENCE_ASSESSMENT (note "Superclass for confidence assessments over some oth
     assesses describes CONFIDENCE_ASSESSMENT with at most 1 value.
     assesses is a type of wasImpactedBy.
 
+	wasGeneratedBy of CONFIDENCE_ASSESSMENT only has values of type ASSESSING_CONFIDENCE.
+
 BDU_CONFIDENCE_ASSESSMENT (note "A belief-disbelief-uncertainty confidence assessment, c.f. Subjective Logic. belief, disbelief, and uncertainty should sum to 1") is a type of CONFIDENCE_ASSESSMENT.
     belief (note "belief that an assessment is true") describes CONFIDENCE_ASSESSMENT with a single value of type float. // [0,1].
     disbelief (note "belief that an assessment is false") describes CONFIDENCE_ASSESSMENT with a single value of type float. // [0,1].

--- a/RACK-Ontology/ontology/HAZARD.sadl
+++ b/RACK-Ontology/ontology/HAZARD.sadl
@@ -45,6 +45,8 @@ HAZARD
 	// A Hazard can be mitigated by a requirement, operating procedure etc., mitigation by REQUIREMENT is defined in REQUIREMENTS.sadl.
 	H:mitigates (note "a HAZARD may be mitigated by a OP_PROCEDURE") describes OP_PROCEDURE with values of type HAZARD.
 
+	wasGeneratedBy of HAZARD only has values of type HAZARD_IDENTIFICATION.
+
 HAZARD_IDENTIFICATION
 	(note "ACTIVITY that identifies potential sources of HAZARD whose risk must be evaluated")
 	is a type of ACTIVITY.

--- a/RACK-Ontology/ontology/REQUIREMENTS.sadl
+++ b/RACK-Ontology/ontology/REQUIREMENTS.sadl
@@ -35,6 +35,8 @@ REQUIREMENT
 
 	Rq:mitigates (note "ENTITY(s) (e.g. HAZARD) that is being mitigated by this REQUIREMENT") describes REQUIREMENT with values of type ENTITY.
 	Rq:mitigates is a type of wasImpactedBy.
+	
+	wasGeneratedBy of REQUIREMENT only has values of type REQUIREMENT_DEVELOPMENT.
 
 DATA_DICTIONARY_TERM
 	(note "Defines some conceptual data that may be collected somewhere and used somewhere else")

--- a/RACK-Ontology/ontology/REVIEW.sadl
+++ b/RACK-Ontology/ontology/REVIEW.sadl
@@ -30,6 +30,8 @@ REVIEW_LOG
 	reviews is a type of wasImpactedBy.
 
 	reviewResult (note "Review status descriptor") describes REVIEW_LOG with values of type REVIEW_STATE.
+	
+	wasGeneratedBy of REVIEW_LOG only has values of type REVIEW.
 
 REVIEW_STATE (note "Life-cycle status of a review log")
     is a type of THING,

--- a/RACK-Ontology/ontology/SYSTEM.sadl
+++ b/RACK-Ontology/ontology/SYSTEM.sadl
@@ -34,6 +34,8 @@ SYSTEM
 
 	function (note "functionality / capability of a SYSTEM") describes SYSTEM with values of type FUNCTION.
 	function is a type of wasImpactedBy.
+	
+	wasGeneratedBy of SYSTEM only has values of type SYSTEM_DEVELOPMENT.
 
 INTERFACE
 	(note "INTERFACEs describe directed connections between a SYSTEM providing what another SYSTEM requires")

--- a/RACK-Ontology/ontology/TESTING.sadl
+++ b/RACK-Ontology/ontology/TESTING.sadl
@@ -25,6 +25,8 @@ TEST
 
 	verifies (note "ENTITY(s) (e.g. REQUIREMENT) that this test verifies") describes TEST with values of type ENTITY.
 	verifies is a type of wasImpactedBy.
+	
+	wasGeneratedBy of TEST only has values of type TEST_DEVELOPMENT. 
 
 TEST_STATUS (note "The high-level outcome of a TEST_RESULT")
     is a type of THING,
@@ -41,6 +43,8 @@ TEST_RESULT
 
 	confirms (note "Parent test(s) of this test result") describes TEST_RESULT with values of type TEST.
 	confirms is a type of wasImpactedBy.
+	
+	wasGeneratedBy of TEST_RESULT only has values of type TEST_EXECUTION.
 
 
 TEST_PROCEDURE (note "A TEST_PROCEDURE is the TEST_STEPs that perform TESTs. ") is a type of COLLECTION.
@@ -71,5 +75,5 @@ TEST_EXECUTION
 	(note "ACTIVITY of performing a TEST and record its corresponding TEST_RESULT")
 	is a type of ACTIVITY.
 
-	testProcedure (note "TEST_PROCEDURE that was executed.")describes TEST_EXECUTION with values of type TEST_PROCEDURE.
+	testProcedure (note "TEST_PROCEDURE that was executed.") describes TEST_EXECUTION with values of type TEST_PROCEDURE.
 	testProcedure is a type of used.


### PR DESCRIPTION
Per our discussion this PR identifies ENTITIES that have specific ACTIVITY subtypes that are intended to create them.

Fixes #630