### PR TITLE
Turnstile: created a new ACTIVITY instance for SoftwareThread

### DIFF
--- a/Turnstile-Example/Turnstile-IngestionPackage/TurnstileLowLevelRequirements/turnstile_SoftwareThread2.csv
+++ b/Turnstile-Example/Turnstile-IngestionPackage/TurnstileLowLevelRequirements/turnstile_SoftwareThread2.csv
@@ -1,4 +1,4 @@
 identifier,dataInsertedBy_identifier,partOf_identifier,wasGeneratedBy_identifier
-InputThread,TurnstileIngestion-Low Level Requirements,CounterApplication,SwDesign
-OutputThread,TurnstileIngestion-Low Level Requirements,CounterApplication,SwDesign
-ExecutiveThread,TurnstileIngestion-Low Level Requirements,CounterApplication,SwDesign
+InputThread,TurnstileIngestion-Low Level Requirements,CounterApplication,SysThreadDesign
+OutputThread,TurnstileIngestion-Low Level Requirements,CounterApplication,SysThreadDesign
+ExecutiveThread,TurnstileIngestion-Low Level Requirements,CounterApplication,SysThreadDesign

--- a/Turnstile-Example/TurnstileDataCreation_Requirements.py
+++ b/Turnstile-Example/TurnstileDataCreation_Requirements.py
@@ -525,15 +525,15 @@ def CreateCdrs():
     #------------ InputThread ------------
     Add.turnstile_SoftwareThread(identifier = "InputThread",
                                  partOf_identifier = "CounterApplication",
-		                         wasGeneratedBy_identifier = "SwDesign")
+		                         wasGeneratedBy_identifier = "SysThreadDesign")
     #------------ OutputThread ------------
     Add.turnstile_SoftwareThread(identifier = "OutputThread",
                                  partOf_identifier = "CounterApplication",
-		                         wasGeneratedBy_identifier = "SwDesign")
+		                         wasGeneratedBy_identifier = "SysThreadDesign")
     #------------ ExecutiveThread ------------
     Add.turnstile_SoftwareThread(identifier = "ExecutiveThread",
                                  partOf_identifier = "CounterApplication",
-		                         wasGeneratedBy_identifier = "SwDesign")
+		                         wasGeneratedBy_identifier = "SysThreadDesign")
     #------------ DCC-1 ------------	
     Add.turnstile_DataAndControlCouple(identifier = "DCC-1",
                                        description = "PowerUp",


### PR DESCRIPTION
I recently ran into a problem ingesting the Turnstile data. The problem was that the identifier SwDesign was created as an instance of SoftwareDesign and as an instance of SYSTEM_DEVELOPMENT. Later in referencing the ACTIVITY for linking the satisfying OBJECTIVE, SemTK didn't know which instance to use.

So to correct this dataset, I created a new instance called SysThreadDesign. It is created as type `SYSTEM_DEVELOPMENT` because we're using the nodegroup ingest_turnstile_SoftwareThread that "create if missing". Further down the line, we may want to consider #674.