### PR TITLE
clear the cwe datagraph

### DIFF
--- a/cli/setup-arcos.sh
+++ b/cli/setup-arcos.sh
@@ -31,4 +31,4 @@ rack nodegroups import ../nodegroups/ingestion/arcos.arbiter
 
 rack model import ../RACK-Ontology/OwlModels/MITRE-CWE.yaml
 rack nodegroups import ../nodegroups/arcos.cwe
-rack data import ../RACK-Ontology/ontology/MITRE-CWE/import.yaml # datagraph http://rack001/mitre-cwe
+rack data import --clear ../RACK-Ontology/ontology/MITRE-CWE/import.yaml # datagraph http://rack001/mitre-cwe

--- a/cli/setup-clear.sh
+++ b/cli/setup-clear.sh
@@ -10,6 +10,7 @@ rack data clear                               \
     --data-graph http://rack001/data          \
     --data-graph http://rack001/arp-4754a     \
     --data-graph http://rack001/do-330        \
-    --data-graph http://rack001/do-178c
+    --data-graph http://rack001/do-178c       \
+    --data-graph http://rack001/mitre-cwe
 
 rack nodegroups delete-all --yes


### PR DESCRIPTION
Need to clear out the cwe datagraph in the setup scripts to prevent errors.
- Added `http://rack001/mitre-cwe` as one of the datagraphs to clear in `setup-clear.sh`
- Added the `--clear` flag to the `rack data import` line for MITRE-CWE data

@glguy, please take a look. Thanks!