### PR TITLE
fix rack-migration re. PEP508

### DIFF
--- a/migration/pyproject.toml
+++ b/migration/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "RACK migration tool suite"
+name = "rack-migration"
 version = "0.1"
 description = "Helps capturing changes to the RACK ontology"
 dependencies = ["colorama", "pydantic", "typing-extensions"]

--- a/migration/pyproject.toml
+++ b/migration/pyproject.toml
@@ -10,9 +10,12 @@ dependencies = ["colorama", "pydantic", "typing-extensions"]
 requires-python = ">=3.7"
 authors = [{ email = "val@galois.com" }, { name = "Valentin Robert" }]
 
-[project.scripts]
-rack_crawl = "rack_crawl:rack_crawl"
-rack_migrate = "rack_migrate:rack_migrate"
+# This breaks everything and is experimental and **very poorly** documented.
+# Disabling it for now.
+
+# [project.scripts]
+# rack_crawl = "rack_crawl:rack_crawl"
+# rack_migrate = "rack_migrate:rack_migrate"
 
 [tool.pyright]
 ignore = ["typings"]


### PR DESCRIPTION
It appears the tooling around pyproject.toml has recently decided to check the
project name against PEP508.  This no longer allows freeform text as the
project name, so we change it to be compliant.