### PR TITLE
Ontology vis and overlay checking

### DIFF
--- a/sadl-examples/AllOntology.sadl
+++ b/sadl-examples/AllOntology.sadl
@@ -1,0 +1,266 @@
+uri "http://arcos.rack/AllOntology" alias All.
+
+import "http://www.w3.org/2000/01/rdf-schema".
+import "http://arcos.rack/AGENTS".
+import "http://arcos.rack/ANALYSIS".
+import "http://arcos.rack/BASELINE".
+import "http://arcos.rack/CONFIDENCE".
+import "http://arcos.rack/DOCUMENT".
+import "http://arcos.rack/FILE".
+import "http://arcos.rack/HARDWARE".
+import "http://arcos.rack/HAZARD".
+import "http://arcos.rack/MODEL".
+import "http://arcos.rack/PROCESS".
+import "http://arcos.rack/REQUIREMENTS".
+import "http://arcos.rack/REVIEW".
+import "http://arcos.rack/SECURITY".
+import "http://arcos.rack/SOFTWARE".
+import "http://arcos.rack/SYSTEM".
+import "http://arcos.rack/TESTING".
+
+import "http://arcos.AH-64D/Boeing".
+import "http://arcos.acert/GrammaTech".
+import "http://arcos.certgate/LM".
+import "http://arcos.aace/RTX".
+import "http://arcos.descert/SRI".
+import "http://arcos.descert/SRI-SS".
+import "http://arcos.arbiter/STR".
+
+//import "http://arcos.turnstile/GE".
+//import "http://arcos.rack/CPS".
+//import "http://arcos.sadl-examples/TurnstileSecurity".
+
+// This file is in sadl-examples folder; so have this project references all the other 
+// relevant RACK projects. 
+// In this file, importing all these SADL files.
+// To get a visualization that shows all inherited properties, I need the "transitive" rule;
+// however that rule gives errors in this setup.
+// So, have commented out the "transitive" rule.
+// Based on the following experiment, the root cause of the issue is the fact that projects reference other projects.
+//		In the same Eclipse + SADL env, I made a project where all the SADL files were placed;
+//		so no need to reference any other project. Then I could keep the transitive rule and
+//		I got all the inherited properties.
+
+// The "transitive" rule does work in another setup where I use
+// * eclipse: Version 2021-09 (4.21.0)
+// * SADL features version 3.5.0.202203142132
+
+// The Ask query and Graph have similar structure but the Ask query results can be pasted into an excel
+// and massaged so that all the properties are present. Then you can identify properties that are
+// not adding anything "new".
+
+// Note that the out of the box visualization is messy with restrictions etc.;
+// so doing my own visualization (note that this vis will not have straight line arrows).
+// Each overlay is shown in a different color.
+
+// SADL settings
+// 1.	Using OWL_MEM reasoner
+// 2.	Uncheck "Translate multiple domain or range as union"
+// 3.	Uncheck "Property range specification required"
+// 4.	Check "Type checking issues as warning only"
+
+// TBD
+// 1. rename variables, add more comments. 
+
+// Limitations / Functionality of the graphing
+// 1. Not showing properties for the root node (THING). This is because I am getting the tooltip info
+// 		for "child". I could duplicate the code and get it for "parent" but have not done that.
+// 2. Inherited properties are shown first and below that are the "direct" properties (separated by "----")
+// 3. Below that we show max, min and exact cardinality and "all values" info.
+// 4. Am I handling correctly where the range is a union? 
+//		Yes, if it is union of 2 things then 2 rows of data is presented.
+// 5. The amount of info that a tooltip shows is limited, so at place where it is truncated there will be "..."
+// 6. When "all values" restriction present, both that restriction and the original range of property are shown.
+// 7. When the range is a union, a blank node is shown.
+// 8. Have not tried it where there are List, the range is say [1,..10], enumerations etc.
+// 9. Have observed some issues in underlying Jena reasoner related to OPTIONAL, concat etc.
+// 10. ARCOS specific: In graphing have dropped restrictions related to THING, ENTITY and ACTIVITY
+
+//Rule Transitive
+//if cls is a type of cls2
+//   and cls2 is a type of cls3
+//then cls is a type of cls3.
+
+Graph: "select ?parent ?subclass ?child ?parent_style ?child_style ?child_fillcolor ?parent_fillcolor 
+    (?propChild as ?child_tooltip) 
+where 
+{
+# get child and parent
+ ?child <rdfs:subClassOf> ?parent 
+ . FILTER(regex(str(?parent),'arcos')) 
+ . FILTER NOT EXISTS {?child <rdfs:subClassOf> ?p1 . ?p1 <rdfs:subClassOf> ?parent}
+ . LET(?subclass := '')
+
+ # set up coloring 
+ . LET(?child_style := 'filled') . LET(?parent_style := 'filled')
+ . OPTIONAL{FILTER(regex(str(?child), 'rack'))     . LET(?child_fillcolor :=  'white')}
+ . OPTIONAL{FILTER(regex(str(?parent),'rack'))     . LET(?parent_fillcolor := 'white')}
+ . OPTIONAL{FILTER(regex(str(?child), 'AH-64D'))   . LET(?child_fillcolor :=  'bisque')}
+ . OPTIONAL{FILTER(regex(str(?parent),'AH-64D'))   . LET(?parent_fillcolor := 'bisque')}
+ . OPTIONAL{FILTER(regex(str(?child), 'acert'))    . LET(?child_fillcolor :=  'aqua')}
+ . OPTIONAL{FILTER(regex(str(?parent),'acert'))    . LET(?parent_fillcolor := 'aqua')}
+ . OPTIONAL{FILTER(regex(str(?child), 'certgate')) . LET(?child_fillcolor :=  'red')}
+ . OPTIONAL{FILTER(regex(str(?parent),'certgate')) . LET(?parent_fillcolor := 'red')}
+ . OPTIONAL{FILTER(regex(str(?child), 'descert'))  . LET(?child_fillcolor :=  'darkseagreen1')}
+ . OPTIONAL{FILTER(regex(str(?parent),'descert'))  . LET(?parent_fillcolor := 'darkseagreen1')}
+ . OPTIONAL{FILTER(regex(str(?child), 'arbiter'))  . LET(?child_fillcolor :=  'darkgoldenrod')}
+ . OPTIONAL{FILTER(regex(str(?parent),'arbiter'))  . LET(?parent_fillcolor := 'darkgoldenrod')}
+ . OPTIONAL{FILTER(regex(str(?child), 'aace'))     . LET(?child_fillcolor :=  'fuchsia')}
+ . OPTIONAL{FILTER(regex(str(?parent),'aace'))     . LET(?parent_fillcolor := 'fuchsia')}
+
+# get all the max, min, exact cardinality restrictions
+. OPTIONAL{{select distinct ?child (group_concat(distinct ?propInfo3;separator='&#10;') as ?propChildxxx) where
+       {   ?child <rdfs:subClassOf> ?z 
+         . ?z ?y1 ?z1 . FILTER(regex(str(?z1),'Restriction')) 
+         . ?z ?restrictionType ?z2 
+         . FILTER(regex(str(?restrictionType),'maxCardinality') || regex(str(?restrictionType),'maxQualifiedCardinality') 
+                  || regex(str(?restrictionType),'cardinality') || regex(str(?restrictionType),'minCardinality'))
+         . ?z ?onProp ?onPropVal . FILTER(regex(str(?onProp),'onProperty'))
+         . LET(?strippedRestrictionType :=replace(str(?restrictionType),'http.*#',''))
+         . LET(?strippedOnPropVal :=replace(str(?onPropVal),'http.*#',''))
+         . LET(?propInfo3 := concat(?strippedOnPropVal, concat(concat(' : ',str(?strippedRestrictionType)), concat(' is ',str(?z2)))))
+      } group by ?child
+}}
+
+# specific to PROV-S: we will strip out all restrictions on properties of THING, ENTITY, AGENT, ACTIVITY
+# the final value is to be in ?propChild; so rename / comment appropriately
+# But first add line return at end
+. LET(?pChild1 := concat(?propChildxxx,'&#10;'))
+# from THING
+. LET(?pChild2 := replace(?pChild1,'identifier : maxCardinality is 1&#10;',''))
+. LET(?pChild3 := replace(?pChild2,'title : maxCardinality is 1&#10;',''))
+. LET(?pChild4 := replace(?pChild3,'description : maxCardinality is 1&#10;',''))
+
+
+# from ENTITY
+. LET(?pChild5 := replace(?pChild4,'wasGeneratedBy : maxCardinality is 1&#10;',''))
+. LET(?pChild6 := replace(?pChild5,'generatedAtTime : maxCardinality is 1&#10;',''))
+. LET(?pChild7 := replace(?pChild6,'invalidatedAtTime : maxCardinality is 1&#10;',''))
+
+# from ACTIVITY
+. LET(?pChild8 := replace(?pChild7,'startedAtTime : maxCardinality is 1&#10;',''))
+. LET(?pChild9 := replace(?pChild8,'endedAtTime : maxCardinality is 1&#10;',''))
+
+. LET(?propCardinalityRestrictions := ?pChild9)
+
+# get all the 'only has values of type' NOTE that if any found then the 'original' property range is also displayed
+. OPTIONAL{{select distinct ?child (group_concat(distinct ?propInfo3;separator='&#10;') as ?propOnlyValuesOfType) where
+       {   ?child <rdfs:subClassOf> ?z 
+         . ?z ?y1 ?z1 . FILTER(regex(str(?z1),'Restriction')) 
+         . ?z ?restrictionType ?z2 
+         . FILTER(regex(str(?restrictionType),'allValuesFrom')) 
+         . LET(?strippedz2 :=replace(str(?z2),'http.*#','')) 
+         . ?z ?onProp ?onPropVal . FILTER(regex(str(?onProp),'onProperty'))
+         . LET(?strippedOnPropVal :=replace(str(?onPropVal),'http.*#','')) 
+         . LET(?propInfo3 := concat(str(?strippedOnPropVal),concat(' : only has values of type ',?strippedz2)))
+      } group by ?child
+}}
+
+# get all the parent properties
+. OPTIONAL{{select distinct ?child (group_concat(distinct ?propInfo;separator='&#10;') as ?propFromParent) where
+       {  ?prop ?y2 ?z2 . FILTER(regex(str(?y2), 'domain')) . ?child <rdfs:subClassOf> ?z2  
+         . ?prop ?range ?r1 . FILTER(regex(str(?range),'range'))
+         . LET(?strippedProp := replace(str(?prop),'http.*#',''))
+         . LET(?strippedRange := replace(str(?r1),'http.*#',''))
+         . LET(?propInfo := concat(str(?strippedProp), concat(' -> ',str(?strippedRange)))	)	
+      } group by ?child
+}}
+
+# get all the direct properties
+. OPTIONAL{{select distinct ?child (group_concat(distinct ?propInfo;separator='&#10;') as ?propDirect) where
+       {  ?prop ?y2 ?child . FILTER(regex(str(?y2), 'domain'))   
+         . ?prop ?range ?r1 . FILTER(regex(str(?range),'range'))
+         . LET(?strippedProp := replace(str(?prop),'http.*#',''))
+         . LET(?strippedRange := replace(str(?r1),'http.*#',''))
+         . LET(?propInfo := concat(str(?strippedProp), concat(' -> ',str(?strippedRange)))	)	
+      } group by ?child
+}}
+
+# now concatenate everything from ?propFromParent, ?propCardinalityRestrictions, ?propOnlyValuesOfType
+. LET(?null := '')
+. LET(?ttt := concat(?propCardinalityRestrictions, concat('&#10;',?propOnlyValuesOfType)))
+. LET(?ttt1 := coalesce(?ttt,?propCardinalityRestrictions,?propOnlyValuesOfType,?null)) 
+. LET(?ttt1A := concat('---------&#10;',?ttt1)) 
+. LET(?ttt3 := concat(?propFromParent,concat('&#10;---------&#10;',?propChild4)))
+. LET(?ttt4 := coalesce(?ttt3, ?propFromParent, ?propChild4,?null))
+
+. LET(?propChild := concat(?ttt4,concat('&#10;', ?ttt1A)))
+}".
+
+// The following query is similar to the Graph query above but the output from it is meant for analysis in Excel.
+Ask: "select distinct ?parent ?child ?propFromParent ?propDirect ?propCardinalityRestrictions ?propOnlyValuesOfType 
+where 
+{
+# get child and parent
+ ?child <rdfs:subClassOf> ?parent 
+ . FILTER(regex(str(?parent),'arcos')) 
+ . FILTER NOT EXISTS {?child <rdfs:subClassOf> ?p1 . ?p1 <rdfs:subClassOf> ?parent}
+
+# get all the max, min, exact cardinality restrictions
+. OPTIONAL{{select distinct ?child (group_concat(distinct ?propInfo3;separator='&#10;') as ?propChildxxx) where
+       {   ?child <rdfs:subClassOf> ?z 
+         . ?z ?y1 ?z1 . FILTER(regex(str(?z1),'Restriction')) 
+         . ?z ?restrictionType ?z2 
+         . FILTER(regex(str(?restrictionType),'maxCardinality') || regex(str(?restrictionType),'maxQualifiedCardinality') 
+                  || regex(str(?restrictionType),'cardinality') || regex(str(?restrictionType),'minCardinality'))
+         . ?z ?onProp ?onPropVal . FILTER(regex(str(?onProp),'onProperty'))
+         . LET(?strippedRestrictionType :=replace(str(?restrictionType),'http.*#',''))
+         . LET(?strippedOnPropVal :=replace(str(?onPropVal),'http.*#',''))
+         . LET(?propInfo3 := concat(?strippedOnPropVal, concat(concat(' : ',str(?strippedRestrictionType)), concat(' is ',str(?z2)))))
+      } group by ?child
+}}
+
+# specific to PROV-S: we will strip out all restrictions on properties of THING, ENTITY, AGENT, ACTIVITY
+# the final value is to be in ?propChild; so rename / comment appropriately
+# But first add line return at end
+. LET(?pChild1 := concat(?propChildxxx,'&#10;'))
+# from THING
+. LET(?pChild2 := replace(?pChild1,'identifier : maxCardinality is 1&#10;',''))
+. LET(?pChild3 := replace(?pChild2,'title : maxCardinality is 1&#10;',''))
+. LET(?pChild4 := replace(?pChild3,'description : maxCardinality is 1&#10;',''))
+
+# from ENTITY
+. LET(?pChild5 := replace(?pChild4,'wasGeneratedBy : maxCardinality is 1&#10;',''))
+. LET(?pChild6 := replace(?pChild5,'generatedAtTime : maxCardinality is 1&#10;',''))
+. LET(?pChild7 := replace(?pChild6,'invalidatedAtTime : maxCardinality is 1&#10;',''))
+
+# from ACTIVITY
+. LET(?pChild8 := replace(?pChild7,'startedAtTime : maxCardinality is 1&#10;',''))
+. LET(?pChild9 := replace(?pChild8,'endedAtTime : maxCardinality is 1&#10;',''))
+
+. LET(?propCardinalityRestrictions := ?pChild9)
+
+# get all the 'only has values of type' NOTE that if any found then the 'original' property range is also displayed
+. OPTIONAL{{select distinct ?child (group_concat(distinct ?propInfo3;separator=';') as ?propOnlyValuesOfType) where
+       {   ?child <rdfs:subClassOf> ?z 
+         . ?z ?y1 ?z1 . FILTER(regex(str(?z1),'Restriction')) 
+         . ?z ?restrictionType ?z2 
+         . FILTER(regex(str(?restrictionType),'allValuesFrom')) 
+         . LET(?strippedz2 :=replace(str(?z2),'http.*#','')) 
+         . ?z ?onProp ?onPropVal . FILTER(regex(str(?onProp),'onProperty'))
+         . LET(?strippedOnPropVal :=replace(str(?onPropVal),'http.*#','')) 
+         . LET(?propInfo3 := concat(str(?strippedOnPropVal),concat(' : only has values of type ',?strippedz2)))
+      } group by ?child
+}}
+
+# get all the parent properties
+. OPTIONAL{{select distinct ?child (group_concat(distinct ?propInfo;separator='; &#10;') as ?propFromParent) where
+       {  ?prop ?y2 ?z2 . FILTER(regex(str(?y2), 'domain')) . ?child <rdfs:subClassOf> ?z2  
+         . ?prop ?range ?r1 . FILTER(regex(str(?range),'range'))
+         . LET(?strippedProp := replace(str(?prop),'http.*#',''))
+         . LET(?strippedRange := replace(str(?r1),'http.*#',''))
+         . LET(?propInfo := concat(str(?strippedProp), concat(' -> ',str(?strippedRange)))	)	
+      } group by ?child
+}}
+
+# get all the direct properties
+. OPTIONAL{{select distinct ?child (group_concat(distinct ?propInfo;separator='; &#10;') as ?propDirect) where
+       {  ?prop ?y2 ?child . FILTER(regex(str(?y2), 'domain'))   
+         . ?prop ?range ?r1 . FILTER(regex(str(?range),'range'))
+         . LET(?strippedProp := replace(str(?prop),'http.*#',''))
+         . LET(?strippedRange := replace(str(?r1),'http.*#',''))
+         . LET(?propInfo := concat(str(?strippedProp), concat(' -> ',str(?strippedRange)))	)	
+      } group by ?child
+}}
+
+} order by ?child".

--- a/sadl-examples/OverlayChecks.sadl
+++ b/sadl-examples/OverlayChecks.sadl
@@ -1,0 +1,121 @@
+uri "http://arcos.rack/OverlayChecks" alias chk.
+
+// Set SADL "Translate multiple-class domain or range as union" property to be false 
+// for the overlay ontology being checked - this is really only needed for SRI ontology
+// as they have instances where a property has multiple domains / ranges.
+// Have not tested it on Turnstile ontology as that is currently being restructured
+//	and after restructuring we may be able to just import one file.
+
+// Currently, there are no violations in any of the overlays,
+// but to test these overlay checks use the SRI ontology that
+// was in RACK v 6.
+import "http://arcos.descert/SRI".
+//import "http://arcos.descert/SRI-SS".
+//import "http://arcos.certgate/LM".
+//import "http://arcos.acert/GrammaTech".
+//import "http://arcos.AH-64D/Boeing".
+//import "http://arcos.arbiter/STR".
+//import "http://arcos.aace/RTX".
+
+// Note that these do not find all issues; for details see https://github.com/SemanticApplicationDesignLanguage/sadl/discussions/897
+// and the project that I posted on Git for Andy to take a look at is OverlayCheckIssue in this workspace.
+
+// This does the overlay checks on the DesCert overlay ontology.
+// Enable appropriate SADL properties to get fully qualified names as that will help
+// in facilitating manual checking of the results of the two queries.
+// To do checks on a different overlay ontology import it instead of DesCert overlay ontology.
+
+//////////////////////////////////////////// ONTOLOGY OVERLAY CHECK QUERIES //////////////////////////////////
+Print: "".
+Print: "****** Three queries for checking ontology overlays, the first one checks domain and the second one checks range".
+Print: "".
+Print: "****** Check domain info for the following properties:".
+Print: "******      the domain in overlay ontology should be a subclass of the domain in core ontology.".
+Print: "".
+
+Ask: "select distinct ?property ?coreOntologyDomain ?overlayOntologyDomain  where
+{?property ?y ?z 
+. FILTER(regex(str(?y),'domain'))
+. FILTER(regex(str(?property),'arcos.rack'))
+. ?property ?y ?z1 . FILTER(?z1 != ?z) # get another domain
+ 
+. OPTIONAL{?z1 ?y2 ?z2 . FILTER(regex(str(?y2),'unionOf'))
+           . ?z2 ?y3 ?z3 . FILTER(regex(str(?y3),'first'))
+           . ?z2 ?y4 ?z4 . FILTER(regex(str(?y4),'rest'))
+           . ?z4 ?y5 ?z5 . FILTER(regex(str(?y5),'first'))
+           . LET(?t1 := concat('{',str(?z3))) 
+           . LET(?t2 := concat(str(?z5),'}')) 
+           . LET(?t3 := concat(?t1, concat(', ',?t2))) 
+          }
+. LET(?overlayOntologyDomain := coalesce(?t3, ?z1))
+. FILTER(!regex(str(?overlayOntologyDomain),'arcos.rack'))
+. OPTIONAL{?z ?y6 ?z6 . FILTER(regex(str(?y6),'unionOf'))
+           . ?z6 ?y7 ?z7 . FILTER(regex(str(?y7),'first'))
+           . ?z6 ?y8 ?z8 . FILTER(regex(str(?y8),'rest'))
+           . ?z8 ?y9 ?z9 . FILTER(regex(str(?y9),'first'))
+           . LET(?t4 := concat('{',str(?z7))) 
+           . LET(?t5 := concat(str(?z9),'}')) 
+           . LET(?t6 := concat(?t4, concat(', ',?t5))) 
+          }
+. LET(?coreOntologyDomain := coalesce(?t6, ?z))
+. FILTER(regex(str(?coreOntologyDomain),'arcos.rack'))
+} order by ?property ?coreOntologyDomain".
+
+Print: "".
+Print: "****** Check range info for the following properties:".
+Print: "******      the range in overlay ontology should be a subclass of the range in core ontology.".
+Print: "".
+
+Ask: "select distinct ?property ?coreOntologyRange ?overlayOntologyRange  where
+{?property ?y ?z 
+. FILTER(regex(str(?y),'range'))
+. FILTER(regex(str(?property),'arcos.rack'))
+. ?property ?y ?z1 . FILTER(?z1 != ?z) # get another range
+. OPTIONAL{?z1 ?y2 ?z2 . FILTER(regex(str(?y2),'unionOf'))
+           . ?z2 ?y3 ?z3 . FILTER(regex(str(?y3),'first'))
+           . ?z2 ?y4 ?z4 . FILTER(regex(str(?y4),'rest'))
+           . ?z4 ?y5 ?z5 . FILTER(regex(str(?y5),'first'))
+           . LET(?t1 := concat('{',str(?z3))) 
+           . LET(?t2 := concat(str(?z5),'}')) 
+           . LET(?t3 := concat(?t1, concat(', ',?t2))) 
+          }
+. LET(?coreOntologyRange := coalesce(?t3, ?z1))
+. FILTER(regex(str(?coreOntologyRange),'arcos.rack'))
+. OPTIONAL{?z ?y6 ?z6 . FILTER(regex(str(?y6),'unionOf'))
+           . ?z6 ?y7 ?z7 . FILTER(regex(str(?y7),'first'))
+           . ?z6 ?y8 ?z8 . FILTER(regex(str(?y8),'rest'))
+           . ?z8 ?y9 ?z9 . FILTER(regex(str(?y9),'first'))
+           . LET(?t4 := concat('{',str(?z7))) 
+           . LET(?t5 := concat(str(?z9),'}')) 
+           . LET(?t6 := concat(?t4, concat(', ',?t5))) 
+          }
+. LET(?overlayOntologyRange := coalesce(?t6, ?z)) 
+} order by ?property ?coreOntologyRange".
+
+Print: "".
+////////////////////////////////////////// DONE: ONTOLOGY OVERLAY CHECK QUERIES //////////////////////////////////
+
+// Other checks - want overlays to not extend core ontology class with a property, rather they
+// should define a subclass and extend that. This will avoid issues in automated nodegroup generation.
+
+Print: "".
+Print: "****** Check that the overlay does not extend core ontology class with a property".
+Print: "******      this avoids issues in the automated nodegroup generation.".
+Print: "".
+
+Ask: "select ?property ?domain ?range where {
+?property ?y ?domain
+. FILTER(regex(str(?y),'domain'))
+. FILTER(!regex(str(?property),'arcos.rack')) # property in overlay
+. FILTER(regex(str(?domain),'arcos.rack')) # domain in core
+. ?property ?y2 ?range
+. FILTER(regex(str(?y2),'range'))
+. FILTER(regex(str(?range),'arcos.rack'))
+} order by ?property".
+
+//Ask:"select * where {
+//?x <rdfs:subClassOf> <ENTITY>
+//. FILTER NOT EXISTS {?x <rdfs:subClassOf> ?y . ?y <rdfs:subClassOf> <ENTITY>}
+//} order by ?x".
+
+

--- a/sadl-examples/OverlayGraphs.sadl
+++ b/sadl-examples/OverlayGraphs.sadl
@@ -1,0 +1,226 @@
+uri "http://arcos.rack/OverlayGraphs" alias graph.
+
+// Set SADL "Translate multiple-class domain or range as union" property to be false 
+// for the overlay ontology being graphed.
+import "http://arcos.descert/SRI-SS". // the overlay ontology to check
+
+// Still need to check that we are not missing anything.
+// This does graphing for SRI ontology; to do graphing for other ontologies
+// need to replace instances of DesCert and descert appropriately.
+// Have not really checked it out though.
+
+// CAN I simplify by adding a property say linearize of range string where ever we have a union.
+// I would have a rule that sets up the value for this property.
+// Then I can more easily do graphing and querying etc.
+// This is going to be complicated as for each property we would need to define linearized domain and range
+// and then how exactly will the rule iterate and set up the string????
+
+// How to read the generated visualization (added this much later - so double check; 
+// 	also note lot of issues that were present have been addressed so currently no "aqua" color property generated
+//		nodes with black font are from the overlay ontology being checked
+//		red color property: are not defined in this overlay and the overlay is "refining" that property for a subclass (allowed)
+//		fuschia color property: check if overlay domain class is a subclass of core domain class for that property
+//		aqua color property: check if overlay range class is a subclass of appropriate core class range for that property; aqua color
+// Note that there can be disconnected compomonents when say the range is a union of 2 or more things
+// (we only show upto 4 things in the union).
+
+///////////////////////////////////GRAPHING start////////////////////////////////////////
+// Can choose to not show properties with range string, int etc. by uncommenting the line which has "XMLSchema".
+// If the domain or range is union of more than 4 classes then we show up to 4 of these only.
+Graph: "select ?N1 ?link ?N2 ?N1_fontcolor ?link_fontcolor ?N2_fontcolor ?link_style
+where 
+{
+{
+  ?unstrippedprop <rdfs:domain> ?unstrippeddomain . ?unstrippedprop <rdfs:range> ?unstrippedrange
+. FILTER(!regex(str(?unstrippedprop),'sadlimplicitmodel'))
+. FILTER(!regex(str(?unstrippedprop),'sadllistmodel'))
+. FILTER(regex(str(?unstrippeddomain), 'http'))
+. FILTER(regex(str(?unstrippeddomain),'arcos.descert') || regex(str(?unstrippedprop),'arcos.descert') || regex(str(?unstrippedrange),'arcos.descert'))
+. LET(?domain := replace(str(?unstrippeddomain),'http.*#','')) 
+. LET(?prop := replace(str(?unstrippedprop),'http.*#',''))
+. LET(?range := replace(str(?unstrippedrange),'http.*#',''))    
+}
+
+union # union of exactly 2 in range  
+{?unstrippeddomain <rdfs:subClassOf> ?z  
+. ?z ?y2 ?z2 . FILTER(regex(str(?z2),'Restriction')) 
+. ?z ?y3 ?unstrippedprop . FILTER(regex(str(?y3),'onProperty')) 
+. ?z ?y4 ?z4 . FILTER(regex(str(?y4),'allValuesFrom'))
+. ?z4 ?y5 ?z5 . FILTER(regex(str(?y5), 'unionOf'))
+. ?z5 ?y6 ?z6 . FILTER(regex(str(?y6),'first'))
+. ?z5 ?y7 ?z7 . FILTER(regex(str(?y7),'rest'))
+. ?z7 ?y8 ?z8 . FILTER(regex(str(?y8),'first')) 
+. ?z7 ?y9 ?z9 . FILTER(regex(str(?y9),'rest')) . FILTER(regex(str(?z9),'#nil')) #nothing more
+
+. LET(?strippedz6 := replace(str(?z6),'http.*#',''))
+. LET(?strippedz8 := replace(str(?z8),'http.*#',''))
+. LET(?unstrippedrange := concat(str(?z6),concat(' or ',str(?z8))))
+. LET(?range := concat(str(?strippedz6),concat(' or ',str(?strippedz8))))
+. LET(?domain := replace(str(?unstrippeddomain),'http.*#','')) 
+. LET(?prop := replace(str(?unstrippedprop),'http.*#','')) 
+}
+
+union # union of exactly 3 in range 
+{?unstrippeddomain <rdfs:subClassOf> ?z  
+. ?z ?y2 ?z2 . FILTER(regex(str(?z2),'Restriction')) 
+. ?z ?y3 ?unstrippedprop . FILTER(regex(str(?y3),'onProperty')) 
+. ?z ?y4 ?z4 . FILTER(regex(str(?y4),'allValuesFrom'))
+. ?z4 ?y5 ?z5 . FILTER(regex(str(?y5), 'unionOf'))
+. ?z5 ?y6 ?z6 . FILTER(regex(str(?y6),'first'))
+. ?z5 ?y7 ?z7 . FILTER(regex(str(?y7),'rest'))
+. ?z7 ?y8 ?z8 . FILTER(regex(str(?y8),'first')) 
+. ?z7 ?y9 ?z9 . FILTER(regex(str(?y9),'rest')) 
+. ?z9 ?y10 ?z10 . FILTER(regex(str(?y10),'first'))
+. ?z9 ?y11 ?z11 . FILTER(regex(str(?y11),'rest')) . FILTER(regex(str(?z11),'#nil')) #nothing more
+
+. LET(?strippedz6 := replace(str(?z6),'http.*#',''))
+. LET(?strippedz8 := replace(str(?z8),'http.*#',''))
+. LET(?strippedz10 := replace(str(?z10),'http.*#',''))
+. LET(?t1 := concat(str(?z6),concat(' or ',str(?z8))))
+. LET(?unstrippedrange := concat(str(?t1),concat(' or ',str(?z10))))
+. LET(?u1 := concat(str(?strippedz6),concat(' or ',str(?strippedz8))))
+. LET(?range := concat(str(?u1),concat(' or ',str(?strippedz10))))
+. LET(?domain := replace(str(?unstrippeddomain),'http.*#','')) 
+. LET(?prop := replace(str(?unstrippedprop),'http.*#','')) 
+}
+
+union # union of ATLEAST 4 in range 
+{?unstrippeddomain <rdfs:subClassOf> ?z  
+. ?z ?y2 ?z2 . FILTER(regex(str(?z2),'Restriction')) 
+. ?z ?y3 ?unstrippedprop . FILTER(regex(str(?y3),'onProperty')) 
+. ?z ?y4 ?z4 . FILTER(regex(str(?y4),'allValuesFrom'))
+. ?z4 ?y5 ?z5 . FILTER(regex(str(?y5), 'unionOf'))
+. ?z5 ?y6 ?z6 . FILTER(regex(str(?y6),'first'))
+. ?z5  ?y7  ?z7  . FILTER(regex(str(?y7), 'rest'))
+. ?z7  ?y8  ?z8  . FILTER(regex(str(?y8), 'first')) 
+. ?z7  ?y9  ?z9  . FILTER(regex(str(?y9), 'rest')) 
+. ?z9  ?y10 ?z10 . FILTER(regex(str(?y10),'first'))
+. ?z9  ?y11 ?z11 . FILTER(regex(str(?y11),'rest')) 
+. ?z11 ?y12 ?z12 . FILTER(regex(str(?y12),'first'))
+. ?z11 ?y13 ?z13 . FILTER(regex(str(?y13),'rest')) #. FILTER(regex(str(?z13),'#nil')) #nothing more
+
+. LET(?strippedz6  := replace(str(?z6), 'http.*#',''))
+. LET(?strippedz8  := replace(str(?z8), 'http.*#',''))
+. LET(?strippedz10 := replace(str(?z10),'http.*#',''))
+. LET(?strippedz12 := replace(str(?z12),'http.*#',''))
+. LET(?t1 := concat(str(?z6),concat(' or ',str(?z8))))
+. LET(?t2 := concat(str(?t1),concat(' or ',str(?z10))))
+. LET(?unstrippedrange := concat(str(?t2),concat(' or ',str(?z12))))
+. LET(?u1 := concat(str(?strippedz6),concat(' or ',str(?strippedz8))))
+. LET(?u2 := concat(str(?u1),concat(' or ',str(?strippedz10))))
+. LET(?range := concat(str(?u2),concat(' or ',str(?strippedz12))))
+. LET(?domain := replace(str(?unstrippeddomain),'http.*#','')) 
+. LET(?prop := replace(str(?unstrippedprop),'http.*#','')) 
+}
+
+union # union of exactly 2 in domain  
+{?unstrippedprop <rdfs:domain> ?z 
+. ?unstrippedprop <rdfs:range> ?unstrippedrange
+. ?z ?y2 ?z2 . FILTER(regex(str(?y2),'unionOf'))
+. ?z2 ?y3 ?z3 . FILTER(regex(str(?y3),'first'))
+. ?z2 ?y4 ?z4 . FILTER(regex(str(?y4),'rest'))
+. ?z4 ?y5 ?z5 . FILTER(regex(str(?y5),'first')) 
+. ?z4 ?y6 ?z6 . FILTER(regex(str(?y4),'rest')) . FILTER(regex(str(?z6),'#nil')) #nothing more
+
+. LET(?strippedz3 := replace(str(?z3),'http.*#',''))
+. LET(?strippedz5 := replace(str(?z5),'http.*#','')) 
+. LET(?unstrippeddomain := concat(str(?z3),concat(' or ',str(?z5))))
+. LET(?domain := concat(str(?strippedz3),concat(' or ',str(?strippedz5))))
+. LET(?range := replace(str(?unstrippedrange),'http.*#','')) 
+. LET(?prop := replace(str(?unstrippedprop),'http.*#',''))  
+}
+
+union # union of exactly 3 in domain 
+{?unstrippedprop <rdfs:domain> ?z 
+. ?unstrippedprop <rdfs:range> ?unstrippedrange
+. ?z ?y2 ?z2 . FILTER(regex(str(?y2),'unionOf'))
+. ?z2 ?y3 ?z3 . FILTER(regex(str(?y3),'first'))
+. ?z2 ?y4 ?z4 . FILTER(regex(str(?y4),'rest'))
+. ?z4 ?y5 ?z5 . FILTER(regex(str(?y5),'first')) 
+. ?z4 ?y6 ?z6 . FILTER(regex(str(?y6),'rest')) 
+. ?z6 ?y7 ?z7 . FILTER(regex(str(?y7),'first')) 
+. ?z6 ?y8 ?z8 . FILTER(regex(str(?y8),'rest')) . FILTER(regex(str(?z8),'#nil')) #nothing more
+
+. LET(?strippedz3 := replace(str(?z3),'http.*#',''))
+. LET(?strippedz5 := replace(str(?z5),'http.*#','')) 
+. LET(?strippedz7 := replace(str(?z7),'http.*#',''))
+. LET(?t1 := concat(str(?z3),concat(' or ',str(?z5))))
+. LET(?unstrippeddomain := concat(str(?t1), concat(' or ',str(?z7))))
+. LET(?u1 := concat(str(?strippedz3),concat(' or ',str(?strippedz5))))
+. LET(?domain := concat(str(?u1), concat(' or ',str(?strippedz7))))
+. LET(?range := replace(str(?unstrippedrange),'http.*#','')) 
+. LET(?prop := replace(str(?unstrippedprop),'http.*#',''))  
+}
+
+union # union of ATLEAST 4 in domain 
+{?unstrippedprop <rdfs:domain> ?z 
+. ?unstrippedprop <rdfs:range> ?unstrippedrange
+. ?z ?y2 ?z2 . FILTER(regex(str(?y2),'unionOf'))
+. ?z2 ?y3 ?z3 . FILTER(regex(str(?y3),'first'))
+. ?z2 ?y4 ?z4 . FILTER(regex(str(?y4),'rest'))
+. ?z4 ?y5 ?z5 . FILTER(regex(str(?y5),'first')) 
+. ?z4 ?y6 ?z6 . FILTER(regex(str(?y6),'rest')) 
+. ?z6 ?y7 ?z7 . FILTER(regex(str(?y7),'first')) 
+. ?z6 ?y8 ?z8 . FILTER(regex(str(?y8),'rest'))
+. ?z8 ?y9 ?z9 . FILTER(regex(str(?y9),'first')) 
+. ?z8 ?y10 ?z10 . FILTER(regex(str(?y10),'rest'))  #. FILTER(regex(str(?z10),'#nil')) #nothing more
+
+. LET(?strippedz3 := replace(str(?z3),'http.*#',''))
+. LET(?strippedz5 := replace(str(?z5),'http.*#','')) 
+. LET(?strippedz7 := replace(str(?z7),'http.*#',''))
+. LET(?strippedz9 := replace(str(?z9),'http.*#',''))
+. LET(?t1 := concat(str(?z3),concat(' or ',str(?z5))))
+. LET(?t2 := concat(str(?t1),concat(' or ',str(?z7))))
+. LET(?unstrippeddomain := concat(str(?t2), concat(' or ',str(?z9))))
+. LET(?u1 := concat(str(?strippedz3),concat(' or ',str(?strippedz5))))
+. LET(?u2 := concat(str(?u1),concat(' or ',str(?strippedz7))))
+. LET(?domain := concat(str(?u2), concat(' or ',str(?strippedz9))))
+. LET(?range := replace(str(?unstrippedrange),'http.*#','')) 
+. LET(?prop := replace(str(?unstrippedprop),'http.*#',''))  
+}
+
+union # get class - subclass relationships; note we want to use subClass and layout to have core class at top so domain and range opposite of what we might first think of
+{ ?unstrippedrange <rdfs:subClassOf> ?unstrippeddomain
+. FILTER(!regex(str(?unstrippeddomain),'blank node'))
+. FILTER NOT EXISTS {?unstrippedrange <rdfs:subClassOf> ?a1 . ?a1 <rdfs:subClassOf> ?unstrippeddomain }
+. FILTER(regex(str(?unstrippedrange),'arcos.descert') || regex(str(?unstrippeddomain),'arcos.descert')) 
+
+. LET(?range := replace(str(?unstrippedrange),'http.*#',''))
+. LET(?domain := replace(str(?unstrippeddomain),'http.*#',''))
+. LET(?prop := 'subClass') . LET(?link_fontcolor := 'blue') . LET(?link_style := 'dashed')
+}  
+
+# this is where core ontology is being changed, want a color that pops but using fuschia and aqua at the moment
+# twp cases: 
+# [overlay,core,core] : check if overlay domain class is a subclass of core domain class for that property; fuschia color
+# [core,core,overlay] : check if overlay range class is a subclass of appropriate core class range for that property; aqua color
+# [core,overlay,core] : this is ok as the property is an overlay property 
+. OPTIONAL{FILTER(regex(str(?unstrippedprop),'arcos.rack'))
+           . FILTER(regex(str(?unstrippeddomain),'SRI')) #????? was DesCert
+           . FILTER(regex(str(?unstrippedrange),'arcos.rack')) 
+           . LET(?link_fontcolor := 'fuchsia') 
+           }
+. OPTIONAL{FILTER(regex(str(?unstrippedprop),'arcos.rack'))
+           . FILTER(regex(str(?unstrippeddomain),'arcos.rack'))
+           . FILTER(regex(str(?unstrippedrange),'SRI')) #????? was DesCert
+           . LET(?link_fontcolor := 'aqua') 
+           }
+#. OPTIONAL{FILTER(regex(str(?unstrippedprop),'SRI')) # overlay property #????? was DesCert
+#           . FILTER(regex(str(?unstrippeddomain),'arcos.rack')) # core 
+#           . FILTER(regex(str(?unstrippedrange),'arcos.rack')) # core
+#           . LET(?link_fontcolor := 'fuchsia') 
+#           }
+
+# can turn on or off showing when range is string / int etc. by commenting / uncommenting next line 
+#. FILTER(!regex(str(?unstrippedrange),'http://www.w3.org/2001/XMLSchema'))
+ 
+. OPTIONAL{FILTER(!regex(str(?unstrippedprop),'SRI')) . LET(?link_fontcolor := 'red')} #????? was DesCert
+. OPTIONAL{FILTER(!regex(str(?unstrippeddomain),'SRI')) . LET(?N1_fontcolor := 'red')} #????? was DesCert
+. OPTIONAL{FILTER(!regex(str(?unstrippedrange),'SRI')) . LET(?N2_fontcolor := 'red')} #????? was DesCert
+. LET(?link := ?prop)
+. LET(?N2 := ?range)
+. LET(?N1 := ?domain)
+}".
+
+////////////////////////////GRAPHING over////////////////////////////////
+

--- a/sadl-examples/RdfsSubset.sadl
+++ b/sadl-examples/RdfsSubset.sadl
@@ -1,0 +1,15 @@
+ uri "http://www.w3.org/2000/01/rdf-schema" alias rdfs.
+
+^type is a property.
+
+ rdfs:domain is a property.
+ rdfs:range is a property.
+ rdfs:subClassOf is a property.
+ rdfs:subPropertyOf is a property.
+ rdfs:subTypeOf is a property.
+ rdfs:onProperty is a property.
+ rdfs:allValuesFrom is a property.
+ rdfs:onClass is a property.
+ 
+ rdfs:equivalentClass is a property.
+ 


### PR DESCRIPTION
This works in the older eclipse + SADL setup. Out of the box, the transitive rule is commented out and so the visualization does not show all properties. Note that sadl-examples project has to reference all the other relevant projects.

If in the same eclipse + SADL environment, a new project is made with all the SADL files so that project reference is not used then the transitive rule can be uncommented and the visualization shows all the properties.
