### PR TITLE
Change CONFIDENCE_ASSESSMENT from a THING to an ENTITY.

### DIFF
--- a/RACK-Ontology/ontology/CONFIDENCE.sadl
+++ b/RACK-Ontology/ontology/CONFIDENCE.sadl
@@ -22,7 +22,7 @@ uri "http://arcos.rack/CONFIDENCE" alias CONFIDENCE.
 import "http://arcos.rack/PROV-S".
 
 
-CONFIDENCE_ASSESSMENT (note "Superclass for confidence assessments over some other data in the ontology.") is a type of THING.
+CONFIDENCE_ASSESSMENT (note "Superclass for confidence assessments over some other data in the ontology.") is a type of ENTITY.
 
     assesses (note "ENTITY(s) whose confidence is assessed") describes CONFIDENCE_ASSESSMENT with values of type ENTITY.
     assesses describes CONFIDENCE_ASSESSMENT with at most 1 value.


### PR DESCRIPTION
A confidence assessment is something which exists, and is therefore reasonable to be an entity.

In addition, it has a wasGeneratedBy property that is not defined for THING but which is defined for ENTITY.  This issue was detected by ASSIST-DV with the enhancements in PR#782 with the following report:

> ERROR: Property http://arcos.rack/PROV-S#wasGeneratedBy was referenced on class http://arcos.rack/CONFIDENCE#CONFIDENCE_ASSESSMENT, but that property is only defined for the unrelated class http://arcos.rack/PROV-S#ENTITY