### PR TITLE
Upgrade Fuseki to 4.7.0 and RACK graph to TDB2

### DIFF
--- a/.github/workflows/assemble-files.yml
+++ b/.github/workflows/assemble-files.yml
@@ -51,12 +51,12 @@ jobs:
     - name: Download Fuseki
       shell: bash
       run: |
-        curl -LSfs https://archive.apache.org/dist/jena/binaries/apache-jena-fuseki-4.6.1.tar.gz -o RACK/rack-box/files/fuseki.tar.gz
+        curl -LSfs https://archive.apache.org/dist/jena/binaries/apache-jena-fuseki-4.7.0.tar.gz -o RACK/rack-box/files/fuseki.tar.gz
 
     - name: Download Apache Jena
       shell: bash
       run: |
-        curl -LSfs https://archive.apache.org/dist/jena/binaries/apache-jena-4.6.1.tar.gz -o RACK/rack-box/files/jena.tar.gz
+        curl -LSfs https://archive.apache.org/dist/jena/binaries/apache-jena-4.7.0.tar.gz -o RACK/rack-box/files/jena.tar.gz
 
     - name: Download SemTK
       shell: bash

--- a/cli/optimize.sh
+++ b/cli/optimize.sh
@@ -18,8 +18,8 @@ fi
 
 RACK_DB="/etc/fuseki/databases/RACK"
 RACK_FUSEKI_CONFIG="/etc/fuseki/configuration/RACK.ttl"
-# Currently using TDB1, this should become tdb2.tdbstats for TDB2
-TDBSTATS="/opt/jena/bin/tdbstats"
+# Currently using TDB2, revert to tdbstats for TDB1
+TDBSTATS="/opt/jena/bin/tdb2.tdbstats"
 TMP_STATS="/tmp/stats.opt"
 # Usually it goes into a `Data-0001` subdirectory, but it seems that with our
 # RACK.ttl configuration we just don't have the extra directory.

--- a/rack-box/scripts/install.sh
+++ b/rack-box/scripts/install.sh
@@ -152,7 +152,7 @@ sed -e 's/"30000"/"300000"/' -i /etc/fuseki/config.ttl
 
 # Create the RACK dataset
 
-curl -Ss -d 'dbName=RACK' -d 'dbType=tdb' 'http://localhost:3030/$/datasets'
+curl -Ss -d 'dbName=RACK' -d 'dbType=tdb2' 'http://localhost:3030/$/datasets'
 
 # Configure the SemTK services and webapps
 


### PR DESCRIPTION
Closes #951

assemble-files.yml: Bump Fuseki and Jena from 4.6.1 to 4.7.0.

optimize.sh: Switch from tdbstats to tdb2.tdbstats.

install.sh: Switch from tdb to tdb2.