### PR TITLE
get the pid before stopping in optimize script

### DIFF
--- a/cli/optimize.sh
+++ b/cli/optimize.sh
@@ -3,17 +3,20 @@
 
 set -eu
 
-echo "Stopping Fuseki"
-FUSEKI_PID=$(systemctl show --property MainPID fuseki)
-FUSEKI_PID=${FUSEKI_PID#"MainPID="}
-if [ -n "${FUSEKI_PID}" ]; then
+if systemctl is-active --quiet fuseki; then
+
+    echo "Stopping Fuseki"
+
+    # remember the PID in case stopping fuseki doesn't stop it    
+    FUSEKI_PID=$(systemctl show --property MainPID fuseki)
+    FUSEKI_PID=${FUSEKI_PID#"MainPID="}
+
     systemctl stop fuseki
-fi
-# systemctl stop doesn't always work, so kill -9 for now to be sure
-FUSEKI_PID=$(systemctl show --property MainPID fuseki)
-FUSEKI_PID=${FUSEKI_PID#"MainPID="}
-if [ -n "${FUSEKI_PID}" ]; then
-    kill -9 "${FUSEKI_PID}" > /dev/null 2>&1
+
+    # systemctl stop doesn't always work, so kill -9 for now to be sure
+    if [ -n "${FUSEKI_PID}" ]; then
+        kill -9 "${FUSEKI_PID}" &> /dev/null || true
+    fi
 fi
 
 RACK_DB="/etc/fuseki/databases/RACK"


### PR DESCRIPTION
Gets the PID before stopping fuseki so that it can tell if the stopping succeeded.

When I test this it successfully stops the service, however I'm getting an error from tdbstats that that doesn't seem related to my change.

```
Stopping Fuseki
Running tdbstats
org.apache.jena.sparql.ARQException: No such type: <http://jena.apache.org/2016/tdb#DatasetTDB2>
	at org.apache.jena.sparql.core.assembler.AssemblerUtils.build(AssemblerUtils.java:140)
	at org.apache.jena.sparql.core.assembler.AssemblerUtils.build(AssemblerUtils.java:132)
	at tdb2.cmdline.ModTDBDataset.createDataset(ModTDBDataset.java:81)
	at arq.cmdline.ModDataset.getDataset(ModDataset.java:35)
	at tdb2.cmdline.CmdTDB.getDataset(CmdTDB.java:77)
	at tdb2.cmdline.CmdTDB.getDatasetGraph(CmdTDB.java:69)
	at tdb2.tdbstats.exec(tdbstats.java:94)
	at org.apache.jena.cmd.CmdMain.mainMethod(CmdMain.java:87)
	at org.apache.jena.cmd.CmdMain.mainRun(CmdMain.java:56)
	at org.apache.jena.cmd.CmdMain.mainRun(CmdMain.java:43)
	at tdb2.tdbstats.main(tdbstats.java:43)
Now printing the contents of stats.opt:
cat: /etc/fuseki/databases/RACK/stats.opt: No such file or directory
```