### PR TITLE
RACK-928: Slow Startup RiB Container on Apple M1

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -26,9 +26,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - arch: aarch64
+          - arch: armv7
             distro: ubuntu22.04
-            ubuntu-arch: linux/amd64
+            ubuntu-arch: linux/arm64/v8
 
     steps:
     - name: Check out RACK source

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -29,9 +29,6 @@ jobs:
           - arch: aarch64
             distro: ubuntu22.04
             ubuntu-arch: linux/amd64
-          - arch: armv7
-            distro: ubuntu22.04
-            ubuntu-arch: linux/arm64/v8
 
     steps:
     - name: Check out RACK source

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -28,8 +28,10 @@ jobs:
         include:
           - arch: aarch64
             distro: ubuntu22.04
+            ubuntu-arch: linux/amd64
           - arch: armv7
             distro: ubuntu22.04
+            ubuntu-arch: linux/arm64/v8
 
     steps:
     - name: Check out RACK source
@@ -51,7 +53,7 @@ jobs:
           distro: ${{ matrix.distro }}
           run: |
             cd RACK/rack-box
-            packer build -var version=${{ inputs.version }} rack-box-docker.json
+            packer build -var version=${{ inputs.version }} -var arch=${{ matrix.ubuntu-arch }} rack-box-docker.json
 
     - name: Login to Docker Hub
       if: inputs.push == true

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -21,6 +21,15 @@ jobs:
 
   build-docker-image:
     runs-on: ubuntu-22.04
+    name: Build on ${{ matrix.distro }} ${{ matrix.arch }}
+
+    strategy:
+      matrix:
+        include:
+          - arch: aarch64
+            distro: ubuntu22.04
+          - arch: armv7
+            distro: ubuntu22.04
 
     steps:
     - name: Check out RACK source
@@ -36,9 +45,13 @@ jobs:
         path: RACK/rack-box/files
 
     - name: Build rack-box docker image
-      run: |
-        cd RACK/rack-box
-        packer build -var version=${{ inputs.version }} rack-box-docker.json
+      uses: uraimo/run-on-arch-action@v2
+      with:
+          arch: ${{ matrix.arch }}
+          distro: ${{ matrix.distro }}
+          run: |
+            cd RACK/rack-box
+            packer build -var version=${{ inputs.version }} rack-box-docker.json
 
     - name: Login to Docker Hub
       if: inputs.push == true

--- a/rack-box/rack-box-docker.json
+++ b/rack-box/rack-box-docker.json
@@ -19,7 +19,7 @@
       "commit": true,
       "image": "ubuntu:22.04",
       "platform": "{{user `arch`}}",
-      "pull": false
+      "pull": true
     }
   ],
 

--- a/rack-box/rack-box-docker.json
+++ b/rack-box/rack-box-docker.json
@@ -10,14 +10,26 @@
 
   "builders": [
     {
+      "name": "arch_amd64",
       "type": "docker",
-
       "changes": [
         "ENTRYPOINT [ \"/usr/bin/python3\", \"/usr/bin/systemctl\" ]"
       ],
       "commit": true,
       "image": "ubuntu:22.04",
+      "platform": "linux/amd64",
       "pull": false
+    },
+    {
+      "name": "arch_arm64v8",
+      "type": "docker",
+      "changes": [
+        "ENTRYPOINT [ \"/usr/bin/python3\", \"/usr/bin/systemctl\" ]"
+      ],
+      "commit": true,
+      "image": "ubuntu:22.04",
+      "platform": "linux/arm64/v8",
+      "pull": true
     }
   ],
 

--- a/rack-box/rack-box-docker.json
+++ b/rack-box/rack-box-docker.json
@@ -19,7 +19,7 @@
       "commit": true,
       "image": "ubuntu:22.04",
       "platform": "{{user `arch`}}",
-      "pull": true
+      "pull": false
     }
   ],
 

--- a/rack-box/rack-box-docker.json
+++ b/rack-box/rack-box-docker.json
@@ -5,6 +5,7 @@
     "no_proxy": "{{env `no_proxy`}}",
     "repository": "gehighassurance/rack-box",
     "tags": "{{user `version`}}",
+    "arch": "{{user `arch`}}",
     "version": "dev"
   },
 
@@ -17,6 +18,7 @@
       ],
       "commit": true,
       "image": "ubuntu:22.04",
+      "platform": "{{user `arch`}}",
       "pull": false
     }
   ],

--- a/rack-box/rack-box-docker.json
+++ b/rack-box/rack-box-docker.json
@@ -10,26 +10,14 @@
 
   "builders": [
     {
-      "name": "arch_amd64",
       "type": "docker",
+
       "changes": [
         "ENTRYPOINT [ \"/usr/bin/python3\", \"/usr/bin/systemctl\" ]"
       ],
       "commit": true,
       "image": "ubuntu:22.04",
-      "platform": "linux/amd64",
       "pull": false
-    },
-    {
-      "name": "arch_arm64v8",
-      "type": "docker",
-      "changes": [
-        "ENTRYPOINT [ \"/usr/bin/python3\", \"/usr/bin/systemctl\" ]"
-      ],
-      "commit": true,
-      "image": "ubuntu:22.04",
-      "platform": "linux/arm64/v8",
-      "pull": true
     }
   ],
 


### PR DESCRIPTION
RACK-928: Slow Startup RiB Container on Apple M1

Enhancing github workflow to include AARCH64 (Apple Silicon) platform docker image. The linux/amd64 os/arch images were not performant on M1 machines.

Solves: RACK-928