### PR TITLE
Adam/ada identifier fixes

### DIFF
--- a/ada/node_naming.py
+++ b/ada/node_naming.py
@@ -76,11 +76,7 @@ def get_node_identifier(node: GraphNode) -> NodeIdentifier:
     """
     Computes the identifier to use in the database.
     """
-    xref = node.p_gnat_xref()
-    if not xref:
-        return NodeURI(f'SWCOM_{node.p_relative_name.p_canonical_text}')
-        # raise Exception(f"The reference to node {node} could not be resolved.")
-    return NodeURI(f'SWCOM_{xref.p_basic_decl.p_canonical_fully_qualified_name}')
+    return NodeURI(f'SWCOM_{node.doc_name.lower()}')
 
 def get_node_uri(node: GraphNode) -> NodeURI:
     """Computes the URI to use for a node."""

--- a/ada/run_analysis.py
+++ b/ada/run_analysis.py
@@ -281,10 +281,12 @@ def analyze_structure(unit: lal.AnalysisUnit) -> None:
     analysis_output = visitor.packages
 
     for package, components in analysis_output.items():
+        filename = package.p_relative_name.unit.filename.rsplit('/', 1)[-1]
         Evidence.Add.SOFTWARE.SWCOMPONENT(
             identifier=get_node_identifier(package),
             title=escape(package.doc_name),
             componentType_identifier=ontology.MODULE,
+            definedIn_identifier=filename,
         )
         for component in components:
             Evidence.Add.SOFTWARE.SWCOMPONENT(


### PR DESCRIPTION
When running the ada ingestion with run_analysis.py, there were errors due to identifier collisions where two things got assigned to the same identifier. This happened in `get_node_identifier`, when `xref_ = node.p_gnat_xref()` returned None for some identifiers, and the fallback value of `node.p_relative_name.p_canonical_text` was not unique. Returning `node.doc_name` produces the correct results and eliminates cardinality errors.

In addition, I added the definedIn_Identifier for componentType_Identifier Module.