### PR TITLE
Assist unions

### DIFF
--- a/assist/bin/common_opts.pl
+++ b/assist/bin/common_opts.pl
@@ -144,6 +144,9 @@ load_data_from_dir(Opts) :-
      load_data(NS, D)
     ).
 
+% Setting the verbose prolog_flag affects print_message: if set to "silent" then
+% "informational" and "banner" messages are suppressed.  Valid values are
+% "normal" and "silent".
 set_verbosity([]).
 set_verbosity([verbose(true)|_]) :- set_prolog_flag(verbose, normal).
 set_verbosity([verbose(false)|_]) :- set_prolog_flag(verbose, silent).

--- a/assist/bin/rack/check.pl
+++ b/assist/bin/rack/check.pl
@@ -38,6 +38,7 @@ check_missing_notes(Class) :-
     has_interesting_prefix(Class),
     \+ rdf(Class, rdfs:comment, _),
     \+ rdf_is_bnode(Class),
+    print_message(informational, unary_op(check_missing_notes, Class)),
     print_message(warning, class_missing_note(Class)).
 
 check_not_prov_s(Class) :-
@@ -46,6 +47,7 @@ check_not_prov_s(Class) :-
     rack_ref('PROV-S#NODE', NodeBase),
     \+ rdf_reachable(Class, rdfs:subClassOf, NodeBase),
     \+ rdf_is_bnode(Class),
+    print_message(informational, unary_op(check_not_prov_s, Class)),
     print_message(warning, not_prov_s_node_class(Class)).
 
 check_instance_types(I) :-
@@ -56,6 +58,7 @@ check_instance_types(I) :-
     findall(IT, rdf(I, rdf:type, IT), ITs),
     length(ITs, N),
     N > 1,
+    print_message(informational, unary_op(check_instance_types, I)),
     print_message(error, multiple_types_for_instance(I, ITs)).
 
 check_instance_property_violations(Property) :-
@@ -83,6 +86,7 @@ check_cardinality_exact(Property, I, T) :-
     length(VS, VSLen),
     VSLen \= N,
     rack_instance_ident(I, IName),
+    print_message(informational, trinary_op(check_cardinality_exact, Property, I, T)),
     print_message(error, cardinality_violation(T, I, IName, Property, N, VSLen)).
 
 check_cardinality_min(Property, I, T) :-
@@ -93,6 +97,7 @@ check_cardinality_min(Property, I, T) :-
     length(VS, VSLen),
     VSLen < N,
     rack_instance_ident(I, IName),
+    print_message(informational, trinary_op(check_cardinality_min, Property, I, T)),
     print_message(error, min_cardinality_violation(T, I, IName, Property, N, VSLen)).
 
 check_cardinality_max(Property, I, T) :-
@@ -103,6 +108,7 @@ check_cardinality_max(Property, I, T) :-
     length(VS, VSLen),
     VSLen > N,
     rack_instance_ident(I, IName),
+    print_message(informational, trinary_op(check_cardinality_max, Property, I, T)),
     print_message(error, max_cardinality_violation(T, I, IName, Property, N, VSLen)).
 
 check_maybe_prop(Property, I, T) :-
@@ -114,6 +120,7 @@ check_maybe_prop(Property, I, T) :-
      length(VS, 1), !, fail; % fail: do not report during check
      length(VS, VSLen),
      rack_instance_ident(I, IName),
+     print_message(informational, trinary_op(check_maybe_prop, Property, I, T)),
      print_message(error, maybe_restriction(T, I, IName, Property, VSLen))).
 
 check_target_type(Property, I, T) :-
@@ -126,6 +133,7 @@ check_target_type(Property, I, T) :-
     rack_instance_ident(I, IName),
     rdf(Val, rdf:type, ValTy),
     property_range_type(T, Property, ModelTy),
+    print_message(informational, trinary_op(check_target_type, Property, I, T)),
     print_message(error, property_value_wrong_type(T, I, IName, Property, ValTy, Val, ModelTy)).
 
 check_target_type_restrictions(Property, I, T) :-
@@ -160,10 +168,12 @@ check_values_from(Property, I, T) :-
       rdf_list(ClsLst, CList),
       ( member(CL, CList),
         rdf_reachable(DefTy, rdfs:subClassOf, CL), !  % matches, stop processing
-      ; print_message(error,
+      ; print_message(informational, trinary_op(check_values_from, Property, I, T)),
+        print_message(error,
                       property_value_wrong_type_in(T, I, IName, Property, DefTy, Val, CList))
       )
     ; \+ rdf_reachable(DefTy, rdfs:subClassOf, Cls),
+      print_message(informational, trinary_op(check_values_from, Property, I, T)),
       print_message(error, property_value_wrong_type(T, I, IName, Property, DefTy, Val, Cls))
     ).
 
@@ -179,6 +189,7 @@ check_invalid_value(Property, I, T) :-
     !,
     rdf_list(Enums,L),
     rack_instance_ident(I, IName),
+    print_message(informational, trinary_op(check_invalid_value, Property, I, T)),
     print_message(error, invalid_value_in_enum(T, I, IName, Property, V, L)).
 
 check_invalid_value(Property, I, T) :-
@@ -199,6 +210,7 @@ check_invalid_value(Property, I, T) :-
     actual_val(V, RT, Val),
     (rdf_compare(<,Val,MinVal) ; rdf_compare(>,Val,MaxVal)),
     rack_instance_ident(I, IName),
+    print_message(informational, trinary_op(check_invalid_value, Property, I, T)),
     print_message(error, value_outside_range(T, I, IName, Property, RT, Val, MinVal, MaxVal)).
 
 % True for any SrcClass that has no Prop relationship to any target
@@ -209,6 +221,7 @@ check_has_no_rel(Context, SrcClass, Prop, SrcInst) :-
     rack_data_instance(SrcClass, SrcInst),
     none_of(SrcInst, rack_instance_relationship(SrcClass, Prop)),
     rack_instance_ident(SrcInst, SrcName),
+    print_message(informational, quarnary_op(check_has_no_rel, Context, SrcClass, Prop, SrcInst)),
     print_message(warning, missing_any_tgt(Context, SrcClass, SrcInst, SrcName, Prop)).
 
 % True for any SrcClass that has no Prop relationship to an instance
@@ -219,6 +232,7 @@ check_has_no_rel(Context, SrcClass, Prop, TgtClass, SrcInst) :-
     rack_data_instance(SrcClass, SrcInst),
     none_of(SrcInst, rack_instance_relationship(SrcClass, Prop, TgtClass)),
     rack_instance_ident(SrcInst, SrcName),
+    print_message(informational, quintary_op(check_has_no_rel, Context, SrcClass, Prop, TgtClass, SrcInst)),
     print_message(warning, missing_tgt(Context, SrcClass, SrcInst, SrcName, Prop, TgtClass)),
     % -- if the above fails, it's probably useful to see if there are
     % *any* targets of Src--[Rel]-->
@@ -232,6 +246,7 @@ is_valid_property(_, SrcClass, Property) :-
     rdf(Property, rdfs:domain, PropClass),
     rdf_reachable(SrcClass, rdfs:subClassOf, PropClass), !.
 is_valid_property(Context, SrcClass, Property) :-
+    print_message(informational, trinary_op(is_valid_property, '_', SrcClass, Property)),
     print_message(error, invalid_property_in_check(Context, SrcClass, Property)),
     fail.
 
@@ -255,8 +270,10 @@ check_invalid_domain_class(SrcClass, Property, DefinedClass) :-
     findall(OtherParent, (property(OtherParent, Property, Usage), OtherParent \= SrcClass), OtherParents),
     \+ member(DefinedClass, OtherParents),
     ( Property = ParentProp,
+      print_message(informational, trinary_op(check_invalid_domain_class, SrcClass, Property, DefinedClass)),
       print_message(error, invalid_domain(SrcClass, Property, DefinedClass))
     ; Property \= ParentProp,
+      print_message(informational, trinary_op(check_invalid_domain_class, SrcClass, Property, DefinedClass)),
       print_message(error, invalid_subclass_domain(SrcClass, Property, ParentProp, DefinedClass))
     ).
 
@@ -300,6 +317,14 @@ sum_all_nonzero([(_,N)|CNS], Sum) :-
     Sum is N + SubSum.
 
 
+prolog:message(unary_op(Name, Arg1)) -->
+    [ 'vv ~w(~w)'-[Name, Arg1] ].
+prolog:message(trinary_op(Name, Arg1, Arg2, Arg3)) -->
+    [ 'vv ~w(~w, ~w, ~w)'-[Name, Arg1, Arg2, Arg3] ].
+prolog:message(quarnary_op(Name, Arg1, Arg2, Arg3, Arg4)) -->
+    [ 'vv ~w(~w, ~w, ~w, ~w)'-[Name, Arg1, Arg2, Arg3, Arg4] ].
+prolog:message(quintary_op(Name, Arg1, Arg2, Arg3, Arg4, Arg5)) -->
+    [ 'vv ~w(~w, ~w, ~w, ~w, ~w)'-[Name, Arg1, Arg2, Arg3, Arg4, Arg5] ].
 prolog:message(class_missing_note(Class)) -->
     [ 'CE-100: No Note/Description for class ~w'-[Class] ].
 prolog:message(not_prov_s_node_class(Class)) -->

--- a/assist/bin/rack/check.pl
+++ b/assist/bin/rack/check.pl
@@ -71,14 +71,15 @@ check_instance_property_violations(Property) :-
     ( check_cardinality_exact(Property, I, T)
     ; check_cardinality_min(Property, I, T)
     ; check_cardinality_max(Property, I, T)
-    ; check_maybe_prop(Property, I, T)
     ; check_target_type(Property, I, T)
     ; check_target_type_restrictions(Property, I, T)
     ; check_values_from(Property, I, T)
     ).
 
 check_instance_property_violations(Property) :-
-    check_invalid_value(Property).
+    (check_maybe_prop(Property)
+    ; check_invalid_value(Property)
+    ).
 
 check_cardinality_exact(Property, I, T) :-
     property_extra(T, Property, cardinality(N)),
@@ -113,8 +114,11 @@ check_cardinality_max(Property, I, T) :-
     print_message(informational, trinary_op(check_cardinality_max, Property, I, T)),
     print_message(error, max_cardinality_violation(T, I, IName, Property, N, VSLen)).
 
-check_maybe_prop(Property, I, T) :-
+check_maybe_prop(Property) :-
     property_extra(T, Property, maybe),
+    rdf(I, rdf:type, T),
+    rack_data_instance(I),
+    has_interesting_prefix(I),
     has_interesting_prefix(Property),
     % How many actual values for that property on this instance
     findall(V, rdf(I, Property, V), VS),

--- a/assist/bin/rack/check.pl
+++ b/assist/bin/rack/check.pl
@@ -43,10 +43,10 @@ check_missing_notes(Class) :-
 check_not_prov_s(Class) :-
     rdf(Class, rdf:type, owl:'Class'),
     has_interesting_prefix(Class),
-    rack_ref('PROV-S#NODE', Thing),
-    \+ rdf_reachable(Class, rdfs:subClassOf, Thing),
+    rack_ref('PROV-S#NODE', NodeBase),
+    \+ rdf_reachable(Class, rdfs:subClassOf, NodeBase),
     \+ rdf_is_bnode(Class),
-    print_message(warning, not_prov_s_thing_class(Class)).
+    print_message(warning, not_prov_s_node_class(Class)).
 
 check_instance_types(I) :-
     % Get an instance
@@ -302,8 +302,8 @@ sum_all_nonzero([(_,N)|CNS], Sum) :-
 
 prolog:message(class_missing_note(Class)) -->
     [ 'CE-100: No Note/Description for class ~w'-[Class] ].
-prolog:message(not_prov_s_thing_class(Class)) -->
-    [ 'CE-101: Not a subclass of PROV-S#THING: ~w'-[Class] ].
+prolog:message(not_prov_s_node_class(Class)) -->
+    [ 'CE-101: Not a subclass of PROV-S#NODE: ~w'-[Class] ].
 prolog:message(num_classes(What, Count)) -->
     [ 'There are ~:d RACK ~w.'-[Count, What] ].
 prolog:message(cardinality_violation(InstType, Instance, InstanceIdent, Property, Specified, Actual)) -->

--- a/assist/bin/rack/check.pl
+++ b/assist/bin/rack/check.pl
@@ -186,6 +186,15 @@ check_values_from(Property, I, T) :-
         print_message(error,
                       property_value_wrong_type_in(T, I, IName, Property, DefTy, Val, CList))
       )
+    ; % Cls might be a union of multiple possible classes
+      rdf_is_bnode(Cls), rdf(Cls, owl:unionOf, ClsLst), !,
+      rdf_list(ClsLst, CList),
+      ( member(CL, CList),
+        rdf_reachable(DefTy, rdfs:subClassOf, CL), ! % matches, stop processing
+      ; print_message(informational, trinary_op(check_values_from, Property, I, T)),
+        print_message(error,
+                        property_value_wrong_type_in(T, I, IName, Property, DefTy, Val, CList))
+    )
     ; \+ rdf_reachable(DefTy, rdfs:subClassOf, Cls),
       print_message(informational, trinary_op(check_values_from, Property, I, T)),
       print_message(error, property_value_wrong_type(T, I, IName, Property, DefTy, Val, Cls))

--- a/assist/bin/rack/model.pl
+++ b/assist/bin/rack/model.pl
@@ -662,13 +662,23 @@ rack_instance_ident(_, "<no-identifier>").
 
 rack_instance_target(SrcInst, Rel, TgtInst) :-
     rdf(SrcInst, rdf:type, SrcClass),
-    property_extra(SrcClass, Rel, Restriction),
-    instance_target(SrcInst, Rel, Restriction, TgtInst).
+    (property_extra(SrcClass, Rel, Restriction),
+     instance_target_restr(SrcInst, Rel, Restriction, TgtInst)
+    ; rdf(SrcInst, Rel, TgtInst)
+    ).
 
-instance_target(SrcInst, Rel, value_from(TgtClass), TgtInst) :-
+instance_target_restr(SrcInst, Rel, value_from(TgtClass), TgtInst) :-
     rdf(SrcInst, Rel, TgtInst),
     rdf(TgtInst, rdfs:isSubClassOf, TgtClass).
-instance_target(SrcInst, Rel, Restr, TgtInst) :-
+instance_target_restr(SrcInst, Rel, value_from(TgtClass), TgtInst) :-
+    rdf_is_bnode(TgtClass),
+    rdf(TgtClass, owl:unionOf, TgtUnion),
+    rdf_list(TgtUnion),
+    rdf_list(TgtUnion, TgtList),
+    rdf(SrcInst, Rel, TgtInst),
+    rdf(TgtInst, rdf:type, TIClass),
+    member(TIClass, TgtList).
+instance_target_restr(SrcInst, Rel, Restr, TgtInst) :-
     Restr \= value_from(_),
     rdf(SrcInst, Rel, TgtInst).
 


### PR DESCRIPTION
Various updates to the ASSIST-DV package to:
* Handle Unions for property range targets
* Handle the new `NODE`  base element introduced below 
* Some performance optimizations