### PR TITLE
Use most current Ubuntu 22.04 vagrant box

### DIFF
--- a/.github/workflows/build-virtual-machine.yml
+++ b/.github/workflows/build-virtual-machine.yml
@@ -33,10 +33,10 @@ jobs:
 
     - name: Download base box for virtual machine
       run: |
-        curl -LOSfs https://app.vagrantup.com/ubuntu/boxes/jammy64/versions/20230720.0.0/providers/virtualbox.box
+        curl -LOSfs https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64-vagrant.box
         mkdir -p RACK/rack-box/jammy64
-        tar -xf virtualbox.box -C RACK/rack-box/jammy64
-        rm -f virtualbox.box
+        tar -xf jammy-server-cloudimg-amd64-vagrant.box -C RACK/rack-box/jammy64
+        rm -f jammy-server-cloudimg-amd64-vagrant.box
 
     - name: Build rack-box virtual machine
       run: |

--- a/rack-box/README.md
+++ b/rack-box/README.md
@@ -76,9 +76,10 @@ although we will mention each file here as well:
   --exclude=.github --exclude=assist --exclude=cli --exclude=rack-box
   --exclude=tests --exclude=tools RACK`)
 
-- `jammy64\*`: Download latest Ubuntu 22.04 vagrant box from
-  <https://app.vagrantup.com/ubuntu/boxes/jammy64>, unpacking it in a
-  `jammy64` folder (`tar -xf virtualbox.box -C RACK/rack-box/jammy64`)
+- `jammy64\*`: Download current Ubuntu 22.04 vagrant box from
+  <https://cloud-images.ubuntu.com/jammy/current>, unpacking it in a
+  `jammy64` folder (`tar -xf jammy-server-cloudimg-amd64-vagrant.box
+  -C RACK/rack-box/jammy64`)
 
 Once you have put these files into the `files` subdirectory, skip to
 [Build the rack-box images](#Build-the-rack-box-images) for the next

--- a/rack-box/scripts/clean.sh
+++ b/rack-box/scripts/clean.sh
@@ -26,7 +26,7 @@ fi
 
 # Upgrade all packages
 
-apt-get update -yqq
+apt-get -o Acquire::Check-Valid-Until=false -o Acquire::Check-Date=false update -yqq
 apt-get upgrade -yqq
 
 # Clean apt cache and temporary files

--- a/rack-box/scripts/install.sh
+++ b/rack-box/scripts/install.sh
@@ -10,7 +10,7 @@ cd /tmp/files
 
 export DEBIAN_FRONTEND=noninteractive
 export DEBCONF_NONINTERACTIVE_SEEN=true
-apt-get update -yqq
+apt-get -o Acquire::Check-Valid-Until=false -o Acquire::Check-Date=false update -yqq
 apt-get install -yqq ca-certificates software-properties-common
 cp GE_External_Root_CA_2_1.crt /usr/local/share/ca-certificates
 update-ca-certificates


### PR DESCRIPTION
Make the release workflow always use the most current Ubuntu 22.04 vagrant box (update the README as well).  Also modify the apt update commands in the scripts to prevent "Release is not valid yet" errors in case VM is set to local time while using UTC timezone.

build-virtual-machine.yml: Always download and use most current Ubuntu 22.04 vagrant box.

README.md: Update place where to get most current vagrant box.

clean.sh, install.sh: Run apt update with additional options to avoid "Release is not valid yet" error messages.