### PR TITLE
disable dependency checking in assemble-turnstile-data

### DIFF
--- a/.github/workflows/assemble-turnstile-data.yml
+++ b/.github/workflows/assemble-turnstile-data.yml
@@ -34,7 +34,7 @@ jobs:
 
     - name: Install RACK CLI
       run: |
-        pip3 install RACK/cli/wheels/*.whl
+        pip3 install --no-dependencies RACK/cli/wheels/*.whl
         sudo apt-get install -qq --yes swi-prolog
 
     - name: Assemble Turnstile ingestion package


### PR DESCRIPTION
This disables dependency checking when installing the wheel files. the dependency checking will have already been done at this point. Git versions of things seem to break normal wheel installation.